### PR TITLE
WEKOのフォルダ作成のログメッセージ定義の追加

### DIFF
--- a/addons/weko/static/wekoAnonymousLogActionList.json
+++ b/addons/weko/static/wekoAnonymousLogActionList.json
@@ -4,6 +4,7 @@
     "weko_index_linked" : "A user linked a WEKO index to a project",
     "weko_index_created" : "A user created an index to a project",
     "weko_item_created" : "A user created an item to a project",
+    "weko_folder_created" : "A user created a folder in WEKO in a project",
     "weko_node_authorized" : "A user authorized the WEKO addon for a project",
     "weko_node_deauthorized" : "A user deauthorized the WEKO addon for a project",
     "weko_node_deauthorized_no_user" : "WEKO addon for a project deauthorized"

--- a/addons/weko/static/wekoLogActionList.json
+++ b/addons/weko/static/wekoLogActionList.json
@@ -4,6 +4,7 @@
     "weko_index_linked" : "${user} linked WEKO index ${dataset} to ${node}",
     "weko_index_created" : "${user} created an index ${filename} on ${node}",
     "weko_item_created" : "${user} created an item ${filename} on ${node}",
+    "weko_folder_created" : "${user} created folder ${filename} in WEKO index ${dataset} in ${node}",
     "weko_node_authorized" : "${user} authorized the WEKO addon for ${node}",
     "weko_node_deauthorized" : "${user} deauthorized the WEKO addon for ${node}",
     "weko_node_deauthorized_no_user" : "WEKO addon for ${node} deauthorized"


### PR DESCRIPTION
## Purpose

WEKOのフォルダ作成のログメッセージの定義が漏れていたため、追加しました。

## Changes

- "weko_folder_created" のログメッセージ定義の追加

## QA Notes

None

## Side Effects

None

## Ticket

GRDM-9218
