### PR TITLE
change MAX_UPLOAD_SIZE setting for some addons.

### DIFF
--- a/addons/azureblobstorage/apps.py
+++ b/addons/azureblobstorage/apps.py
@@ -1,5 +1,6 @@
 import os
 from addons.base.apps import BaseAddonAppConfig, generic_root_folder
+from addons.azureblobstorage.settings import MAX_UPLOAD_SIZE
 
 azureblobstorage_root_folder = generic_root_folder('azureblobstorage')
 
@@ -19,7 +20,7 @@ class AzureBlobStorageAddonAppConfig(BaseAddonAppConfig):
     configs = ['accounts', 'node']
     categories = ['storage']
     has_hgrid_files = True
-    max_file_size = 128  # MB
+    max_file_size = MAX_UPLOAD_SIZE
     node_settings_template = os.path.join(TEMPLATE_PATH, 'azureblobstorage_node_settings.mako')
     user_settings_template = os.path.join(TEMPLATE_PATH, 'azureblobstorage_user_settings.mako')
 

--- a/addons/azureblobstorage/settings/defaults.py
+++ b/addons/azureblobstorage/settings/defaults.py
@@ -1,0 +1,2 @@
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 5 * 1024

--- a/addons/box/settings/defaults.py
+++ b/addons/box/settings/defaults.py
@@ -11,4 +11,4 @@ BOX_OAUTH_AUTH_ENDPOINT = 'https://www.box.com/api/oauth2/authorize'
 BOX_OAUTH_REVOKE_ENDPOINT = 'https://api.box.com/oauth2/revoke'
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = 250
+MAX_UPLOAD_SIZE = 5 * 1024

--- a/addons/dropbox/settings/defaults.py
+++ b/addons/dropbox/settings/defaults.py
@@ -5,4 +5,4 @@ DROPBOX_SECRET = None
 DROPBOX_AUTH_CSRF_TOKEN = 'dropbox-auth-csrf-token'
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = 150
+MAX_UPLOAD_SIZE = 5 * 1024

--- a/addons/dropboxbusiness/settings/defaults.py
+++ b/addons/dropboxbusiness/settings/defaults.py
@@ -26,7 +26,7 @@ PROPERTY_SPLIT_DATA_CONF = {
 }
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = 150
+MAX_UPLOAD_SIZE = 5 * 1024
 
 EPPN_TO_EMAIL_MAP = {
     # e.g.

--- a/addons/nextcloud/settings/defaults.py
+++ b/addons/nextcloud/settings/defaults.py
@@ -2,4 +2,4 @@ DEFAULT_HOSTS = []
 USE_SSL = True
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = None
+MAX_UPLOAD_SIZE = 5 * 1024

--- a/addons/nextcloudinstitutions/settings/defaults.py
+++ b/addons/nextcloudinstitutions/settings/defaults.py
@@ -2,7 +2,7 @@ DEFAULT_HOSTS = []
 USE_SSL = True
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = None
+MAX_UPLOAD_SIZE = 5 * 1024
 
 DEFAULT_BASE_FOLDER = '/GRDM'
 

--- a/addons/ociinstitutions/settings/defaults.py
+++ b/addons/ociinstitutions/settings/defaults.py
@@ -1,7 +1,7 @@
 ENCRYPT_UPLOADS = True
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = None
+MAX_UPLOAD_SIZE = 5 * 1024
 
 DEFAULT_BASE_BUCKET = 'GRDM'
 

--- a/addons/owncloud/settings/defaults.py
+++ b/addons/owncloud/settings/defaults.py
@@ -2,4 +2,4 @@ DEFAULT_HOSTS = []
 USE_SSL = True
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = 512
+MAX_UPLOAD_SIZE = 5 * 1024

--- a/addons/s3compat/settings/defaults.py
+++ b/addons/s3compat/settings/defaults.py
@@ -9,7 +9,7 @@ STATIC_PATH = os.path.join(parent_dir(HERE), 'static')
 MAX_RENDER_SIZE = (1024 ** 2) * 3
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = 128
+MAX_UPLOAD_SIZE = 5 * 1024
 
 ALLOWED_ORIGIN = '*'
 

--- a/addons/s3compatb3/settings/defaults.py
+++ b/addons/s3compatb3/settings/defaults.py
@@ -9,7 +9,7 @@ STATIC_PATH = os.path.join(parent_dir(HERE), 'static')
 MAX_RENDER_SIZE = (1024 ** 2) * 3
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = 128
+MAX_UPLOAD_SIZE = 5 * 1024
 
 ALLOWED_ORIGIN = '*'
 

--- a/addons/s3compatinstitutions/settings/defaults.py
+++ b/addons/s3compatinstitutions/settings/defaults.py
@@ -1,7 +1,7 @@
 ENCRYPT_UPLOADS = True
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = None
+MAX_UPLOAD_SIZE = 5 * 1024
 
 DEFAULT_BASE_BUCKET = 'GRDM'
 

--- a/addons/swift/apps.py
+++ b/addons/swift/apps.py
@@ -1,5 +1,6 @@
 import os
 from addons.base.apps import BaseAddonAppConfig, generic_root_folder
+from addons.swift.settings import MAX_UPLOAD_SIZE
 
 swift_root_folder = generic_root_folder('swift')
 
@@ -19,7 +20,7 @@ class SwiftAddonAppConfig(BaseAddonAppConfig):
     configs = ['accounts', 'node']
     categories = ['storage']
     has_hgrid_files = True
-    max_file_size = 128  # MB
+    max_file_size = MAX_UPLOAD_SIZE
     node_settings_template = os.path.join(TEMPLATE_PATH, 'swift_node_settings.mako')
     user_settings_template = os.path.join(TEMPLATE_PATH, 'swift_user_settings.mako')
 

--- a/addons/swift/settings/defaults.py
+++ b/addons/swift/settings/defaults.py
@@ -1,2 +1,5 @@
 # Timeout using connection checking
 TEST_TIMEOUT = 30
+
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 5 * 1024


### PR DESCRIPTION
## Purpose

アドオンごとのアップロードファイルサイズ制限を5GBに統一する

## Changes

osf.ioリポジトリ配下の各アドオンに設定されたMAX_UPLOAD_SIZEの設定値を5x1024MBに変更する

