### PR TITLE
Nextcloud addonテストの修正

### DIFF
--- a/addons/nextcloud/tests/test_views.py
+++ b/addons/nextcloud/tests/test_views.py
@@ -38,7 +38,7 @@ class TestConfigViews(NextcloudAddonTestCase, OAuthAddonConfigViewsTestCaseMixin
 
     def setUp(self):
         super(TestConfigViews, self).setUp()
-        self.mock_ser_api = mock.patch('nextcloud.Client.login')
+        self.mock_ser_api = mock.patch('owncloud.Client.login')
         self.mock_ser_api.start()
         self.set_node_settings(self.node_settings)
 


### PR DESCRIPTION
Travis CIによるNextcloud addonテストにおける以下のエラーへの対処を実施しました。

```
addons/nextcloud/tests/test_views.py:42: in setUp
    self.mock_ser_api.start()
../../../virtualenv/python2.7.14/lib/python2.7/site-packages/mock.py:1396: in start
    result = self.__enter__()
../../../virtualenv/python2.7.14/lib/python2.7/site-packages/mock.py:1252: in __enter__
    self.target = self.getter()
../../../virtualenv/python2.7.14/lib/python2.7/site-packages/mock.py:1414: in <lambda>
    getter = lambda: _importer(target)
../../../virtualenv/python2.7.14/lib/python2.7/site-packages/mock.py:1098: in _importer
    thing = __import__(import_path)
E   ImportError: No module named nextcloud
```

Nextcloud AddonはNextcloud serverとの通信用ライブラリとしてはownCloud clientを使用しており(Nextcloud専用としたPython client libraryは今の所ないようです)、このことの考慮をせずテストコードを変更してしまっていました。