### PR TITLE
Fix flake8 errors of AzureBlobStorage and S3Compat Addons for regexp

### DIFF
--- a/addons/azureblobstorage/utils.py
+++ b/addons/azureblobstorage/utils.py
@@ -27,7 +27,7 @@ def get_container_names(node_settings):
 def validate_container_name(name):
     """Make sure the container name conforms to Azure's expectations
     """
-    label = '[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])*'
+    label = r'[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])*'
     validate_name = re.compile('^' + label + '$')
     return (
         len(name) >= 3 and len(name) <= 63 and bool(validate_name.match(name))

--- a/addons/s3compat/utils.py
+++ b/addons/s3compat/utils.py
@@ -83,9 +83,9 @@ def validate_bucket_name(name):
     http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
     The laxer rules for US East (N. Virginia) are not supported.
     """
-    label = '[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])?'
+    label = r'[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])?'
     validate_name = re.compile('^' + label + '(?:\\.' + label + ')*$')
-    is_ip_address = re.compile('^[0-9]+(?:\.[0-9]+){3}$')
+    is_ip_address = re.compile(r'^[0-9]+(?:\.[0-9]+){3}$')
     return (
         len(name) >= 3 and len(name) <= 63 and bool(validate_name.match(name)) and not bool(is_ip_address.match(name))
     )


### PR DESCRIPTION
## Purpose

AzureBlobStorage と S3Compat Addons の flake8 エラーの修正

## Changes

- 各アドオン util モジュール内 container/bucket 名 validateメソッドの一部の正規表現を raw string を使うよう修正

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-13033
