### PR TITLE
s3, dataverse, owncloudアドオンにおけるRDM Addons Force to use非表示オプションの有効化

### DIFF
--- a/admin/templates/rdm_addons/addons/dataverse_institution_settings.html
+++ b/admin/templates/rdm_addons/addons/dataverse_institution_settings.html
@@ -9,11 +9,14 @@
     <h4 class="addon-title">
         <img class="addon-icon" src="{{ addon.addon_icon_url }}">
         <span data-bind="text: properName">{# addon.addon_full_name #}</span>
+        {% if addon.is_supported_force_to_use %}
         <small>
             <a href="#dataverseInputCredentials" data-toggle="modal" class="pull-right text-primary">Connect or Reauthorize Account</a>
         </small>
+        {% endif %}
     </h4>
 
+    {% if addon.is_supported_force_to_use %}
     <div class="addon-auth-table" id="{{ addon.addon_short_name }}-header">
         <!-- ko foreach: accounts -->
         <a data-bind="click: $root.askDisconnect.bind($root)" class="text-danger pull-right default-authorized-by" href="#dataverseDisconnectAccount">Disconnect Account</a>
@@ -45,4 +48,5 @@
         </div>
         <!-- /ko -->
     </div>
+    {% endif %}
 </div>

--- a/admin/templates/rdm_addons/addons/owncloud_institution_settings.html
+++ b/admin/templates/rdm_addons/addons/owncloud_institution_settings.html
@@ -9,11 +9,14 @@
     <h4 class="addon-title">
         <img class="addon-icon" src="{{ addon.addon_icon_url }}">
         <span data-bind="text: properName">{{ addon.addon_full_name }}</span>
+        {% if addon.is_supported_force_to_use %}
         <small>
             <a href="#ownCloudCredentialsModal" data-toggle="modal" class="pull-right text-primary">Connect or Reauthorize Account</a>
         </small>
+        {% endif %}
     </h4>
 
+    {% if addon.is_supported_force_to_use %}
     <div class="addon-auth-table" id="{{ addon.addon_short_name }}-header">
         <!-- ko foreach: accounts -->
         <a data-bind="click: $root.askDisconnect.bind($root)" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
@@ -45,4 +48,5 @@
         </div>
         <!-- /ko -->
     </div>
+    {% endif %}
 </div>

--- a/admin/templates/rdm_addons/addons/s3_institution_settings.html
+++ b/admin/templates/rdm_addons/addons/s3_institution_settings.html
@@ -9,11 +9,14 @@
     <h4 class="addon-title">
         <img class="addon-icon" src="{{ addon.addon_icon_url }}">
         <span data-bind="text: properName">{{ addon.addon_full_name }}</span>
+        {% if addon.is_supported_force_to_use %}
         <small>
             <a href="#s3InputCredentials" data-toggle="modal" class="pull-right text-primary">Connect or Reauthorize Account</a>
         </small>
+        {% endif %}
     </h4>
 
+    {% if addon.is_supported_force_to_use %}
     <div class="addon-auth-table" id="{{ addon.addon_short_name }}-header">
         <!-- ko foreach: accounts -->
         <a data-bind="click: $root.askDisconnect.bind($root)" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
@@ -46,4 +49,5 @@
         </div>
         <!-- /ko -->
     </div>
+    {% endif %}
 </div>


### PR DESCRIPTION
## Purpose

RDM Addonsにおける UNSUPPORTED_FORCE_TO_USE_ADDONS オプションによる、設定画面のForce to use設定UIを非表示にするオプションが、s3, dataverse, owncloud アドオンにも適用されるよう修正しました。

## Changes

- `admin/templates/rdm_addons/addons/{s3, dataverse, owncloud}_institution_settings.html` ... UNSUPPORTED_FORCE_TO_USE_ADDONSオプションの適用

## QA Notes

None

## Side Effects

None

## Ticket

GRDM-8521
