### PR TITLE
[GRDM-30449,GRDM-30758] IQB-RIMSアドオンのトークン更新処理・パーミッション修正

### DIFF
--- a/addons/iqbrims/client.py
+++ b/addons/iqbrims/client.py
@@ -16,13 +16,19 @@ _user_settings_cache = {}
 FILE_ENTRY_MARGIN = 3
 
 
+def _ensure_string(access_token):
+    if isinstance(access_token, bytes):
+        return access_token.decode('utf8')
+    return access_token
+
+
 class IQBRIMSAuthClient(BaseClient):
 
     def userinfo(self, access_token):
         return self._make_request(
             'GET',
             self._build_url(settings.API_BASE_URL, 'oauth2', 'v3', 'userinfo'),
-            params={'access_token': access_token},
+            params={'access_token': _ensure_string(access_token)},
             expects=(200, ),
             throws=HTTPError(401)
         ).json()
@@ -36,7 +42,8 @@ class IQBRIMSClient(BaseClient):
     @property
     def _default_headers(self):
         if self.access_token:
-            return {'authorization': 'Bearer {}'.format(self.access_token)}
+            access_token = _ensure_string(self.access_token)
+            return {'authorization': 'Bearer {}'.format(access_token)}
         return {}
 
     def about(self):
@@ -353,7 +360,8 @@ class SpreadsheetClient(BaseClient):
     @property
     def _default_headers(self):
         if self.access_token:
-            return {'authorization': 'Bearer {}'.format(self.access_token)}
+            access_token = _ensure_string(self.access_token)
+            return {'authorization': 'Bearer {}'.format(access_token)}
         return {}
 
     def sheets(self):

--- a/addons/iqbrims/views.py
+++ b/addons/iqbrims/views.py
@@ -136,7 +136,7 @@ def iqbrims_get_status(**kwargs):
                      'attributes': status}}
 
 @must_be_valid_project
-@must_have_permission('admin')
+@must_have_permission('write')
 @must_have_addon(SHORT_NAME, 'node')
 def iqbrims_set_status(**kwargs):
     node = kwargs['node'] or kwargs['project']


### PR DESCRIPTION
## Purpose

最新ブランチにおけるIQB-RIMSアドオンの問題: トークン更新処理・パーミッション修正 への対応

## Changes

GRDM-30758 に関連して、以下を修正しました。

- IQB-RIMSアドオン ステータス取得エンドポイント(/iqbrims/status)が1時間ごとに401エラーを返す問題の修正 ... ExternalAccountに格納されたaccess_tokenがbytesになる場合があるので修正
- IQB-RIMSアドオンでプロジェクト管理者しか投稿できない問題を修正 ... iqbrims_set_statusの権限を見直し

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-30449, GRDM-30758