### PR TITLE
#22470 DMP閲覧画面の実装

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -55,7 +55,8 @@
         "nextcloud": "partial",
         "nextcloudinstitutions": "partial",
         "iqbrims": "partial",
-        "dropboxbusiness": "partial"
+        "dropboxbusiness": "partial",
+        "niirdccore": "partial"
     },
     "addons_commentable": [
         "osfstorage",
@@ -78,7 +79,8 @@
         "nextcloud",
         "nextcloudinstitutions",
         "iqbrims",
-        "dropboxbusiness"
+        "dropboxbusiness",
+        "niirdccore"
     ],
     "addons_based_on_ids": [
         "osfstorage",

--- a/addons/niirdccore/apps.py
+++ b/addons/niirdccore/apps.py
@@ -18,7 +18,7 @@ class AddonAppConfig(BaseAddonAppConfig):
 
     owners = ['node']
 
-    views = []
+    views = ['page']
     configs = ['node']
 
     categories = ['other']
@@ -30,7 +30,7 @@ class AddonAppConfig(BaseAddonAppConfig):
     @property
     def routes(self):
         from . import routes
-        return [routes.api_routes]
+        return [routes.page_routes, routes.api_routes]
 
     @property
     def node_settings(self):

--- a/addons/niirdccore/routes.py
+++ b/addons/niirdccore/routes.py
@@ -3,9 +3,28 @@ Routes associated with the niirdccore addon
 """
 
 from framework.routing import Rule, json_renderer
+from website.routes import notemplate
 from . import SHORT_NAME
 from . import views
 
+# HTML endpoints
+page_routes = {
+    'rules': [
+        # Home (Base) | GET
+        Rule(
+            [
+                '/<pid>/{}'.format(SHORT_NAME),
+                '/<pid>/node/<nid>/{}'.format(SHORT_NAME),
+            ],
+            'get',
+            views.project_niirdccore,
+            notemplate
+        ),
+
+    ]
+}
+
+# JSON endpoints
 api_routes = {
     'rules': [
         Rule([

--- a/addons/niirdccore/views.py
+++ b/addons/niirdccore/views.py
@@ -12,6 +12,7 @@ from website.project.decorators import (
     must_have_permission,
     must_have_addon,
 )
+from website.ember_osf_web.views import use_ember_app
 from addons.jupyterhub.apps import JupyterhubAddonAppConfig
 
 logger = logging.getLogger(__name__)
@@ -59,5 +60,9 @@ def niirdccore_get_dmp_info(**kwargs):
     dmp_info = requests.get(url, headers=headers)
 
     return {'data': {'id': node._id, 'type': 'dmp-status',
-                    'attributes': dmp_info.text}}
+                    'attributes': dmp_info.json()}}
 
+@must_be_valid_project
+@must_have_addon(SHORT_NAME, 'node')
+def project_niirdccore(**kwargs):
+    return use_ember_app()


### PR DESCRIPTION
## Purpose

#22470 3.(4).(2). DMP閲覧画面の実装
・コアアドオン（DMP閲覧画面）のタブが表示されるように修正
・DMP情報取得APIのResponseデータ形式をtextからjsonに修正

## Changes

addons.json
addons/niirdccore/apps.py
addons/niirdccore/routes.py
addons/niirdccore/views.py