### PR TITLE
docker-composeコマンドのオプション修正

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -70,7 +70,7 @@
 
 * _NOTE: After making changes to `Environment Variables` or `Volume Mounts` you will need to recreate the container(s)._
 
-  - `$ docker-compose up --force-recreate --no-deps preprints`
+  - `$ docker-compose up -d --force-recreate --no-deps preprints`
 
 1. Application Settings
  - e.g. OSF & OSF API local.py
@@ -370,4 +370,3 @@ web:
 ```bash
   $ api/timestamp/local-dist.py api/timestamp/local.py
 ```
-


### PR DESCRIPTION
## Purpose

サンプルdocker-composeコマンド実行時に制御が戻ってこない問題の修正

## Changes

`docker-compose up`で制御が戻ってくるように`-d`オプションを追加

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-21338