### PR TITLE
Fix missing addons relationships

### DIFF
--- a/addons/binderhub/models.py
+++ b/addons/binderhub/models.py
@@ -35,3 +35,7 @@ class NodeSettings(BaseNodeSettings):
     def set_binder_url(self, binder_url):
         self.binder_url = binder_url
         self.save()
+
+    @property
+    def complete(self):
+        return True

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -297,7 +297,7 @@ VARNISH_SERVERS = osf_settings.VARNISH_SERVERS
 ESI_MEDIA_TYPES = osf_settings.ESI_MEDIA_TYPES
 
 ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive', 'swift', 'azureblobstorage', 'weko', 'iqbrims']
-ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'bitbucket', 'gitlab', 'mendeley', 'zotero', 'forward']
+ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'bitbucket', 'gitlab', 'mendeley', 'zotero', 'forward', 'binderhub']
 
 BYPASS_THROTTLE_TOKEN = 'test-token'
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -291,6 +291,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'view_only_links',
         'wiki_enabled',
         'wikis',
+        'addons',
     ]
 
     id = IDField(source='_id', read_only=True)
@@ -395,6 +396,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         related_view='nodes:node-storage-providers',
         related_view_kwargs={'node_id': '<_id>'},
     )
+
+    addons = HideIfRegistration(RelationshipField(
+        related_view='nodes:node-addons',
+        related_view_kwargs={'node_id': '<_id>'},
+    ))
 
     settings = RelationshipField(
         related_view='nodes:node-settings',

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -199,7 +199,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             'quota_threshold',
             'wiki_enabled']
         # fields that do not appear on registrations
-        non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'children', 'groups']
+        non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'children', 'groups', 'addons']
 
         for field in NodeSerializer._declared_fields:
             assert_in(field, RegistrationSerializer._declared_fields)


### PR DESCRIPTION
## Purpose

* RDM-ember-osf-webで、プロジェクト画面におけるアドオンタブの表示制御が行えるよう、 `addons` RelationshipをNode APIオブジェクトに追加する

## Changes

* Node APIオブジェクトに `addons` Relationshipがなかったので追加
  * RDM-ember-osf-webに以前からある `addons` プロパティ https://github.com/RCOSDP/RDM-ember-osf-web/blob/nii-mergework-202007/app/models/node.ts#L194 に対応したRelationship(RDM-ember-osf-webではこのプロパティは使われていなかったようで、問題なかったものと思われる)
* BinderHubアドオンが `addons` オブジェクト内に現れるよう、設定を修正

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

* GRDM-27224