### PR TITLE
Python3対応 config.iter()

### DIFF
--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -527,7 +527,7 @@ def user_choose_addons(**kwargs):
     auth = kwargs['auth']
     config = escape_html(request.get_json())
     try:
-        for addon_name, enabled in config.iteritems():
+        for addon_name, enabled in config.items():
             if enabled:
                 validate_rdm_addons_allowed(auth, addon_name)
     except PermissionsError as e:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -451,7 +451,7 @@ def collect_node_config_js(addons):
 def node_choose_addons(auth, node, **kwargs):
     config = request.json
     try:
-        for addon_name, enabled in config.iteritems():
+        for addon_name, enabled in config.items():
             if enabled:
                 validate_rdm_addons_allowed(auth, addon_name)
     except PermissionsError as e:


### PR DESCRIPTION
## Purpose

アドオンの動作確認時に見つかったPython 3対応の修正です。

## Changes

Python 3でDictionaryの関数 `itemiter()` が `iter()` に変更されており、これに対応する修正をしました。

他にも `itemiter()` が使われている箇所がありますが、今回は RDM-developer-guide で動作確認ができている箇所のみのPRを送らせていただきます。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-20575
