### PR TITLE
Fix JupyterHub Label(nii-mergework-202007)

### DIFF
--- a/addons/jupyterhub/static/files.js
+++ b/addons/jupyterhub/static/files.js
@@ -89,7 +89,7 @@ function JupyterButton() {
                     },
                     icon: 'fa fa-external-link',
                     className : 'text-primary'
-                }, 'JupyterHub');
+                }, 'Launch');
                 return {
                   view : function(ctrl, args, children) {
                     var tb = args.treebeard;

--- a/addons/jupyterhub/static/files.js
+++ b/addons/jupyterhub/static/files.js
@@ -6,6 +6,8 @@ var Fangorn = require('js/fangorn').Fangorn;
 var Raven = require('raven-js');
 
 var logPrefix = '[jupyterhub] ';
+var _ = require('js/rdmGettext')._;
+
 
 
 function JupyterButton() {
@@ -89,7 +91,7 @@ function JupyterButton() {
                     },
                     icon: 'fa fa-external-link',
                     className : 'text-primary'
-                }, 'Launch');
+                }, _('Launch'));
                 return {
                   view : function(ctrl, args, children) {
                     var tb = args.treebeard;

--- a/addons/jupyterhub/static/files.js
+++ b/addons/jupyterhub/static/files.js
@@ -9,7 +9,6 @@ var logPrefix = '[jupyterhub] ';
 var _ = require('js/rdmGettext')._;
 
 
-
 function JupyterButton() {
   var self = this;
   self.baseUrl = window.contextVars.node.urls.api + 'jupyterhub/';

--- a/website/translations/en/LC_MESSAGES/js_messages.po
+++ b/website/translations/en/LC_MESSAGES/js_messages.po
@@ -202,6 +202,10 @@ msgstr ""
 msgid "Autocomplete"
 msgstr ""
 
+#: addons/jupyterhub/static/files.js:92
+msgid "Launch"
+msgstr ""
+
 #: admin/static/js/collection_providers/collectionProviders.js:9
 msgid "Hide Form"
 msgstr ""
@@ -6663,4 +6667,3 @@ msgstr ""
 
 #~ msgid "${user}updated file ${path} in Dropbox Business in ${node}"
 #~ msgstr ""
-

--- a/website/translations/ja/LC_MESSAGES/js_messages.po
+++ b/website/translations/ja/LC_MESSAGES/js_messages.po
@@ -204,6 +204,10 @@ msgstr "Wiki構文のヘルプ"
 msgid "Autocomplete"
 msgstr "自動更新"
 
+#: addons/jupyterhub/static/files.js:92
+msgid "Launch"
+msgstr "起動"
+
 #: admin/static/js/collection_providers/collectionProviders.js:9
 msgid "Hide Form"
 msgstr "フォームを隠す"
@@ -7790,4 +7794,3 @@ msgstr "%1$sに報告してください"
 #: website/static/js/pages/wiki-edit-page.js:110
 msgid "Could not GET wiki menu pages"
 msgstr "Wikiメニューページを取得できませんでした"
-

--- a/website/translations/ja/LC_MESSAGES/messages.po
+++ b/website/translations/ja/LC_MESSAGES/messages.po
@@ -3843,7 +3843,7 @@ msgstr "リンクされたJupyterHubs"
 
 #: website/templates/util/render_addon_widget.mako:158
 msgid "Launch"
-msgstr "始める"
+msgstr "起動"
 
 #: website/templates/util/render_addon_widget.mako:166
 msgid "No Linked JupyterHubs"

--- a/website/translations/js_messages.pot
+++ b/website/translations/js_messages.pot
@@ -201,6 +201,10 @@ msgstr ""
 msgid "Autocomplete"
 msgstr ""
 
+#: addons/jupyterhub/static/files.js:92
+msgid "Launch"
+msgstr ""
+
 #: admin/static/js/collection_providers/collectionProviders.js:9
 msgid "Hide Form"
 msgstr ""
@@ -6657,4 +6661,3 @@ msgstr ""
 #: website/static/js/pages/wiki-edit-page.js:110
 msgid "Could not GET wiki menu pages"
 msgstr ""
-


### PR DESCRIPTION
## Purpose

JupyterHubラベルの修正(nii-mergework-202007 向け変更)

## Changes

* ファイルビューでのJupyterHubボタンのラベルを Launch に変更
* 日本語版ビューでのLaunchボタンのラベルを 起動 に変更

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-21433
