### PR TITLE
Hotfix/10639

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -308,52 +308,14 @@ INSTALLED_APPS += ('addons.nextcloud',)
 ADDONS_FOLDER_CONFIGURABLE.append('nextcloud')
 ADDONS_OAUTH.append('nextcloud')
 
-#TST commands delmiter
-TST_COMMAND_DELIMITER = '\0'
-
+TST_COMMAND_DELIMITER = ' '
 # RSA key generation settings
-SSL_GENERATE_KEY = 'openssl' + TST_COMMAND_DELIMITER + \
-                   'genrsa' + TST_COMMAND_DELIMITER + \
-                   '-des3' + TST_COMMAND_DELIMITER + \
-                   '-out' + TST_COMMAND_DELIMITER + \
-                   '{0}.key {1}'
-SSL_GENERATE_KEY_NOPASS = 'openssl' + TST_COMMAND_DELIMITER + \
-                          'rsa' + TST_COMMAND_DELIMITER + \
-                          '-in' + TST_COMMAND_DELIMITER + \
-                          '{0}.key' + TST_COMMAND_DELIMITER + \
-                          '-out' + TST_COMMAND_DELIMITER + \
-                          '{0}.key.nopass'
-SSL_GENERATE_CSR = 'openssl' + TST_COMMAND_DELIMITER + \
-                   'req' + TST_COMMAND_DELIMITER + \
-                   '-new' + TST_COMMAND_DELIMITER + \
-                   '-key' + TST_COMMAND_DELIMITER + \
-                   '{0}.key.nopass' + TST_COMMAND_DELIMITER + \
-                   '-out' + TST_COMMAND_DELIMITER + \
-                   '{0}.csr'
-SSL_GENERATE_SELF_SIGNED = 'openssl' + TST_COMMAND_DELIMITER + \
-                           'req' + TST_COMMAND_DELIMITER + \
-                           '-x509' + TST_COMMAND_DELIMITER + \
-                           '-nodes' + TST_COMMAND_DELIMITER + \
-                           '-days' + TST_COMMAND_DELIMITER + \
-                           '365' + TST_COMMAND_DELIMITER + \
-                           '-newkey' + TST_COMMAND_DELIMITER + \
-                           'rsa:2048' + TST_COMMAND_DELIMITER + \
-                           '-keyout' + TST_COMMAND_DELIMITER + \
-                           '{0}.key' + TST_COMMAND_DELIMITER + \
-                           '-out' + TST_COMMAND_DELIMITER + \
-                           '{0}.crt'
-SSL_PRIVATE_KEY_GENERATION = 'openssl' + TST_COMMAND_DELIMITER + \
-                             'genrsa' + TST_COMMAND_DELIMITER + \
-                             '-out' + TST_COMMAND_DELIMITER + \
-                             '{0}' + TST_COMMAND_DELIMITER + \
-                             '{1}'
-SSL_PUBLIC_KEY_GENERATION = 'openssl' + TST_COMMAND_DELIMITER + \
-                            'rsa' + TST_COMMAND_DELIMITER + \
-                            '-in' + TST_COMMAND_DELIMITER + \
-                            '{0}' + TST_COMMAND_DELIMITER + \
-                            '-pubout' + TST_COMMAND_DELIMITER + \
-                            '-out' + TST_COMMAND_DELIMITER + \
-                            '{1}'
+SSL_GENERATE_KEY = 'openssl genrsa -des3 -out {0}.key {1}'
+SSL_GENERATE_KEY_NOPASS = 'openssl rsa -in {0}.key -out {0}.key.nopass'
+SSL_GENERATE_CSR = 'openssl req -new -key {0}.key.nopass -out {0}.csr'
+SSL_GENERATE_SELF_SIGNED = 'openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout {0}.key -out {0}.crt'
+SSL_PRIVATE_KEY_GENERATION = 'openssl genrsa -out {0} {1}'
+SSL_PUBLIC_KEY_GENERATION = 'openssl rsa -in {0} -pubout -out {1}'
 
 # UserKey Placement destination
 KEY_NAME_PRIVATE = 'pvt'
@@ -365,22 +327,8 @@ KEY_NAME_FORMAT = '{0}_{1}_{2}{3}'
 PRIVATE_KEY_VALUE = 1
 PUBLIC_KEY_VALUE = 2
 # FreeTSA openation commands
-SSL_CREATE_TIMESTAMP_REQUEST = 'openssl' + TST_COMMAND_DELIMITER + \
-                               'ts' + TST_COMMAND_DELIMITER + \
-                               '-query' + TST_COMMAND_DELIMITER + \
-                               '-data' + TST_COMMAND_DELIMITER + \
-                               '{0}' + TST_COMMAND_DELIMITER + \
-                               '-cert' + TST_COMMAND_DELIMITER + \
-                               '-sha512'
-SSL_GET_TIMESTAMP_RESPONSE = 'openssl' + TST_COMMAND_DELIMITER + \
-                             'ts' + TST_COMMAND_DELIMITER + \
-                             '-verify' + TST_COMMAND_DELIMITER + \
-                             '-data' + TST_COMMAND_DELIMITER + \
-                             '{0}' + TST_COMMAND_DELIMITER + \
-                             '-in' + TST_COMMAND_DELIMITER + \
-                             '{1}' + TST_COMMAND_DELIMITER + \
-                             '-CAfile' + TST_COMMAND_DELIMITER + \
-                             '{2}'
+SSL_CREATE_TIMESTAMP_REQUEST = 'openssl ts -query -data {0} -cert -sha512'
+SSL_GET_TIMESTAMP_RESPONSE = 'openssl ts -verify -data {0} -in {1} -CAfile {2}'
 # openssl ts verify check value
 OPENSSL_VERIFY_RESULT_OK = 'OK'
 # timestamp verify rootKey

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -308,13 +308,52 @@ INSTALLED_APPS += ('addons.nextcloud',)
 ADDONS_FOLDER_CONFIGURABLE.append('nextcloud')
 ADDONS_OAUTH.append('nextcloud')
 
+#TST commands delmiter
+TST_COMMAND_DELIMITER = '\0'
+
 # RSA key generation settings
-SSL_GENERATE_KEY = 'openssl genrsa -des3 -out {0}.key {1}'
-SSL_GENERATE_KEY_NOPASS = 'openssl rsa -in {0}.key -out {0}.key.nopass'
-SSL_GENERATE_CSR = 'openssl req -new -key {0}.key.nopass -out {0}.csr'
-SSL_GENERATE_SELF_SIGNED = 'openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout {0}.key -out {0}.crt'
-SSL_PRIVATE_KEY_GENERATION = 'openssl genrsa -out {0} {1}'
-SSL_PUBLIC_KEY_GENERATION = 'openssl rsa -in {0} -pubout -out {1}'
+SSL_GENERATE_KEY = 'openssl' + TST_COMMAND_DELIMITER + \
+                   'genrsa' + TST_COMMAND_DELIMITER + \
+                   '-des3' + TST_COMMAND_DELIMITER + \
+                   '-out' + TST_COMMAND_DELIMITER + \
+                   '{0}.key {1}'
+SSL_GENERATE_KEY_NOPASS = 'openssl' + TST_COMMAND_DELIMITER + \
+                          'rsa' + TST_COMMAND_DELIMITER + \
+                          '-in' + TST_COMMAND_DELIMITER + \
+                          '{0}.key' + TST_COMMAND_DELIMITER + \
+                          '-out' + TST_COMMAND_DELIMITER + \
+                          '{0}.key.nopass'
+SSL_GENERATE_CSR = 'openssl' + TST_COMMAND_DELIMITER + \
+                   'req' + TST_COMMAND_DELIMITER + \
+                   '-new' + TST_COMMAND_DELIMITER + \
+                   '-key' + TST_COMMAND_DELIMITER + \
+                   '{0}.key.nopass' + TST_COMMAND_DELIMITER + \
+                   '-out' + TST_COMMAND_DELIMITER + \
+                   '{0}.csr'
+SSL_GENERATE_SELF_SIGNED = 'openssl' + TST_COMMAND_DELIMITER + \
+                           'req' + TST_COMMAND_DELIMITER + \
+                           '-x509' + TST_COMMAND_DELIMITER + \
+                           '-nodes' + TST_COMMAND_DELIMITER + \
+                           '-days' + TST_COMMAND_DELIMITER + \
+                           '365' + TST_COMMAND_DELIMITER + \
+                           '-newkey' + TST_COMMAND_DELIMITER + \
+                           'rsa:2048' + TST_COMMAND_DELIMITER + \
+                           '-keyout' + TST_COMMAND_DELIMITER + \
+                           '{0}.key' + TST_COMMAND_DELIMITER + \
+                           '-out' + TST_COMMAND_DELIMITER + \
+                           '{0}.crt'
+SSL_PRIVATE_KEY_GENERATION = 'openssl' + TST_COMMAND_DELIMITER + \
+                             'genrsa' + TST_COMMAND_DELIMITER + \
+                             '-out' + TST_COMMAND_DELIMITER + \
+                             '{0}' + TST_COMMAND_DELIMITER + \
+                             '{1}'
+SSL_PUBLIC_KEY_GENERATION = 'openssl' + TST_COMMAND_DELIMITER + \
+                            'rsa' + TST_COMMAND_DELIMITER + \
+                            '-in' + TST_COMMAND_DELIMITER + \
+                            '{0}' + TST_COMMAND_DELIMITER + \
+                            '-pubout' + TST_COMMAND_DELIMITER + \
+                            '-out' + TST_COMMAND_DELIMITER + \
+                            '{1}'
 
 # UserKey Placement destination
 KEY_NAME_PRIVATE = 'pvt'
@@ -326,8 +365,22 @@ KEY_NAME_FORMAT = '{0}_{1}_{2}{3}'
 PRIVATE_KEY_VALUE = 1
 PUBLIC_KEY_VALUE = 2
 # FreeTSA openation commands
-SSL_CREATE_TIMESTAMP_REQUEST = 'openssl ts -query -data {0} -cert -sha512'
-SSL_GET_TIMESTAMP_RESPONSE = 'openssl ts -verify -data {0} -in {1} -CAfile {2}'
+SSL_CREATE_TIMESTAMP_REQUEST = 'openssl' + TST_COMMAND_DELIMITER + \
+                               'ts' + TST_COMMAND_DELIMITER + \
+                               '-query' + TST_COMMAND_DELIMITER + \
+                               '-data' + TST_COMMAND_DELIMITER + \
+                               '{0}' + TST_COMMAND_DELIMITER + \
+                               '-cert' + TST_COMMAND_DELIMITER + \
+                               '-sha512'
+SSL_GET_TIMESTAMP_RESPONSE = 'openssl' + TST_COMMAND_DELIMITER + \
+                             'ts' + TST_COMMAND_DELIMITER + \
+                             '-verify' + TST_COMMAND_DELIMITER + \
+                             '-data' + TST_COMMAND_DELIMITER + \
+                             '{0}' + TST_COMMAND_DELIMITER + \
+                             '-in' + TST_COMMAND_DELIMITER + \
+                             '{1}' + TST_COMMAND_DELIMITER + \
+                             '-CAfile' + TST_COMMAND_DELIMITER + \
+                             '{2}'
 # openssl ts verify check value
 OPENSSL_VERIFY_RESULT_OK = 'OK'
 # timestamp verify rootKey

--- a/website/util/timestamp.py
+++ b/website/util/timestamp.py
@@ -6,6 +6,7 @@ import datetime
 import hashlib
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -450,15 +451,15 @@ def userkey_generation(guid):
         generation_pub_key_name = api_settings.KEY_NAME_FORMAT.format(
             guid, generation_date_hash, api_settings.KEY_NAME_PUBLIC, api_settings.KEY_EXTENSION)
         # private key generation
-        pvt_key_generation_cmd = api_settings.SSL_PRIVATE_KEY_GENERATION.format(
+        pvt_key_generation_cmd = shlex.split(api_settings.SSL_PRIVATE_KEY_GENERATION.format(
             os.path.join(api_settings.KEY_SAVE_PATH, generation_pvt_key_name),
             api_settings.KEY_BIT_VALUE
-        ).split(api_settings.TST_COMMAND_DELIMITER)
+        ))
 
-        pub_key_generation_cmd = api_settings.SSL_PUBLIC_KEY_GENERATION.format(
+        pub_key_generation_cmd = shlex.split(api_settings.SSL_PUBLIC_KEY_GENERATION.format(
             os.path.join(api_settings.KEY_SAVE_PATH, generation_pvt_key_name),
             os.path.join(api_settings.KEY_SAVE_PATH, generation_pub_key_name)
-        ).split(api_settings.TST_COMMAND_DELIMITER)
+        ))
 
         prc = subprocess.Popen(
             pvt_key_generation_cmd, shell=False, stdin=subprocess.PIPE,
@@ -499,7 +500,7 @@ def create_rdmuserkey_info(user_id, key_name, key_kind, date):
 class AddTimestamp:
     #1 create tsq (timestamp request) from file, and keyinfo
     def get_timestamp_request(self, file_name):
-        cmd = api_settings.SSL_CREATE_TIMESTAMP_REQUEST.format(file_name.encode('utf-8')).split(api_settings.TST_COMMAND_DELIMITER)
+        cmd = shlex.split(api_settings.SSL_CREATE_TIMESTAMP_REQUEST.format(file_name.encode('utf-8').replace(' ','\ ')))
         process = subprocess.Popen(
             cmd, shell=False, stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -532,10 +533,10 @@ class AddTimestamp:
         return res_content
 
     def get_timestamp_upki(self, file_name, tmp_dir):
-        cmd = api_settings.UPKI_CREATE_TIMESTAMP.format(
-            file_name.encode('utf-8'),
+        cmd = shlex.split(api_settings.UPKI_CREATE_TIMESTAMP.format(
+            file_name.encode('utf-8').replace(' ','\ '),
             '/dev/stdout'
-        ).split(api_settings.TST_COMMAND_DELIMITER)
+        ))
         try:
             process = subprocess.Popen(
                 cmd, shell=False, stdin=subprocess.PIPE,
@@ -742,11 +743,11 @@ class TimeStampTokenVerifyCheck:
                     except Exception as err:
                         raise err
 
-                    cmd = api_settings.SSL_GET_TIMESTAMP_RESPONSE.format(
-                        file_name.encode('utf-8'),
+                    cmd = shlex.split(api_settings.SSL_GET_TIMESTAMP_RESPONSE.format(
+                        file_name.encode('utf-8').replace(' ','\ '),
                         timestamptoken_file_path,
                         os.path.join(api_settings.KEY_SAVE_PATH, api_settings.VERIFY_ROOT_CERTIFICATE)
-                    ).split(api_settings.TST_COMMAND_DELIMITER)
+                    ))
                     # exec timestamptoken verification
                     try:
                         prc = subprocess.Popen(
@@ -773,10 +774,10 @@ class TimeStampTokenVerifyCheck:
                             fout.write(verify_result.timestamp_token)
                     except Exception as err:
                         raise err
-                    cmd = api_settings.UPKI_VERIFY_TIMESTAMP.format(
-                        file_name.encode('utf-8'),
-                        file_name.encode('utf-8') + '.tst'
-                    ).split(api_settings.TST_COMMAND_DELIMITER)
+                    cmd = shlex.split(api_settings.UPKI_VERIFY_TIMESTAMP.format(
+                        file_name.encode('utf-8').replace(' ','\ '),
+                        file_name.encode('utf-8').replace(' ','\ ') + '.tst'
+                    ))
                     try:
                         process = subprocess.Popen(
                             cmd, shell=False, stdin=subprocess.PIPE,

--- a/website/util/timestamp.py
+++ b/website/util/timestamp.py
@@ -495,12 +495,13 @@ def create_rdmuserkey_info(user_id, key_name, key_kind, date):
     userkey_info.key_kind = key_kind
     userkey_info.created_time = date
     return userkey_info
-
+def filename_formatter(file_name):
+    return file_name.encode('utf-8').replace(' ', '\\ ')
 
 class AddTimestamp:
     #1 create tsq (timestamp request) from file, and keyinfo
     def get_timestamp_request(self, file_name):
-        cmd = shlex.split(api_settings.SSL_CREATE_TIMESTAMP_REQUEST.format(file_name.encode('utf-8').replace(' ','\ ')))
+        cmd = shlex.split(api_settings.SSL_CREATE_TIMESTAMP_REQUEST.format(filename_formatter(file_name)))
         process = subprocess.Popen(
             cmd, shell=False, stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -534,7 +535,7 @@ class AddTimestamp:
 
     def get_timestamp_upki(self, file_name, tmp_dir):
         cmd = shlex.split(api_settings.UPKI_CREATE_TIMESTAMP.format(
-            file_name.encode('utf-8').replace(' ','\ '),
+            filename_formatter(file_name),
             '/dev/stdout'
         ))
         try:
@@ -744,7 +745,7 @@ class TimeStampTokenVerifyCheck:
                         raise err
 
                     cmd = shlex.split(api_settings.SSL_GET_TIMESTAMP_RESPONSE.format(
-                        file_name.encode('utf-8').replace(' ','\ '),
+                        filename_formatter(file_name),
                         timestamptoken_file_path,
                         os.path.join(api_settings.KEY_SAVE_PATH, api_settings.VERIFY_ROOT_CERTIFICATE)
                     ))
@@ -759,11 +760,11 @@ class TimeStampTokenVerifyCheck:
                             ret = api_settings.TIME_STAMP_TOKEN_CHECK_SUCCESS
                             verify_result_title = api_settings.TIME_STAMP_TOKEN_CHECK_SUCCESS_MSG  # 'OK'
                         else:
-                            logger.error('timestamp verification error occured.({}:{}) : {}'.format(verify_result.provider, verify_result.path, stderr_data))
+                            logger.error('timestamp verification error occured.({}:{}) : {}'.format(verify_result.provider, filename_formatter(file_name), stderr_data))
                             ret = api_settings.TIME_STAMP_TOKEN_CHECK_NG
                             verify_result_title = api_settings.TIME_STAMP_TOKEN_CHECK_NG_MSG  # 'NG'
                     except Exception as err:
-                        logger.error('timestamp verification error occured.({}:{}) : {}'.format(verify_result.provider, verify_result.path, err))
+                        logger.error('timestamp verification error occured.({}:{}) : {}'.format(verify_result.provider, filename_formatter(file_name), err))
                         ret = api_settings.TIME_STAMP_VERIFICATION_ERR
                         verify_result_title = api_settings.TIME_STAMP_VERIFICATION_ERR_MSG  # 'NG'
 
@@ -775,8 +776,8 @@ class TimeStampTokenVerifyCheck:
                     except Exception as err:
                         raise err
                     cmd = shlex.split(api_settings.UPKI_VERIFY_TIMESTAMP.format(
-                        file_name.encode('utf-8').replace(' ','\ '),
-                        file_name.encode('utf-8').replace(' ','\ ') + '.tst'
+                        filename_formatter(file_name),
+                        filename_formatter(file_name) + '.tst'
                     ))
                     try:
                         process = subprocess.Popen(

--- a/website/util/timestamp.py
+++ b/website/util/timestamp.py
@@ -449,12 +449,12 @@ def userkey_generation(guid):
         pvt_key_generation_cmd = api_settings.SSL_PRIVATE_KEY_GENERATION.format(
             os.path.join(api_settings.KEY_SAVE_PATH, generation_pvt_key_name),
             api_settings.KEY_BIT_VALUE
-        ).split(' ')
+        ).split(api_settings.TST_COMMAND_DELIMITER)
 
         pub_key_generation_cmd = api_settings.SSL_PUBLIC_KEY_GENERATION.format(
             os.path.join(api_settings.KEY_SAVE_PATH, generation_pvt_key_name),
             os.path.join(api_settings.KEY_SAVE_PATH, generation_pub_key_name)
-        ).split(' ')
+        ).split(api_settings.TST_COMMAND_DELIMITER)
 
         prc = subprocess.Popen(
             pvt_key_generation_cmd, shell=False, stdin=subprocess.PIPE,
@@ -495,7 +495,7 @@ def create_rdmuserkey_info(user_id, key_name, key_kind, date):
 class AddTimestamp:
     #1 create tsq (timestamp request) from file, and keyinfo
     def get_timestamp_request(self, file_name):
-        cmd = api_settings.SSL_CREATE_TIMESTAMP_REQUEST.format(file_name.encode('utf-8')).split(' ')
+        cmd = api_settings.SSL_CREATE_TIMESTAMP_REQUEST.format(file_name.encode('utf-8')).split(api_settings.TST_COMMAND_DELIMITER)
         process = subprocess.Popen(
             cmd, shell=False, stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -531,7 +531,7 @@ class AddTimestamp:
         cmd = api_settings.UPKI_CREATE_TIMESTAMP.format(
             file_name.encode('utf-8'),
             '/dev/stdout'
-        ).split(' ')
+        ).split(api_settings.TST_COMMAND_DELIMITER)
         try:
             process = subprocess.Popen(
                 cmd, shell=False, stdin=subprocess.PIPE,
@@ -742,7 +742,7 @@ class TimeStampTokenVerifyCheck:
                         file_name.encode('utf-8'),
                         timestamptoken_file_path,
                         os.path.join(api_settings.KEY_SAVE_PATH, api_settings.VERIFY_ROOT_CERTIFICATE)
-                    ).split(' ')
+                    ).split(api_settings.TST_COMMAND_DELIMITER)
                     prc = subprocess.Popen(
                         cmd, shell=False, stdin=subprocess.PIPE,
                         stderr=subprocess.PIPE, stdout=subprocess.PIPE)
@@ -767,7 +767,7 @@ class TimeStampTokenVerifyCheck:
                     cmd = api_settings.UPKI_VERIFY_TIMESTAMP.format(
                         file_name.encode('utf-8'),
                         file_name.encode('utf-8') + '.tst'
-                    ).split(' ')
+                    ).split(api_settings.TST_COMMAND_DELIMITER)
                     try:
                         process = subprocess.Popen(
                             cmd, shell=False, stdin=subprocess.PIPE,


### PR DESCRIPTION
## Purpose

・timestamp adding failed when filename with white space
・Bug fix: basefilenode is created when there is no record whose "path"value matches "path" instead of "materialized_path" value

## Changes
## QA Notes
## Side Effects
## Ticket
　GRDM#10639