### PR TITLE
#22461 コアアドオン追加時の所属機関判定を除外、プロビジョニングAPIにJupyterHubリンク設定を追加

### DIFF
--- a/addons/niirdccore/models.py
+++ b/addons/niirdccore/models.py
@@ -41,18 +41,18 @@ class NodeSettings(BaseNodeSettings):
         if instance.has_addon(SHORT_NAME):
             # add済みの場合は終了
             return
-
-        inst_ids = instance.affiliated_institutions.values('id')
-        addon_option = RdmAddonOption.objects.filter(
-            provider=SHORT_NAME,
-            institution_id__in=Subquery(inst_ids),
-            management_node__isnull=False,
-            is_allowed=True
-        ).first()
-        if addon_option is None:
-            return
-        if addon_option.organizational_node is not None and \
-                not addon_option.organizational_node.is_contributor(instance.creator):
-            return
+        # 所属機関によるアドオン追加判定は、adminコンテナの起動が可能になるまでコメントアウトする
+        # inst_ids = instance.affiliated_institutions.values('id')
+        # addon_option = RdmAddonOption.objects.filter(
+        #     provider=SHORT_NAME,
+        #     institution_id__in=Subquery(inst_ids),
+        #     management_node__isnull=False,
+        #     is_allowed=True
+        # ).first()
+        # if addon_option is None:
+        #     return
+        # if addon_option.organizational_node is not None and \
+        #         not addon_option.organizational_node.is_contributor(instance.creator):
+        #     return
 
         instance.add_addon(SHORT_NAME, auth=None, log=False)


### PR DESCRIPTION
## Purpose

#22461 3.(4).(4) アドオン追加機能の修正

・#22474 3.(4).(4). JupyterHub利用環境のプロビジョニング機能の実装
　　プロビジョニングAPIにJupyterHubリンク設定を追加

・#22477 3.(4).(4). RDC Core アドオンのデフォルトアドオン化の実装
　　コアアドオン追加時の所属機関判定をコメントアウト

## Changes

addons/niirdccore/models.py
addons/niirdccore/views.py