### PR TITLE
JupyterHubアドオンの属性修正

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -45,7 +45,6 @@
         "swift": "partial",
         "azureblobstorage": "partial",
         "weko": "partial",
-        "jupyterhub": "partial",
         "s3compat": "partial",
         "nextcloud": "partial"
     },


### PR DESCRIPTION
TestStorageAddonBase.test_addonsにおけるJupyterHubアドオンのエラーにより、JupyterHub addonの設定に誤りがあることがわかりましたので、Pull Requestをお送りします。

アドオン設定ファイル addons.json の addons_archivable に、jupyterhub: partialとしておりましたが、JupyterHub addonはstorageアドオンではなく、Archive時にデータを記録することはしないので、ここにpartialとあるのは誤りでした。本PRにより、 `./osf_tests/test_archiver.py::TestStorageAddonBase::test_addons` のエラーは解消されるものと思います。