### PR TITLE
hide some timestamp features

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -185,8 +185,10 @@
             <li><a href="{% url 'statistics:institutions' %}"><i class='fa fa-link'></i> <span>RDM Statistics</span></a></li>
             <li><a href="{% url 'announcement:index' %}"><i class='fa fa-link'></i> <span>RDM Announcement</span></a></li>
              <li><a href="{% url 'timestampadd:institutions' %}"><i class='fa fa-link'></i> <span>Timestamp Control</span></a></li>
+{% comment GRDM 7117 disable some timestamp features %}
              <li><a href="{% url 'keymanagement:institutions' %}"><i class='fa fa-link'></i> <span>User Keys Management</span></a></li>
              <li><a href="{% url 'timestampsettings:institutions' %}"><i class='fa fa-link'></i> <span>RDM Timestamp Environment</span></a></li>
+{% endcomment %}
           {% endif %}
           </ul><!-- /.sidebar-menu -->
         </section>

--- a/admin/templates/rdm_timestampadd/timestampadd.html
+++ b/admin/templates/rdm_timestampadd/timestampadd.html
@@ -15,7 +15,9 @@
 <h3>TimeStamp Add ({{ project_title }})</h3>
 <form action "" id="addTimestampForm">
     <a class="btn btn-success" id="btn-verify">Verify</a>
+{% comment GRDM 7117 disable some timestamp features %}
     <a class="btn btn-success" id="btn-addtimestamp">Request Trusted Timestamp</a>
+{% endcomment %}
     <font color="red">
         <h4 id="timestamp_errors_spinner"></h4>
     </font>


### PR DESCRIPTION
GRDM-7117 #23 でご依頼いただいた、

・管理画面のRDM TimestampControlのVerifyは表示
・管理画面のRDM TimestampControlのRequest Trusted Timestampは非表示
・管理画面のUser Keys Managementは非表示
・管理画面のRDM Timestamp Environmentは非表示

の対応をいたしました。


## Purpose
- hide some timestamp features


## Changes
- admin/templates/base.html
  comment out: "User Keys Management", "RDM Timestamp Environment" links
 
- admin/templates/rdm_timestampadd/timestampadd.html
  comment out: "Request Trusted Timestamp" button
<!-- Briefly describe or list your changes  -->

## QA Notes
- None

## Side Effects
- None

## Ticket
GRDM-7117
