### PR TITLE
fix: invalid usage of Paginator.page.

### DIFF
--- a/admin/rdm_announcement/views.py
+++ b/admin/rdm_announcement/views.py
@@ -21,6 +21,7 @@ import facebook
 from urllib.parse import urlparse
 import tweepy
 import time
+import math
 
 class RdmAnnouncementPermissionMixin(RdmPermissionMixin):
     @property
@@ -240,10 +241,9 @@ class SendView(RdmAnnouncementPermissionMixin, UserPassesTestMixin, FormView):
             ret['is_success'] = False
             return ret
         try:
-            paginator = Paginator(users_query, EMAIL_USERS_CHUNK_SIZE)
-
-            for page in range(1, paginator.num_pages + 1):
-                to_list = paginator.page(page).values_list('username', flat=True)
+            max_page = math.ceil(users_query.count() / EMAIL_USERS_CHUNK_SIZE)
+            for page in range(0, max_page):
+                to_list = list(users_query[(page * EMAIL_USERS_CHUNK_SIZE):((page + 1) * EMAIL_USERS_CHUNK_SIZE)].values_list('username', flat=True))
                 email = EmailMessage(
                     subject=data['title'],
                     body=data['body'],
@@ -252,8 +252,8 @@ class SendView(RdmAnnouncementPermissionMixin, UserPassesTestMixin, FormView):
                     bcc=to_list
                 )
                 email.send(fail_silently=False)
-                if page < paginator.num_pages + 1:
-                    time.sleep(0.1)  # wait for send rate
+                if page < max_page - 1:
+                    time.sleep(0.2)  # wait for send rate
         except Exception as e:
             ret['is_success'] = False
             ret['error'] = 'Email error: ' + str(e)

--- a/admin/rdm_announcement/views.py
+++ b/admin/rdm_announcement/views.py
@@ -4,7 +4,6 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import render, redirect
 from django.views.generic import UpdateView, TemplateView, FormView
-from django.core.paginator import Paginator
 
 from admin.rdm.utils import RdmPermissionMixin
 from admin.rdm_announcement.forms import PreviewForm, SendForm, SettingsForm


### PR DESCRIPTION
## Purpose

Paginatorの扱いに問題があり期待する動作をしていない問題の対処

## Changes

Paginatorを利用せず、Queryオブジェクトに直接ページごとのレンジを指定する
