### PR TITLE
#23769 アドオン一覧画面でのNII RDC Coreアドオン表示制御の実装

### DIFF
--- a/addons/niirdccore/apps.py
+++ b/addons/niirdccore/apps.py
@@ -7,6 +7,12 @@ import os
 from addons.base.apps import BaseAddonAppConfig
 from . import SHORT_NAME
 
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE_PATH = os.path.join(
+    HERE,
+    'templates'
+)
+
 # `__init__.py` の `default_app_config` により本ファイル内の`AddonAppConfig`が参照される
 class AddonAppConfig(BaseAddonAppConfig):
 
@@ -26,6 +32,8 @@ class AddonAppConfig(BaseAddonAppConfig):
     include_js = {}
 
     include_css = {}
+
+    node_settings_template = os.path.join(TEMPLATE_PATH, 'node_settings.mako')
 
     @property
     def routes(self):

--- a/addons/niirdccore/models.py
+++ b/addons/niirdccore/models.py
@@ -21,7 +21,7 @@ class NodeSettings(BaseNodeSettings):
     """
     プロジェクトにアタッチされたアドオンに関するモデルを定義する。
     """
-    dmp_id = models.TextField(blank=False, null=True)
+    dmp_id = models.TextField(blank=True, null=True)
 
     def get_dmr_api_key(self):
         return settings.DMR_API_KEY

--- a/addons/niirdccore/static/node-cfg.js
+++ b/addons/niirdccore/static/node-cfg.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var $ = require('jquery');
+var osfHelpers = require('js/osfHelpers');
+var SHORT_NAME = 'niirdccore';
+
+function NodeSettings() {
+  var self = this;
+}
+
+var settings = new NodeSettings();
+osfHelpers.applyBindings(settings, `#${SHORT_NAME}Scope`);

--- a/addons/niirdccore/templates/node_settings.mako
+++ b/addons/niirdccore/templates/node_settings.mako
@@ -1,0 +1,6 @@
+<div id="${addon_short_name}Scope" class="scripted">
+    <h4 class="addon-title">
+        <img class="addon-icon" src=${addon_icon_url}>
+        ${addon_full_name}
+    </h4>
+</div>

--- a/framework/addons/data/addons.json
+++ b/framework/addons/data/addons.json
@@ -589,6 +589,36 @@
                 "status": "partial",
                 "text": "IQB-RIMS content will be registered, but version history will not be copied to the registration."
             }
+        },
+        "NII RDC Core": {
+            "Permissions": {
+                "status": "none",
+                "text": "The GakuNin RDM does not affect the permissions of NII RDC Core."
+            },
+            "View / download file versions": {
+                "status": "none",
+                "text": "The NII RDC Core add-on does not provide Storage Features."
+            },
+            "Add / update files": {
+                "status": "none",
+                "text": "The NII RDC Core add-on does not provide Storage Features."
+            },
+            "Delete files": {
+                "status": "none",
+                "text": "The NII RDC Core add-on does not provide Storage Features."
+            },
+            "Logs": {
+                "status": "none",
+                "text": "The NII RDC Core add-on does not provide Storage Features."
+            },
+            "Forking": {
+                "status": "partial",
+                "text": "Forking a project or component copies information about linked DMP Cooperation but the GakuNin RDM does not affect authentication of NII RDC Core."
+            },
+            "Registering": {
+                "status": "none",
+                "text": "NII RDC Core information will not be registered."
+            }
         }
     },
     "disclaimers": [


### PR DESCRIPTION
## Purpose

#23769 3.(4).(1). アドオン一覧画面でのNII RDC Coreアドオン表示制御の実装
・アドオン一覧画面/Configure Add-ons部分に、NII RDC Coreアドオンの表示を追加
・NII RDC Coreアドオンのアドオン規約を仮置き（国際化は未対応）
・NII RDC CoreアドオンをDisableにした際に発生するエラーを解消するため、dmp_idのblankを許容

## Changes

addons/niirdccore/apps.py
addons/niirdccore/models.py
addons/niirdccore/static/node-cfg.js
addons/niirdccore/templates/node_settings.mako
framework/addons/data/addons.json