### PR TITLE
Fix syntax of ES for UglifyJS

### DIFF
--- a/addons/binderhub/static/node-cfg.js
+++ b/addons/binderhub/static/node-cfg.js
@@ -9,7 +9,7 @@ var ChangeMessageMixin = require('js/changeMessage');
 var SaveManager = require('js/saveManager');
 
 var SHORT_NAME = 'binderhub';
-var logPrefix = `[${SHORT_NAME}] `;
+var logPrefix = '[' + SHORT_NAME + '] ';
 
 
 function NodeSettings() {
@@ -46,5 +46,5 @@ function NodeSettings() {
 $.extend(NodeSettings.prototype, ChangeMessageMixin.prototype);
 
 var settings = new NodeSettings();
-osfHelpers.applyBindings(settings, `#${SHORT_NAME}Scope`);
+osfHelpers.applyBindings(settings, '#' + SHORT_NAME + 'Scope');
 settings.loadConfig();


### PR DESCRIPTION
## Purpose

ES6 Template Literalsで一部文字列を記述していたが、これがUglifyJSによってエラーとなる。

## Changes

* 文字列リテラルの記法を修正

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-26446