### PR TITLE
(6) 購読申請API、(7) DMP送信APIを実装

### DIFF
--- a/addons/niirdccore/models.py
+++ b/addons/niirdccore/models.py
@@ -25,11 +25,11 @@ class NodeSettings(BaseNodeSettings):
 
     def get_dmr_api_key(self):
         return settings.DMR_API_KEY
-    
+
     def set_dmp_id(self, dmp_id):
         self.dmp_id = dmp_id
         self.save()
-    
+
     def get_dmp_id(self):
         return self.dmp_id
 
@@ -56,3 +56,48 @@ class NodeSettings(BaseNodeSettings):
         #     return
 
         instance.add_addon(SHORT_NAME, auth=None, log=False)
+
+class AddonList(BaseNodeSettings):
+    """
+    送信先アドオンリストに関するモデルを定義する。
+    """
+    owner    = models.ForeignKey("NodeSettings", null=True, blank=True, related_name="node")
+    node_id = models.CharField(max_length=100, blank=True)
+    dmp_id = models.TextField(blank=True, null=True)
+    addon_id = models.CharField(max_length=50, blank=True)
+    callback = models.CharField(max_length=100, blank=True)
+
+    def get_owner(self):
+        return self.owner
+
+    def set_owner(self, owner):
+        self.owner = owner
+        self.save()
+
+    def get_node_id(self):
+        return node_id
+
+    def set_node_id(self, node_id):
+        self.node_id = node_id
+        self.save()
+
+    def get_dmp_id(self):
+        return self.dmp_id
+
+    def set_dmp_id(self, dmp_id):
+        self.dmp_id = dmp_id
+        self.save()
+
+    def get_addon_id(self):
+        return self.addon_id
+
+    def set_addon_id(self, addon_id):
+        self.addon_id = addon_id
+        self.save()
+
+    def get_callback(self):
+        return self.callback
+
+    def set_callback(self, callback):
+        self.callback = callback
+        self.save()

--- a/addons/niirdccore/routes.py
+++ b/addons/niirdccore/routes.py
@@ -35,6 +35,9 @@ api_routes = {
             '/project/<pid>/{}/dmp'.format(SHORT_NAME),
             '/project/<pid>/node/<nid>/{}/dmp'.format(SHORT_NAME),
         ], 'get', views.niirdccore_get_dmp_info, json_renderer),
+        Rule([
+            '/project/{}/dmp_notification'.format(SHORT_NAME),
+        ], 'post', views.niirdccore_dmp_notification, json_renderer),
     ],
     'prefix': '/api/v1',
 }

--- a/addons/niirdccore/views.py
+++ b/addons/niirdccore/views.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from rest_framework import status as http_status
 from flask import request
+from django.db.models import Subquery
 import logging
 import requests
 
+from osf.models.node import Node
 from . import SHORT_NAME
 from . import settings
 from framework.exceptions import HTTPError
@@ -14,6 +16,9 @@ from website.project.decorators import (
 )
 from website.ember_osf_web.views import use_ember_app
 from addons.jupyterhub.apps import JupyterhubAddonAppConfig
+from addons.niirdccore.models import AddonList
+
+from addons import *
 from addons.jupyterhub.models import NodeSettings
 
 logger = logging.getLogger(__name__)
@@ -77,3 +82,42 @@ def niirdccore_get_dmp_info(**kwargs):
 @must_have_addon(SHORT_NAME, 'node')
 def project_niirdccore(**kwargs):
     return use_ember_app()
+
+@must_have_permission('admin')
+@must_have_addon(SHORT_NAME, 'node')
+def niirdccore_apply_dmp_subscribe(**kwargs):
+    node = kwargs['node']
+    addon = node.get_addon(SHORT_NAME)
+    addon_list = AddonList()
+
+    addon_list.set_node_id(node._id)
+    addon_list.set_dmp_id(addon.get_dmp_id())
+    addon_list.set_addon_id(kwargs['addon_id'])
+    addon_list.set_callback(kwargs['callback'])
+    addon_list.set_owner(node.get_addon(SHORT_NAME))
+
+    return
+
+def niirdccore_dmp_notification(**kwargs):
+
+    # コールバック関数を呼び出す関数
+    def _notification_handler(func, **kwargs):
+        return func(**kwargs)
+
+    # リクエストボディ取得
+    try:
+        dmp_record = request.json['dmp']
+        dmp_id = request.json['dmp']['redboxOid']
+    except KeyError:
+        raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
+
+    addon_list = AddonList.objects.filter(dmp_id=dmp_id)
+
+    for addon in addon_list:
+        # デコレータ対策のため、nodeも引数に含める
+        _notification_handler(
+            func=eval(addon.callback),
+            node=Node.objects.get(guids___id=addon.node_id),
+            dmp_record=dmp_record)
+
+    return


### PR DESCRIPTION
## Purpose

(6) 購読申請API、(7) DMP送信APIを実装

## Changes

addons/niirdccore/models.py
addons/niirdccore/routes.py
addons/niirdccore/views.py


