### PR TITLE
Set SSL = True for Nextcloud

### DIFF
--- a/admin/rdm_custom_storage_location/utils.py
+++ b/admin/rdm_custom_storage_location/utils.py
@@ -476,7 +476,7 @@ def save_nextcloud_credentials(institution_id, storage_name, host_url, username,
         'storage': {
             'bucket': '',
             'folder': '/{}/'.format(folder.strip('/')),
-            'verify_ssl': False,
+            'verify_ssl': True,
             'provider': provider
         },
     }


### PR DESCRIPTION
機関ストレージとして Nextcloud を設定すると、自動的に `verify_ssl = False` が設定されていました。
ローラル環境で `verify_ssl = True` に変えても問題ありませんでした。