### PR TITLE
Add Import button to JupyterHub addon

### DIFF
--- a/addons/jupyterhub/tests/test_view.py
+++ b/addons/jupyterhub/tests/test_view.py
@@ -26,7 +26,8 @@ class TestJupyterhubViews(JupyterhubAddonTestCase, OsfTestCase):
         self.node_settings.save()
         url = self.project.api_url_for('jupyterhub_get_services')
         res = self.app.get(url, auth=self.user.auth)
-        import_url = 'https://jh1.test/' + self.node_settings.owner._id
+        import_url = 'https://jh1.test/rcosrepo/import/' + \
+                     self.node_settings.owner._id
         assert_equals(len(res.json['data']), 1)
         assert_equals(res.json['data'][0]['name'], 'jh1')
         assert_equals(res.json['data'][0]['base_url'], 'https://jh1.test/')

--- a/addons/jupyterhub/tests/test_view.py
+++ b/addons/jupyterhub/tests/test_view.py
@@ -28,6 +28,6 @@ class TestJupyterhubViews(JupyterhubAddonTestCase, OsfTestCase):
         res = self.app.get(url, auth=self.user.auth)
         import_url = 'https://jh1.test/' + self.node_settings.owner._id
         assert_equals(len(res.json['data']), 1)
-        assert_equals(res.json['data'][0]['name'] == 'jh1')
-        assert_equals(res.json['data'][0]['base_url'] == 'https://jh1.test/')
-        assert_equals(res.json['data'][0]['import_url'] == import_url)
+        assert_equals(res.json['data'][0]['name'], 'jh1')
+        assert_equals(res.json['data'][0]['base_url'], 'https://jh1.test/')
+        assert_equals(res.json['data'][0]['import_url'], import_url)

--- a/addons/jupyterhub/tests/test_view.py
+++ b/addons/jupyterhub/tests/test_view.py
@@ -20,3 +20,14 @@ class TestJupyterhubViews(JupyterhubAddonTestCase, OsfTestCase):
         url = self.project.api_url_for('jupyterhub_get_services')
         res = self.app.get(url, auth=self.user.auth)
         assert_equals(len(res.json['data']), 0)
+
+    def test_jupyterhub_services(self):
+        self.node_settings.set_services([('jh1', 'https://jh1.test/')])
+        self.node_settings.save()
+        url = self.project.api_url_for('jupyterhub_get_services')
+        res = self.app.get(url, auth=self.user.auth)
+        import_url = 'https://jh1.test/' + self.node_settings.owner._id
+        assert_equals(len(res.json['data']), 1)
+        assert_equals(res.json['data'][0]['name'] == 'jh1')
+        assert_equals(res.json['data'][0]['base_url'] == 'https://jh1.test/')
+        assert_equals(res.json['data'][0]['import_url'] == import_url)

--- a/addons/jupyterhub/utils.py
+++ b/addons/jupyterhub/utils.py
@@ -11,3 +11,9 @@ def serialize_jupyterhub_widget(node):
     }
     ret.update(jupyterhub.config.to_json())
     return ret
+
+
+def get_jupyterhub_import_url(node, base_url):
+    if not base_url.endswith('/'):
+        base_url += '/'
+    return base_url + node._id

--- a/addons/jupyterhub/utils.py
+++ b/addons/jupyterhub/utils.py
@@ -16,4 +16,4 @@ def serialize_jupyterhub_widget(node):
 def get_jupyterhub_import_url(node, base_url):
     if not base_url.endswith('/'):
         base_url += '/'
-    return base_url + node._id
+    return base_url + 'rcosrepo/import/' + node._id

--- a/addons/jupyterhub/views.py
+++ b/addons/jupyterhub/views.py
@@ -4,6 +4,7 @@ from flask import request
 import logging
 
 from . import settings
+from .utils import get_jupyterhub_import_url
 from framework.exceptions import HTTPError
 from website.project.decorators import (
     must_be_contributor_or_public,
@@ -57,5 +58,7 @@ def jupyterhub_set_config(**kwargs):
 def jupyterhub_get_services(**kwargs):
     node = kwargs['node'] or kwargs['project']
     jupyterhub = node.get_addon('jupyterhub')
-    return {'data': [dict(zip(['name', 'base_url'], s))
-                     for s in jupyterhub.get_services() + settings.SERVICES]}
+    services = jupyterhub.get_services() + settings.SERVICES
+    return {'data': [{'name': name, 'base_url': base_url,
+                      'import_url': get_jupyterhub_import_url(node, base_url)}
+                     for name, base_url in services]}

--- a/website/templates/util/render_addon_widget.mako
+++ b/website/templates/util/render_addon_widget.mako
@@ -151,6 +151,9 @@
                                 <tr>
                                     <td>
                                       <a data-bind="attr: {href: base_url}, text: name" target="_blank"></a>
+                                      <a data-bind="attr: {href: import_url}" style="margin-left: 1em;" class="btn btn-default" target="_blank">
+                                          <i class="fa fa-external-link"></i> Launch
+                                      </a>
                                     </td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
## Purpose

Add Import button which can be used for importing all storages on a project to JupyterHub

## Changes

Add a button to an endpoint of RDM Jupyter Extension https://github.com/RCOSDP/rdm-jupyter-extension on JupyterHub addon

## QA Notes

None

## Side Effects

None

## Ticket

GRDM-9839
