### PR TITLE
HTTP support for S3 Compatible Storage

### DIFF
--- a/addons/s3compat/README.md
+++ b/addons/s3compat/README.md
@@ -26,7 +26,8 @@ which is defined in `addons/s3compat/static/settings.json`.
 ## Enabling the addon
 
 ### Enable on OSF
-1. On osf, enable S3 as a provider
+1. On osf, enable S3 Compatible Storage as a provider
 2. Scroll down to Configure Add-ons
-3. Connect your account and enter your ID and secret
-4. Select a bucket to work from, or create a new one.
+3. Choose desired storage service
+4. Connect your account and enter your ID and secret
+5. Select a bucket to work from, or create a new one.

--- a/addons/s3compat/README.md
+++ b/addons/s3compat/README.md
@@ -2,7 +2,7 @@
 
 S3 Compatible Storage Addon enables to mount Cloud Storage which supports Amazon S3-like API on the project.
 
-## Configuring the addons
+## Configuring the addon
 
 Users can select storage from the S3 Compatible Storage List,
 which is defined in `addons/s3compat/static/settings.json`.

--- a/addons/s3compat/README.md
+++ b/addons/s3compat/README.md
@@ -1,4 +1,4 @@
-# OSF S3 Compatible Storage Addon
+# RDM S3 Compatible Storage Addon
 
 S3 Compatible Storage Addon enables to mount Cloud Storage which supports Amazon S3-like API on the project.
 
@@ -25,8 +25,8 @@ which is defined in `addons/s3compat/static/settings.json`.
 
 ## Enabling the addon
 
-### Enable on OSF
-1. On osf, enable S3 Compatible Storage as a provider
+### Enable on RDM
+1. On RDM, enable S3 Compatible Storage as a provider
 2. Scroll down to Configure Add-ons
 3. Choose desired storage service
 4. Connect your account and enter your ID and secret

--- a/addons/s3compat/README.md
+++ b/addons/s3compat/README.md
@@ -1,0 +1,32 @@
+# OSF S3 Compatible Storage Addon
+
+S3 Compatible Storage Addon enables to mount Cloud Storage which supports Amazon S3-like API on the project.
+
+## Configuring the addons
+
+Users can select storage from the S3 Compatible Storage List,
+which is defined in `addons/s3compat/static/settings.json`.
+
+```
+{
+    "availableServices": [{"name": "Wasabi",
+                           "host": "s3.wasabisys.com",
+                           "bucketLocations": {
+                             "us-east": {"name": "us-east", "host": "s3.wasabisys.com"},
+                             "us-west-1": {"name": "us-west-1", "host": "s3.us-west-1.wasabisys.com"},
+                             "eu-central": {"name": "eu-central", "host": "s3.eu-central-1.wasabisys.com"},
+                             "": {"name": "Virginia"}}},
+                          {"name": "My Private Storage",
+                           "host": "my-private-storage-address:80"}
+                           ],
+    "encryptUploads": true
+}
+```
+
+## Enabling the addon
+
+### Enable on OSF
+1. On osf, enable S3 as a provider
+2. Scroll down to Configure Add-ons
+3. Connect your account and enter your ID and secret
+4. Select a bucket to work from, or create a new one.

--- a/addons/s3compat/tests/utils.py
+++ b/addons/s3compat/tests/utils.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+from nose.tools import (assert_equals, assert_true, assert_false)
+
 from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase
 from addons.s3compat.tests.factories import S3CompatAccountFactory
 from addons.s3compat.provider import S3CompatProvider
 from addons.s3compat.serializer import S3CompatSerializer
+from addons.s3compat import utils
 
 class S3CompatAddonTestCase(OAuthAddonTestCaseMixin, AddonTestCase):
 
@@ -16,3 +19,33 @@ class S3CompatAddonTestCase(OAuthAddonTestCaseMixin, AddonTestCase):
         'name': 'bucket',
         'id': 'bucket'
     }
+
+    def test_https(self):
+        connection = utils.connect_s3compat(host='securehost',
+                                            access_key='a',
+                                            secret_key='s')
+        assert_true(connection.is_secure)
+        assert_equals(connection.host, 'securehost')
+        assert_equals(connection.port, 443)
+
+        connection = utils.connect_s3compat(host='securehost:443',
+                                            access_key='a',
+                                            secret_key='s')
+        assert_true(connection.is_secure)
+        assert_equals(connection.host, 'securehost')
+        assert_equals(connection.port, 443)
+
+    def test_http(self):
+        connection = utils.connect_s3compat(host='normalhost:80',
+                                            access_key='a',
+                                            secret_key='s')
+        assert_false(connection.is_secure)
+        assert_equals(connection.host, 'normalhost')
+        assert_equals(connection.port, 80)
+
+        connection = utils.connect_s3compat(host='normalhost:8080',
+                                            access_key='a',
+                                            secret_key='s')
+        assert_false(connection.is_secure)
+        assert_equals(connection.host, 'normalhost')
+        assert_equals(connection.port, 8080)

--- a/addons/s3compat/utils.py
+++ b/addons/s3compat/utils.py
@@ -40,10 +40,14 @@ def connect_s3compat(host=None, access_key=None, secret_key=None, node_settings=
         if node_settings.external_account is not None:
             host = node_settings.external_account.provider_id.split('\t')[0]
             access_key, secret_key = node_settings.external_account.oauth_key, node_settings.external_account.oauth_secret
-    connection = S3CompatConnection(access_key, secret_key,
+    if host.endswith(':80'):
+        conn = S3CompatConnection(access_key, secret_key, is_secure=False,
                                   calling_format=OrdinaryCallingFormat(),
-                                  host=host)
-    return connection
+                                  host=host.split(':')[0])
+        return conn
+    return S3CompatConnection(access_key, secret_key,
+                              calling_format=OrdinaryCallingFormat(),
+                              host=host)
 
 
 def get_bucket_names(node_settings):

--- a/addons/s3compat/utils.py
+++ b/addons/s3compat/utils.py
@@ -40,14 +40,16 @@ def connect_s3compat(host=None, access_key=None, secret_key=None, node_settings=
         if node_settings.external_account is not None:
             host = node_settings.external_account.provider_id.split('\t')[0]
             access_key, secret_key = node_settings.external_account.oauth_key, node_settings.external_account.oauth_secret
-    if host.endswith(':80'):
-        conn = S3CompatConnection(access_key, secret_key, is_secure=False,
-                                  calling_format=OrdinaryCallingFormat(),
-                                  host=host.split(':')[0])
-        return conn
+    port = 443
+    m = re.match(r'^(.+)\:([0-9]+)$', host)
+    if m is not None:
+        host = m.group(1)
+        port = int(m.group(2))
     return S3CompatConnection(access_key, secret_key,
                               calling_format=OrdinaryCallingFormat(),
-                              host=host)
+                              host=host,
+                              port=port,
+                              is_secure=port == 443)
 
 
 def get_bucket_names(node_settings):


### PR DESCRIPTION
## Purpose

To use S3-like Storage which has no HTTPS endpoints, add HTTP support for S3 Compatible Storage.

## Changes

* Add Port option to `addons/s3compat/static/settings.json`

## QA Notes

None

## Side Effects

None

## Ticket

GRDM-11023