### PR TITLE
IQB-RIMS addon Google Drive編集可能リンク表示修正

### DIFF
--- a/addons/iqbrims/client.py
+++ b/addons/iqbrims/client.py
@@ -152,7 +152,7 @@ class IQBRIMSClient(BaseClient):
                     'DELETE',
                     self._build_url(settings.API_BASE_URL, 'drive', 'v3', 'files',
                     file_id, 'permissions', p['id']),
-                    expects=(200, ),
+                    expects=(200, 204, 404, ),
                     throws=HTTPError(401)
                 )
         return permissions


### PR DESCRIPTION
## Purpose

IQB-RIMS addon Google Drive編集可能リンク表示修正

## Changes

IQB-RIMS addonに関して、アップロードフォームの他、Google Drive編集可能リンクを表示するように修正しました。
IQB-RIMSアップロードフォームではDefault Storageにファイルをアップロードしますが、waterbutlerのアップロードファイルサイズ制限があるため、補助的にGoogle Driveの編集可能リンクを表示し、大きなファイルのアップロードを可能にすることを目的としています。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

None (IQB-RIMSユーザからのリクエストに基づきます)
