### PR TITLE
Fix routes of binderhub

### DIFF
--- a/addons/binderhub/routes.py
+++ b/addons/binderhub/routes.py
@@ -22,9 +22,12 @@ page_routes = {
         Rule([
             '/project/<pid>/{}/<serviceid>/authorize'.format(SHORT_NAME),
             '/project/<pid>/node/<nid>/{}/<serviceid>/authorize'.format(SHORT_NAME),
+            '/<pid>/{}/<serviceid>/authorize'.format(SHORT_NAME),
+            '/<pid>/node/<nid>/{}/<serviceid>/authorize'.format(SHORT_NAME),
         ], 'get', oauth.binderhub_oauth_authorize, json_renderer),
         Rule([
             '/project/{}/callback'.format(SHORT_NAME),
+            '/{}/callback'.format(SHORT_NAME),
         ], 'get', oauth.binderhub_oauth_callback, json_renderer),
     ]
 }

--- a/addons/binderhub/settings/defaults.py
+++ b/addons/binderhub/settings/defaults.py
@@ -3,9 +3,9 @@ DEFAULT_BINDER_URL = 'https://binder.cs.rcos.nii.ac.jp'
 BINDERHUB_OAUTH_CLIENT = dict(
     client_id='AAAA',
     client_secret='BBBB',
-    authorize_url='http://192.168.168.167:8585/api/oauth2/authorize',
-    token_url='http://192.168.168.167:8585/api/oauth2/token',
-    services_url='http://192.168.168.167:8585/api/services',
+    authorize_url='https://192.168.168.167:8585/api/oauth2/authorize',
+    token_url='https://192.168.168.167:8585/api/oauth2/token',
+    services_url='https://192.168.168.167:8585/api/services',
     scope=['identity'],
 )
 

--- a/addons/binderhub/tests/test_view.py
+++ b/addons/binderhub/tests/test_view.py
@@ -12,9 +12,23 @@ from .. import SHORT_NAME
 from .. import settings
 from .utils import BaseAddonTestCase
 from website.util import api_url_for
+from future.moves.urllib.parse import urlparse, parse_qs
 
 
 class TestViews(BaseAddonTestCase, OsfTestCase):
+
+    def test_binderhub_authorize(self):
+        url = self.project.api_url_for('{}_oauth_authorize'.format(SHORT_NAME),
+                                       serviceid='binderhub')
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, http_status.HTTP_302_FOUND)
+        url = res.headers['Location']
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert_equal(params['response_type'][0], 'code')
+        assert_equal(params['scope'][0], 'identity')
+        assert_equal(urlparse(params['redirect_uri'][0]).path, '/project/binderhub/callback')
 
     def test_empty_binder_url(self):
         self.node_settings.set_binder_url('')


### PR DESCRIPTION
## Purpose

BinderHubのroutesが機能しない状態であるため修正を実施しました。

BinderHub addonは webコンテナの /project 配下にBinderHub/JupyterHubとの通信用のendpointを置いていましたが、
Helmで配備された環境では、(RDM-osf.ioが持つdocker-compose(開発用)でデプロイできる環境とは異なり、)
https://osfio.web.server/project/some_path が https://osfio.web.server/some_path と自動的にForwardされるようでした。
そのため、 `/project/` がなくても動作するよう変更を行いました。

## Changes

* routesを変更
* endpointに関するテストを追加

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-23355
