### PR TITLE
Hotfix/7117

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -839,7 +839,7 @@ def upload_file_add_timestamptoken(payload, node):
 
         current_datetime = timezone.now()
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(auth_id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(auth_id, file_node._id, current_datetime_str)
         os.mkdir(tmp_dir)
         download_file_path = os.path.join(tmp_dir, metadata['name'])
         with open(download_file_path, 'wb') as fout:
@@ -876,7 +876,7 @@ def adding_timestamp(auth, node, file_node, version):
         res = requests.get(file_node.generate_waterbutler_url(**dict(action='download',
                            version=version.identifier, mode=None, _internal=False)),
                            headers=headers, cookies=cookies)
-        tmp_dir = 'tmp_{}'.format(ret['user']['id'])
+        tmp_dir = '/tmp/tmp_{}'.format(ret['user']['id'])
         os.mkdir(tmp_dir)
         tmp_file = os.path.join(tmp_dir, file_node.name)
         with open(tmp_file, 'wb') as fout:
@@ -905,10 +905,9 @@ def timestamptoken_verify(auth, node, file_node, version, guid):
     from osf.models import Guid
     import shutil
 
-    tmp_dir = 'tmp_{}'.format(guid)
     current_datetime = timezone.now()
     current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-    tmp_dir = 'tmp_{}_{}_{}'.format(guid, file_node._id, current_datetime_str)
+    tmp_dir = '/tmp/tmp_{}_{}_{}'.format(guid, file_node._id, current_datetime_str)
     tmp_file = None
     try:
         ret = serialize_node(node, auth, primary=True)

--- a/admin/rdm_timestampadd/views.py
+++ b/admin/rdm_timestampadd/views.py
@@ -327,7 +327,7 @@ class AddTimestampData(RdmPermissionMixin, View):
                                               '/' + request_data['file_id'][0],
                                               action='download', direct=None)
             res = requests.get(url, headers=headers, cookies=cookies)
-            tmp_dir = 'tmp_{}'.format(self.request.user._id)
+            tmp_dir = '/tmp/tmp_{}'.format(self.request.user._id)
             if os.path.exists(tmp_dir):
                 shutil.rmtree(tmp_dir)
             os.mkdir(tmp_dir)

--- a/api_tests/timestamp/test_add_timestamp.py
+++ b/api_tests/timestamp/test_add_timestamp.py
@@ -54,7 +54,7 @@ class TestAddTimestamp(ApiTestCase):
         ## create tmp_dir
         current_datetime = datetime.datetime.now(pytz.timezone('Asia/Tokyo'))
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
         os.mkdir(tmp_dir)
 
         ## create tmp_file (file_node)

--- a/api_tests/timestamp/test_timestamptoken_verify.py
+++ b/api_tests/timestamp/test_timestamptoken_verify.py
@@ -61,7 +61,7 @@ class TestTimeStampTokenVerifyCheck(ApiTestCase):
         ## create tmp_dir
         current_datetime = datetime.datetime.now(pytz.timezone('Asia/Tokyo'))
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
         os.mkdir(tmp_dir)
 
         ## create tmp_file (file_node)
@@ -108,7 +108,7 @@ class TestTimeStampTokenVerifyCheck(ApiTestCase):
         ## create tmp_dir
         current_datetime = datetime.datetime.now(pytz.timezone('Asia/Tokyo'))
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
         os.mkdir(tmp_dir)
 
         ## create tmp_file (file_node)
@@ -159,7 +159,7 @@ class TestTimeStampTokenVerifyCheck(ApiTestCase):
         ## create tmp_dir
         current_datetime = datetime.datetime.now(pytz.timezone('Asia/Tokyo'))
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
         os.mkdir(tmp_dir)
 
         ## create tmp_file (file_node)
@@ -202,7 +202,7 @@ class TestTimeStampTokenVerifyCheck(ApiTestCase):
         ## create tmp_dir
         current_datetime = datetime.datetime.now(pytz.timezone('Asia/Tokyo'))
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
         os.mkdir(tmp_dir)
 
         ## create tmp_file (file_node)
@@ -245,7 +245,7 @@ class TestTimeStampTokenVerifyCheck(ApiTestCase):
         ## create tmp_dir
         current_datetime = datetime.datetime.now(pytz.timezone('Asia/Tokyo'))
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
         os.mkdir(tmp_dir)
 
         ## create tmp_file (file_node)
@@ -287,7 +287,7 @@ class TestTimeStampTokenVerifyCheck(ApiTestCase):
         ## create tmp_dir
         current_datetime = datetime.datetime.now(pytz.timezone('Asia/Tokyo'))
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
         os.mkdir(tmp_dir)
 
         ## create tmp_file (file_node)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4983,7 +4983,7 @@ def create_rdmfiletimestamptokenverifyresult(self, filename='test_file_timestamp
     ## create tmp_dir
     current_datetime = dt.datetime.now(pytz.timezone('Asia/Tokyo'))
     current_datetime_str = current_datetime.strftime("%Y%m%d%H%M%S%f")
-    tmp_dir = 'tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
+    tmp_dir = '/tmp/tmp_{}_{}_{}'.format(self.user._id, file_node._id, current_datetime_str)
     os.mkdir(tmp_dir)
     ## create tmp_file (file_node)
     tmp_file = os.path.join(tmp_dir, filename)
@@ -5146,7 +5146,7 @@ class TestAddonFileViewTimestampFunc(OsfTestCase):
         user_info = OSFUser.objects.get(id=Guid.objects.get(_id=ret['user']['id']).object_id)
         filename='tests.test_views.test_timestamptoken_verify'
         file_node = create_test_file(node=self.node, user=self.user, filename=filename) 
-        tmp_dir = 'tmp_{}'.format(ret['user']['id'])
+        tmp_dir = '/tmp/tmp_{}'.format(ret['user']['id'])
         os.mkdir(tmp_dir)
         tmp_file = os.path.join(tmp_dir, file_node.name)
         with open(tmp_file, "wb") as file:

--- a/website/project/views/timestamp.py
+++ b/website/project/views/timestamp.py
@@ -233,7 +233,7 @@ def do_get_timestamp_error_data(auth, node, headers, cookies, data):
         res = requests.get(url, headers=headers, cookies=cookies)
         current_datetime = datetime.now(pytz.timezone('Asia/Tokyo'))
         current_datetime_str = current_datetime.strftime('%Y%m%d%H%M%S%f')
-        tmp_dir = 'tmp_{}_{}_{}'.format(auth.user._id, file_node._id, current_datetime_str)
+        tmp_dir = '/tmp/tmp_{}_{}_{}'.format(auth.user._id, file_node._id, current_datetime_str)
 
         if not os.path.exists(tmp_dir):
             os.mkdir(tmp_dir)
@@ -298,7 +298,7 @@ def add_timestamp_token(auth, node, **kwargs):
 
         # Request To Download File
         res = requests.get(url, headers=headers, cookies=cookies)
-        tmp_dir = 'tmp_{}'.format(auth.user._id)
+        tmp_dir = '/tmp/tmp_{}'.format(auth.user._id)
         if not os.path.exists(tmp_dir):
             os.mkdir(tmp_dir)
         download_file_path = os.path.join(tmp_dir, data['file_name'])


### PR DESCRIPTION
GRDM-7117でご指摘いただいたRDMのAdmin画面のVerifyでエラーの対応です。#10で提示させていただきた暫定対応版になります。

## Purpose

Change temporary download directory to full path : ./tmp_xxxx --> /tm…  …p/tmp_xxxx

## Changes

addons/base/views.py
admin/rdm_timestampadd/views.py
api_tests/timestamp/test_add_timestamp.py
api_tests/timestamp/test_timestamptoken_verify.py
tests/test_views.py
website/project/views/timestamp.py

## QA Notes

None

## Side Effects

None

## Ticket

GRDM-7117