### PR TITLE
#22765 (1). DMR基盤API実行のための認証処理の導入（仮対応）

### DIFF
--- a/addons/niirdccore/models.py
+++ b/addons/niirdccore/models.py
@@ -15,3 +15,6 @@ class NodeSettings(BaseNodeSettings):
     """
     プロジェクトにアタッチされたアドオンに関するモデルを定義する。
     """
+
+    def get_dmr_api_key(self):
+        return settings.DMR_API_KEY

--- a/addons/niirdccore/settings/local-dist.py
+++ b/addons/niirdccore/settings/local-dist.py
@@ -1,0 +1,2 @@
+DMR_API_KEY = 'changeme'
+


### PR DESCRIPTION
## Purpose

#22765 (1). DMR基盤API実行のための認証処理の導入（仮対応）
DMR基盤で提供されているAPIを実行するために、APIキー情報をコンフィグ定義した。

## Changes

addons/niirdccore/settings/local-dist.py
addons/niirdccore/models.py