### PR TITLE
Search normalized filenames when selecting updateURL.

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -752,10 +752,20 @@ function _fangornResolveUploadUrl(item, file) {
     if (configOption) {
         return configOption;
     }
+    var filenames = [file.name];
+    var filenameNFC = file.name.normalize('NFC');
+    var filenameNFD = file.name.normalize('NFD');
+    if (file.name != filenameNFC) filenames.push(filenameNFC);
+    if (file.name != filenameNFD) filenames.push(filenameNFD);
     var updateUrl;
-    $.each(item.children, function( index, value ) {
-        if (file.name === value.data.name) {
-            updateUrl = waterbutler.buildTreeBeardUpload(value);
+    $.each(filenames, function( i, filename ) {
+        $.each(item.children, function( index, value ) {
+            if (filename === value.data.name) {
+                updateUrl = waterbutler.buildTreeBeardUpload(value);
+                return false;
+            }
+        });
+        if (updateUrl) {
             return false;
         }
     });


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Windows - Mac 環境でラウンドトリップした際にファイル名のユニコード正規化方式の違いからファイルが更新ではなく新規作成されてしまう問題に対処する。

## Changes

ファイルが既存のものか検索する際にファイル名にユニコード正規化を施したものも検索対象とするようにした。

## QA Notes

## Documentation

## Side Effects

## Ticket

26855
