### PR TITLE
[GRDM-31254] BinderHubアドオン名修正漏れ対応

### DIFF
--- a/addons/binderhub/static/user-cfg.js
+++ b/addons/binderhub/static/user-cfg.js
@@ -14,7 +14,7 @@ var logPrefix = '[' + SHORT_NAME + '] ';
 
 function UserSettings() {
   var self = this;
-  self.properName = 'BinderHub';
+  self.properName = 'GakuNin Federated Computing Services (Jupyter)';
   self.baseUrl = '/api/v1/settings/' + SHORT_NAME + '/';
 
   self.loading = ko.observable(false);


### PR DESCRIPTION

## Purpose

BinderHubアドオン名修正に漏れがあり、修正を実施。

## Changes

アカウントアドオン編集画面に対して、BinderHubアドオンの名称変更を反映。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-31254