### PR TITLE
Hotfix/7027

### DIFF
--- a/admin/rdm_statistics/views.py
+++ b/admin/rdm_statistics/views.py
@@ -633,7 +633,7 @@ def send_error_mail(err):
         'subject': '[[GakuNin RDM]] ERROR in statistic information collection at ' + current_date.strftime('%Y/%m/%d'),
         'content': 'ERROR OCCURED at ' + current_date.strftime('%Y/%m/%d') + '.\r\nERROR: \r\n' + str(err),
     }
-    send_email(to_list=to_list, cc_list=None, data=mail_data)
+    send_email(to_list=to_list, cc_list=None, user=None, data=mail_data)
     response_hash = {'state': 'fail', 'error': str(err)}
     response_json = json.dumps(response_hash)
     response = HttpResponse(response_json, content_type='application/json')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -446,7 +446,7 @@ services:
     command: 
     - /bin/bash 
     - -c
-    - apt-get update && apt-get install -y libtk8.6 wkhtmltopdf xvfb cron &&
+    - apt-get update && apt-get install -y libtk8.6 wkhtmltopdf xvfb cron curl jq &&
       /etc/init.d/cron start &&
       cat ./admin/rdm_statistics/cron.sh | crontab - &&
       invoke adminserver -h 0.0.0.0


### PR DESCRIPTION
GRDM-7027 にて確認いたしました、 統計情報作成時、エラーメール送信の不具合を
修正いたしました。


## Purpose
- Fix error when no user belonging to the institution, and data exists.

## Changes
- admin/rdm_statistics/views.py 
- docker-compose.yml

## QA Notes
 None

## Side Effects
 None 

## Ticket
- GRDM-7027