### PR TITLE
pass through even if file size over yottabyte(10^24) order.

### DIFF
--- a/admin/rdm_statistics/views.py
+++ b/admin/rdm_statistics/views.py
@@ -764,7 +764,7 @@ def approximate_size(size, a_kilobyte_is_1024_bytes=True):
         if size < multiple:
             return '{0:.1f} {1}'.format(size, suffix)
 
-    raise ValueError('number too large')
+    return '{0:.1f} {1}'.format(size, suffix)
 
 
 ############################################


### PR DESCRIPTION
GRDM-7027 #28 でご依頼いただいた、 プロバイダ・機関毎の集計時、YBを超えてしまった場合であっても異常とせずにそのままYB単位で返戻するようにした修正です。


## Purpose

- pass through even if file size over yottabyte(10^24) order when creating statistics information.

## Changes

- admin/rdm_statistics/views.py

## QA Notes

- None

## Side Effects

- None
## Ticket

- GRDM-7027