### PR TITLE
Hotfix/6981,7162

### DIFF
--- a/admin/rdm_addons/oauth/views.py
+++ b/admin/rdm_addons/oauth/views.py
@@ -20,6 +20,7 @@ from admin.rdm_addons.api_v1.views import disconnect
 from website.oauth.utils import get_service
 from website.routes import make_url_map
 from website import settings as website_settings
+from framework.sessions import get_session
 
 class RdmAddonRequestContextMixin(object):
     app = flask.Flask(__name__)
@@ -78,14 +79,19 @@ class CallbackView(RdmPermissionMixin, RdmAddonRequestContextMixin, UserPassesTe
 
     def test_func(self):
         """check user permissions"""
+        institution_id = None
         addon_name = self.kwargs.get('addon_name')
-        session = self.get_session(addon_name)
-        if 'oauth_states' in session.data:
-            institution_id = int(session.data['oauth_states'][addon_name]['institution_id'])
+        session = get_session()
+        session_data = {}
+        try:
+            session_data = session.data
+        except RuntimeError:
+            print('Unable to access session data')
+
+        if 'oauth_states' in session_data:
+            institution_id = int(session_data['oauth_states'][addon_name]['institution_id'])
         elif 'institution_id' in self.kwargs:
             institution_id = int(self.kwargs.get('institution_id'))
-        else:
-            institution_id = None
         return self.has_auth(institution_id)
 
     def get(self, request, *args, **kwargs):

--- a/admin/rdm_announcement/forms.py
+++ b/admin/rdm_announcement/forms.py
@@ -15,7 +15,8 @@ class PreviewForm(forms.Form):
         choices=[('Email', 'Email'),
                  ('SNS (Twitter)', 'SNS (Twitter)'),
                  #('SNS (Facebook)', 'SNS (Facebook)'),   ## GRDM-6902
-                 #('Push notification', 'Push notification')],
+                 #('Push notification', 'Push notification')
+                 ],
         widget=forms.RadioSelect,
         label='Type',
         initial='Email',

--- a/admin/rdm_announcement/forms.py
+++ b/admin/rdm_announcement/forms.py
@@ -15,7 +15,7 @@ class PreviewForm(forms.Form):
         choices=[('Email', 'Email'),
                  ('SNS (Twitter)', 'SNS (Twitter)'),
                  #('SNS (Facebook)', 'SNS (Facebook)'),   ## GRDM-6902
-                 ('Push notification', 'Push notification')],
+                 #('Push notification', 'Push notification')],
         widget=forms.RadioSelect,
         label='Type',
         initial='Email',

--- a/admin_tests/rdm_announcement/test_forms.py
+++ b/admin_tests/rdm_announcement/test_forms.py
@@ -35,6 +35,7 @@ class TestPreviewForm(AdminTestCase):
         nt.assert_false(form.is_valid())
         nt.assert_in('Body should be at most 140 characters', form.errors['__all__'])
 
+    '''
     def test_clean_from_push_okay(self):
         mod_data = dict(data)
         twitter_body = self.random_body(2000)
@@ -49,6 +50,8 @@ class TestPreviewForm(AdminTestCase):
         form = PreviewForm(data=mod_data)
         nt.assert_false(form.is_valid())
         nt.assert_in('Body should be at most 2000 characters', form.errors['__all__'])
+    '''
+
     ''' disable #GRDM-6902
     def test_clean_from_facebook_okay(self):
         mod_data = dict(data)

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -80,7 +80,9 @@ def osfadmin_oauth_callback(service_name):
     f.path = '/addons/oauth/callback/{}/'.format(service_name)
     f.args = flask.request.args.to_dict(flat=False)
     try:
-        r = requests.get(f.url, headers=dict(flask.request.headers))
+        headers = dict(flask.request.headers)
+        headers['Content-Length'] = str(0)
+        r = requests.get(f.url, headers=headers)
     except ConnectionError:
         return None
     if not r.ok:

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -249,8 +249,8 @@
 
 
         ${self.javascript_bottom()}
-        <script src="https://www.gstatic.com/firebasejs/4.8.0/firebase.js"></script>
-        <script src="/static/public/js/rdm-firebase.js"></script>
+        <!-- <script src="https://www.gstatic.com/firebasejs/4.8.0/firebase.js"></script>
+        <script src="/static/public/js/rdm-firebase.js"></script> -->
     </body>
 </html>
 


### PR DESCRIPTION
GRDM-6981#20でご依頼いただいたPush通知機能の無効化対応と、GRDM-7162のContent-Lengthに0をセットする、およびRuntimeError回避の対応になります。


## Purpose

Invalidation of push notification function.
Set Content-Length to 0 and don't raise an exception if flask session is not accessible.


## Changes

admin/rdm_addons/oauth/views.py
admin/rdm_announcement/forms.py
admin_tests/rdm_announcement/test_forms.py
website/oauth/views.py
website/templates/base.mako


## QA Notes

None


## Side Effects

None


## Ticket

GRDM-6981
GRDM-7162