### PR TITLE
GRDM7225 管理者統計情報作成処理でgoogledriveのサイズが正しく取得できない

### DIFF
--- a/admin/rdm_statistics/views.py
+++ b/admin/rdm_statistics/views.py
@@ -576,10 +576,10 @@ class GatherView(TemplateView):
                 if not ext:
                     ext = 'none'
                 if obj['attributes']['kind'] == 'file':
-                    self.count_list.append(['file', obj['id'], obj['attributes']['size'], ext])
+                    self.count_list.append(['file', obj['id'], int(obj['attributes']['size']), ext])
                 elif obj['attributes']['kind'] == 'folder':
                     path = re.sub('^' + provider, '', obj['id'])
-                    self.count_list.append(['folder', obj['id'], obj['attributes']['size'], ext])
+                    self.count_list.append(['folder', obj['id'], int(obj['attributes']['size'] if obj['attributes']['size'] else 0), ext])
                     self.count_project_files(provider=provider, node_id=node_id, path='/' + path, cookies=cookies)
 
 def simple_auth(access_token):

--- a/admin/rdm_statistics/views.py
+++ b/admin/rdm_statistics/views.py
@@ -581,20 +581,22 @@ class GatherView(TemplateView):
                     try:
                         self.count_list.append(['file', obj['id'], int(obj['attributes']['size'] if obj['attributes']['size'] else 0), ext])
                     except Exception as err:
-                        logger.error('file:{}{} error occured (size:{}). - {}'.format(obj['attributes']['provider'],
-                                                                                      obj['attributes']['path'],
-                                                                                      obj['attributes']['size'],
-                                                                                      err))
+                        logger.error('resource:{} {}{} error occured (file size:{}). - {}'.format(obj['attributes']['resource'],
+                                                                                                  obj['attributes']['provider'],
+                                                                                                  obj['attributes']['path'],
+                                                                                                  obj['attributes']['size'],
+                                                                                                  err))
                         pass
                 elif obj['attributes']['kind'] == 'folder':
                     path = re.sub('^' + provider, '', obj['id'])
                     try:
                         self.count_list.append(['folder', obj['id'], int(obj['attributes']['size'] if obj['attributes']['size'] else 0), ext])
                     except Exception as err:
-                        logger.error('file:{}{} error occured (size:{}). - {}'.format(obj['attributes']['provider'],
-                                                                                      obj['attributes']['path'],
-                                                                                      obj['attributes']['size'],
-                                                                                      err))
+                        logger.error('resource:{} {}{} error occured (file size:{}). - {}'.format(obj['attributes']['resource'],
+                                                                                                  obj['attributes']['provider'],
+                                                                                                  obj['attributes']['path'],
+                                                                                                  obj['attributes']['size'],
+                                                                                                  err))
                         pass
                     self.count_project_files(provider=provider, node_id=node_id, path='/' + path, cookies=cookies)
 

--- a/admin/rdm_statistics/views.py
+++ b/admin/rdm_statistics/views.py
@@ -44,6 +44,8 @@ from admin.base import settings
 from admin.rdm.utils import RdmPermissionMixin, get_dummy_institution
 from admin.rdm_addons import utils
 
+import logging
+logger = logging.getLogger(__name__)
 
 RANGE_STATISTICS = 10
 STATISTICS_IMAGE_WIDTH = 8
@@ -576,10 +578,24 @@ class GatherView(TemplateView):
                 if not ext:
                     ext = 'none'
                 if obj['attributes']['kind'] == 'file':
-                    self.count_list.append(['file', obj['id'], int(obj['attributes']['size']), ext])
+                    try:
+                        self.count_list.append(['file', obj['id'], int(obj['attributes']['size'] if obj['attributes']['size'] else 0), ext])
+                    except Exception as err:
+                        logger.error('file:{}{} error occured (size:{}). - {}'.format(obj['attributes']['provider'],
+                                                                                      obj['attributes']['path'],
+                                                                                      obj['attributes']['size'],
+                                                                                      err))
+                        pass
                 elif obj['attributes']['kind'] == 'folder':
                     path = re.sub('^' + provider, '', obj['id'])
-                    self.count_list.append(['folder', obj['id'], int(obj['attributes']['size'] if obj['attributes']['size'] else 0), ext])
+                    try:
+                        self.count_list.append(['folder', obj['id'], int(obj['attributes']['size'] if obj['attributes']['size'] else 0), ext])
+                    except Exception as err:
+                        logger.error('file:{}{} error occured (size:{}). - {}'.format(obj['attributes']['provider'],
+                                                                                      obj['attributes']['path'],
+                                                                                      obj['attributes']['size'],
+                                                                                      err))
+                        pass
                     self.count_project_files(provider=provider, node_id=node_id, path='/' + path, cookies=cookies)
 
 def simple_auth(access_token):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
fixed sum error when filesize represented by a character string(eg. google drive, owncloud)
- When statistical information created, explicitly convert the file size item to numeric type.
<!-- Describe the purpose of your changes -->

## Changes
- admin/rdm_statistics/views.py
<!-- Briefly describe or list your changes  -->

## QA Notes
- None
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the GakuNin RDM should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
- None
<!-- Any possible side effects? -->

## Ticket
GRDM-7225
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
