### PR TITLE
S3 Compatible Storage Addon有効化時にAmazon S3 AddonのConnect Accountボタンが表示されない

### DIFF
--- a/addons/azureblobstorage/templates/azureblobstorage_credentials_modal.mako
+++ b/addons/azureblobstorage/templates/azureblobstorage_credentials_modal.mako
@@ -11,15 +11,15 @@
 
                     <div class="row">
                         <div class="col-sm-3"></div>
-                        
+
                         <div class="col-sm-6">
                             <div class="form-group">
                                 <label for="azureblobstorageAddon">Account Name</label>
-                                <input class="form-control" data-bind="value: accessKey" id="access_key" name="access_key" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: accessKey" name="access_key" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="azureblobstorageAddon">Account Key</label>
-                                <input type="password" class="form-control" data-bind="value: secretKey" id="secret_key" name="secret_key" ${'disabled' if disabled else ''} />
+                                <input type="password" class="form-control" data-bind="value: secretKey" name="secret_key" ${'disabled' if disabled else ''} />
                             </div>
                         </div>
                     </div><!-- end row -->

--- a/addons/s3compat/static/s3compatNodeConfig.js
+++ b/addons/s3compat/static/s3compatNodeConfig.js
@@ -15,7 +15,9 @@ var OauthAddonFolderPicker = require('js/oauthAddonNodeConfig')._OauthAddonNodeC
 var s3compatFolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
     constructor: function(addonName, url, selector, folderPicker, opts, tbOpts) {
         var self = this;
-        self.super.constructor(addonName, url, selector, folderPicker, tbOpts);
+        // TODO: [OSF-7069]
+        self.super.super.constructor.call(self, addonName, url, selector, folderPicker, tbOpts);
+        self.super.construct.call(self, addonName, url, selector, folderPicker, opts, tbOpts);
         // Non-OAuth fields
         self.availableServices = ko.observableArray(s3compatSettings['availableServices']);
         self.selectedService = ko.observable(s3compatSettings['availableServices'][0]);
@@ -24,7 +26,7 @@ var s3compatFolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
         // Treebeard config
         self.treebeardOptions = $.extend(
             {},
-            OauthAddonFolderPicker.prototype.treebeardOptions,
+            self.treebeardOptions,
             {   // TreeBeard Options
                 columnTitles: function() {
                     return [{

--- a/addons/s3compat/templates/s3compat_credentials_modal.mako
+++ b/addons/s3compat/templates/s3compat_credentials_modal.mako
@@ -19,11 +19,11 @@
                             </div>
                             <div class="form-group">
                                 <label for="s3compatAddon">Access Key</label>
-                                <input class="form-control" data-bind="value: accessKey" id="access_key" name="access_key" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: accessKey" name="access_key" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="s3compatAddon">Secret Key</label>
-                                <input type="password" class="form-control" data-bind="value: secretKey" id="secret_key" name="secret_key" ${'disabled' if disabled else ''} />
+                                <input type="password" class="form-control" data-bind="value: secretKey" name="secret_key" ${'disabled' if disabled else ''} />
                             </div>
                         </div>
                     </div><!-- end row -->

--- a/addons/swift/templates/swift_credentials_modal.mako
+++ b/addons/swift/templates/swift_credentials_modal.mako
@@ -15,31 +15,31 @@
                         <div class="col-sm-6">
                             <div class="form-group">
                                 <label for="swiftAddon">Authentication(Keystone) Version</label>
-                                <select class="form-control" data-bind="value: authVersion, options: ['v2', 'v3']" id="auth_version" name="auth_version" ${'disabled' if disabled else ''} ></select>
+                                <select class="form-control" data-bind="value: authVersion, options: ['v2', 'v3']" name="auth_version" ${'disabled' if disabled else ''} ></select>
                             </div>
                             <div class="form-group">
                                 <label for="swiftAddon">Authentication URL</label>
-                                <input class="form-control" data-bind="value: authUrl" id="auth_url" name="auth_url" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: authUrl" name="auth_url" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="swiftAddon">Tenant name</label>
-                                <input class="form-control" data-bind="value: tenantName" id="tenant_name" name="tenant_name" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: tenantName" name="tenant_name" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="swiftAddon">Project Domain name</label>
-                                <input class="form-control" data-bind="value: projectDomainName, enable: authVersion() == 'v3'" id="project_domain_name" name="project_domain_name" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: projectDomainName, enable: authVersion() == 'v3'" name="project_domain_name" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="swiftAddon">Username</label>
-                                <input class="form-control" data-bind="value: accessKey" id="access_key" name="access_key" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: accessKey" name="access_key" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="swiftAddon">User Domain name</label>
-                                <input class="form-control" data-bind="value: userDomainName, enable: authVersion() == 'v3'" id="user_domain_name" name="user_domain_name" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: userDomainName, enable: authVersion() == 'v3'" name="user_domain_name" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="swiftAddon">Password</label>
-                                <input type="password" class="form-control" data-bind="value: secretKey" id="secret_key" name="secret_key" ${'disabled' if disabled else ''} />
+                                <input type="password" class="form-control" data-bind="value: secretKey" name="secret_key" ${'disabled' if disabled else ''} />
                             </div>
                         </div>
                     </div><!-- end row -->

--- a/addons/weko/templates/weko_credentials_modal.mako
+++ b/addons/weko/templates/weko_credentials_modal.mako
@@ -31,15 +31,15 @@
                         <div class="col-sm-6" data-bind="visible: selectedRepo() == 'Other Repository (Basic Auth)'">
                             <div class="form-group">
                                 <label for="wekoAddon">WEKO SWORD URL</label>
-                                <input class="form-control" data-bind="value: swordUrl" id="sword_url" name="sword_url" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: swordUrl" name="sword_url" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="wekoAddon">WEKO Username</label>
-                                <input class="form-control" data-bind="value: accessKey" id="access_key" name="access_key" ${'disabled' if disabled else ''} />
+                                <input class="form-control" data-bind="value: accessKey" name="access_key" ${'disabled' if disabled else ''} />
                             </div>
                             <div class="form-group">
                                 <label for="wekoAddon">WEKO Password</label>
-                                <input type="password" class="form-control" data-bind="value: secretKey" id="secret_key" name="secret_key" ${'disabled' if disabled else ''} />
+                                <input type="password" class="form-control" data-bind="value: secretKey" name="secret_key" ${'disabled' if disabled else ''} />
                             </div>
                         </div>
 


### PR DESCRIPTION
S3 Compatible Storage Addon有効化時にAmazon S3 AddonのConnect Accountボタンが表示されない問題に関して、修正を実施しました。

原因は、OSF-7069 oauthAddonNodeConfigのコンストラクタ呼び出し不足
https://github.com/CenterForOpenScience/osf.io/blob/d85f7a015ac9df5a30cb94853afc41f99846abb3/website/static/js/oauthAddonNodeConfig.js#L34-L35
へのワークアラウンド
https://github.com/CenterForOpenScience/osf.io/blob/08a604c550c68c53653bf751ccd0571acc50cab4/addons/owncloud/static/owncloudNodeConfig.js#L16-L17
をs3compatNodeConfig.jsで実施していなかったことにあるよう。結果的に、s3NodeConfig.jsで作成されるs3FolderPickerViewModel (こちらもOSF-7069の対処をしていない)とs3compatNodeConfig.jsのs3compatFolderPickerViewModelの間でスコープが一部共有されてしまうような状態となり、意図しない動作をしてしまったと思われます。そのため、s3compatNodeConfig.jsに対して、OSF-7069の対処を行いました。

また、access_key, secret_keyの入力フィールドのIDに関して重複を示すエラーが現れていましたので、これについても合わせて対応しています。(IDは使用しておらず不要なため削除)
ただし、hostSelect IDについては、もともとCenterForOpenScience/osf.ioでも重複があり、これについては現状は機能上の問題はなさそうなため修正していません。

