### PR TITLE
Hotfix/6898,6901

### DIFF
--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -286,6 +286,12 @@ NPLUSONE_RAISE = False
 FCM_SETTINGS = {
     'FCM_SERVER_KEY': ''
 }
+# separator to devide domain from eppn
 SHIB_EPPN_SCOPING_SEPARATOR = '@'
+
+# hide embededDS, login user form in Adoministrator login page
 ENABLE_SHB_LOGIN = True
 ENABLE_LOGIN_FORM = False
+
+# mail address uses mail from rdm_announcement
+ANNOUNCEMENT_EMAIL_FROM = 'noreply@rdm.rcos.nii.ac.jp'

--- a/admin/common_auth/views.py
+++ b/admin/common_auth/views.py
@@ -84,6 +84,13 @@ class ShibLoginView(RedirectView):
             return redirect('auth:login')
         eppn_user = get_user(eppn=eppn)
         if eppn_user:
+            try:
+                others = eppn_user.affiliated_institutions.exclude(id=institution.id).get()
+            except Institution.DoesNotExist:
+                pass
+            else:
+                eppn_user.affiliated_institutions.remove(others)
+
             eppn_user.affiliated_institutions.add(institution)
             if 'GakuninRDMAdmin' in request.environ['HTTP_AUTH_ENTITLEMENT']:
                 # login success

--- a/admin/common_auth/views.py
+++ b/admin/common_auth/views.py
@@ -84,6 +84,7 @@ class ShibLoginView(RedirectView):
             return redirect('auth:login')
         eppn_user = get_user(eppn=eppn)
         if eppn_user:
+            eppn_user.affiliated_institutions.add(institution)
             if 'GakuninRDMAdmin' in request.environ['HTTP_AUTH_ENTITLEMENT']:
                 # login success
                 # code is below this if/else tree

--- a/admin/rdm_announcement/views.py
+++ b/admin/rdm_announcement/views.py
@@ -247,7 +247,7 @@ class SendView(RdmAnnouncementPermissionMixin, UserPassesTestMixin, FormView):
                 subject=data['title'],
                 body=data['body'],
                 from_email=ANNOUNCEMENT_EMAIL_FROM
-                to=[SUPPORT_EMAIL or now_user.username],
+                to=[SUPPORT_EMAIL or now_user.username]
                 bcc=to_list
             )
             email.send(fail_silently=False)

--- a/admin/rdm_announcement/views.py
+++ b/admin/rdm_announcement/views.py
@@ -13,7 +13,7 @@ from osf.models.user import OSFUser
 from django.core.mail import EmailMessage
 from website.settings import SUPPORT_EMAIL
 from admin.base.settings import FCM_SETTINGS
-from admin.base.settings import EMAIL_HOST, EMAIL_PORT, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD, EMAIL_USE_TLS  # noqa
+from admin.base.settings import EMAIL_HOST, EMAIL_PORT, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD, EMAIL_USE_TLS, ANNOUNCEMENT_EMAIL_FROM  # noqa
 from redminelib import Redmine
 from pyfcm import FCMNotification
 import facebook
@@ -246,7 +246,7 @@ class SendView(RdmAnnouncementPermissionMixin, UserPassesTestMixin, FormView):
             email = EmailMessage(
                 subject=data['title'],
                 body=data['body'],
-                from_email=SUPPORT_EMAIL or now_user.username,
+                from_email=ANNOUNCEMENT_EMAIL_FROM or now_user.username,
                 to=[SUPPORT_EMAIL or now_user.username],
                 bcc=to_list
             )

--- a/admin/rdm_announcement/views.py
+++ b/admin/rdm_announcement/views.py
@@ -246,7 +246,7 @@ class SendView(RdmAnnouncementPermissionMixin, UserPassesTestMixin, FormView):
             email = EmailMessage(
                 subject=data['title'],
                 body=data['body'],
-                from_email=ANNOUNCEMENT_EMAIL_FROM or now_user.username,
+                from_email=ANNOUNCEMENT_EMAIL_FROM
                 to=[SUPPORT_EMAIL or now_user.username],
                 bcc=to_list
             )

--- a/admin/rdm_announcement/views.py
+++ b/admin/rdm_announcement/views.py
@@ -246,8 +246,8 @@ class SendView(RdmAnnouncementPermissionMixin, UserPassesTestMixin, FormView):
             email = EmailMessage(
                 subject=data['title'],
                 body=data['body'],
-                from_email=ANNOUNCEMENT_EMAIL_FROM
-                to=[SUPPORT_EMAIL or now_user.username]
+                from_email=ANNOUNCEMENT_EMAIL_FROM,
+                to=[SUPPORT_EMAIL or now_user.username],
                 bcc=to_list
             )
             email.send(fail_silently=False)


### PR DESCRIPTION
管理者機能によるメール送信機能からの送信時の設定パラメタ追加、および
Adminページログイン時の所属機関再設定

GRDM-6898でご指摘いただいた、「shibboleth loginにおいて認可を与えている機関のものではない管理画面にアクセスできる」件、および
GRDM-6901でご指摘いただいた「管理者機能によるメール送信機能でのメールの FROM 欄を
現状の実装の SUPPORT_EMAIL以外への変更」 について対応させていただきました。

各々の修正ですが、
GRDM-6898
https://github.com/RCOSDP/RDM-osf.io/commit/6e572f7dbecc5e44ad337884f7d77a372a7d8045

GRDM-6901
https://github.com/RCOSDP/RDM-osf.io/commit/5bcec4b19d5954d97fccce7c1f40d0a7aa732d6d
https://github.com/RCOSDP/RDM-osf.io/commit/8eac159c0dc2582ffa5f2656e1ca80041750cab7
の修正となります。
https://redmine.devops.rcos.nii.ac.jp/issues/6901#note-3 の
ご指摘

> 不特定多数(now_user.username)をSESに登録するのは現実的ではないです。

を鑑み、FROMメールからnow_user.username をいったん削除いたしました。


 ## Purpose

 - 1. add parameter 'ANNOUNCEMENT_EMAIL_FROM' when sending mail from rdm_annoucement.
 - 2. reassign affiliated institution id when user logs in to admin page

## Changes
  - admin/base/settings/defaults.py
 - admin/rdm_announcement/views.py
   add parameter 'ANNOUNCEMENT_EMAIL_FROM'

 - admin/common_auth/views.py
   reassign affiliated institution when log in to Admin, and user already exists.

  ## QA Notes
 - None

 ## Side Effects
 - None

## Ticket
- GRDM-6898, GRDM-6901