### PR TITLE
RDM独自アドオンコードをCOSに追従して更新

### DIFF
--- a/addons/azureblobstorage/models.py
+++ b/addons/azureblobstorage/models.py
@@ -37,7 +37,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
 
     folder_id = models.TextField(blank=True, null=True)
     folder_name = models.TextField(blank=True, null=True)
-    user_settings = models.ForeignKey(UserSettings, null=True, blank=True)
+    user_settings = models.ForeignKey(UserSettings, null=True, blank=True, on_delete=models.CASCADE)
 
     @property
     def folder_path(self):

--- a/addons/azureblobstorage/models.py
+++ b/addons/azureblobstorage/models.py
@@ -141,5 +141,5 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             },
         )
 
-    def after_delete(self, node, user):
+    def after_delete(self, user):
         self.deauthorize(Auth(user=user), log=True)

--- a/addons/azureblobstorage/models.py
+++ b/addons/azureblobstorage/models.py
@@ -43,9 +43,6 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     def folder_path(self):
         return self.folder_name
 
-    def fetch_folder_name(self):
-        return self.folder_name
-
     @property
     def display_name(self):
         return u'{0}: {1}'.format(self.config.full_name, self.folder_id)

--- a/addons/gitlab/models.py
+++ b/addons/gitlab/models.py
@@ -76,7 +76,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     repo_id = models.TextField(blank=True, null=True)
     hook_id = models.TextField(blank=True, null=True)
     hook_secret = models.TextField(blank=True, null=True)
-    user_settings = models.ForeignKey(UserSettings, null=True, blank=True)
+    user_settings = models.ForeignKey(UserSettings, null=True, blank=True, on_delete=models.CASCADE)
 
     @property
     def folder_id(self):

--- a/addons/nextcloud/models.py
+++ b/addons/nextcloud/models.py
@@ -137,7 +137,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             },
         )
 
-    def after_delete(self, node, user):
+    def after_delete(self, user):
         self.deauthorize(Auth(user=user), add_log=True)
         self.save()
 

--- a/addons/onedrive/models.py
+++ b/addons/onedrive/models.py
@@ -98,7 +98,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
 
     folder_id = models.TextField(null=True, blank=True)
     folder_path = models.TextField(null=True, blank=True)
-    user_settings = models.ForeignKey(UserSettings, null=True, blank=True)
+    user_settings = models.ForeignKey(UserSettings, null=True, blank=True, on_delete=models.CASCADE)
 
     _api = None
 

--- a/addons/onedrive/models.py
+++ b/addons/onedrive/models.py
@@ -128,10 +128,6 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         else:
             return '/ (Full OneDrive)'
 
-    def fetch_folder_name(self):
-        """Required.  Called by base views"""
-        return self.folder_name
-
     def clear_settings(self):
         self.folder_id = None
         self.folder_path = None

--- a/addons/s3compat/models.py
+++ b/addons/s3compat/models.py
@@ -171,5 +171,5 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             },
         )
 
-    def after_delete(self, node, user):
+    def after_delete(self, user):
         self.deauthorize(Auth(user=user), log=True)

--- a/addons/s3compat/models.py
+++ b/addons/s3compat/models.py
@@ -39,7 +39,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     folder_name = models.TextField(blank=True, null=True)
     folder_location = models.TextField(blank=True, null=True)
     encrypt_uploads = models.BooleanField(default=ENCRYPT_UPLOADS_DEFAULT)
-    user_settings = models.ForeignKey(UserSettings, null=True, blank=True)
+    user_settings = models.ForeignKey(UserSettings, null=True, blank=True, on_delete=models.CASCADE)
 
     @property
     def folder_path(self):

--- a/addons/swift/models.py
+++ b/addons/swift/models.py
@@ -51,9 +51,6 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     def folder_path(self):
         return self.folder_name
 
-    def fetch_folder_name(self):
-        return self.folder_name
-
     @property
     def display_name(self):
         return u'{0}: {1}'.format(self.config.full_name, self.folder_id)

--- a/addons/swift/models.py
+++ b/addons/swift/models.py
@@ -37,7 +37,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
 
     folder_id = models.TextField(blank=True, null=True)
     folder_name = models.TextField(blank=True, null=True)
-    user_settings = models.ForeignKey(UserSettings, null=True, blank=True)
+    user_settings = models.ForeignKey(UserSettings, null=True, blank=True, on_delete=models.CASCADE)
 
     _api = None
 

--- a/addons/swift/models.py
+++ b/addons/swift/models.py
@@ -158,5 +158,5 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             },
         )
 
-    def after_delete(self, node, user):
+    def after_delete(self, user):
         self.deauthorize(Auth(user=user), log=True)

--- a/addons/weko/models.py
+++ b/addons/weko/models.py
@@ -36,7 +36,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
 
     index_title = models.TextField(blank=True, null=True)
     index_id = models.TextField(blank=True, null=True)
-    user_settings = models.ForeignKey(UserSettings, null=True, blank=True)
+    user_settings = models.ForeignKey(UserSettings, null=True, blank=True, on_delete=models.CASCADE)
 
     _api = None
 

--- a/addons/weko/models.py
+++ b/addons/weko/models.py
@@ -154,7 +154,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
 
     ##### Callback overrides #####
 
-    def after_delete(self, node, user):
+    def after_delete(self, user):
         self.deauthorize(Auth(user=user), add_log=True)
         self.save()
 


### PR DESCRIPTION
## Purpose

nii-mergework-201901に含まれるCOSのアドオンに関する変更を、RDM独自アドオンコードへ適用しました。

## Changes

以下のコミットに追従

- [PLAT-575] Optimize Bulk Node Deletes via the API https://github.com/RCOSDP/RDM-osf.io/commit/c4d10a0781a8a1a21516e0c07bc9e6e0e23bb5ac
-  Add `on_delete` arg to all ForeignKey and OnetoOne fields. https://github.com/RCOSDP/RDM-osf.io/commit/5d1a2eb16117b7955d501d0678cf6a2ae7ac1a5e
- Generalize fetch_folder_name https://github.com/RCOSDP/RDM-osf.io/commit/9bd324e16a3a86182d94502be1f88eacf5e336a4

## QA Notes

None

## Side Effects

None

## Ticket

GRDM-8733
