### PR TITLE
[GRDM-31419, GRDM-32613, GRDM-32614, GRDM-32169] メタデータアドオンの修正

### DIFF
--- a/addons/metadata/report_format/report_en.csv.j2
+++ b/addons/metadata/report_format/report_en.csv.j2
@@ -1,10 +1,10 @@
 Funder,e-Rad project ID,Project name,Data No.,Title,Date (Issued / Updated),Description,Research field,Data type,File size,Data utilization and provision policy(Free/Consideration),Data utilization and provision policy(License),Data utilization and provision policy(citation information),Access rights,Repository information,Repository URL/ DOI link,Creator Name,Creator name identifier (e-Rad),Hosting institution,Data manager,Data manager identifier (e-Rad),Contact of data manager,Remarks
 {% for grdm_file in grdm_files -%}
-{{funder | quotecsv}},{{e_rad_project_id | quotecsv}},{{project_name_en | quotecsv}},{{grdm_file.data_number | quotecsv}},{{grdm_file.title_en | quotecsv}},{{grdm_file.date_issued_updated | quotecsv}},{{grdm_file.data_description_en | quotecsv}},
+{{funder_tooltip_1 | quotecsv}},{{e_rad_project_id | quotecsv}},{{project_name_en | quotecsv}},{{grdm_file.data_number | quotecsv}},{{grdm_file.title_en | quotecsv}},{{grdm_file.date_issued_updated | quotecsv}},{{grdm_file.data_description_en | quotecsv}},
     {%- if grdm_file.data_research_field == 'project' -%}
-        {{grdm_file.data_research_field | quotecsv}}
+        {{project_research_field_tooltip_1 | quotecsv}}
     {%- else -%}
-        {{grdm_file.project_research_field | quotecsv}}
+        {{grdm_file.data_research_field_tooltip_1 | quotecsv}}
     {%- endif -%}
-,{{grdm_file.data_type | quotecsv}},{{grdm_file.file_size | quotecsv}},{{grdm_file.data_policy_free | quotecsv}},{{grdm_file.data_policy_license | quotecsv}},{{grdm_file.data_policy_cite_en | quotecsv}},{{grdm_file.access_rights | quotecsv}},{{grdm_file.repo_information_en | quotecsv}},{{grdm_file.repo_url_doi_link | quotecsv}},{{grdm_file.creators | map(attribute="name_en") | join(";") | quotecsv}},{{grdm_file.creators | map(attribute="number") | join(";") | quotecsv}},{{grdm_file.hosting_inst_en | quotecsv}},{{grdm_file.data_man_name_en | quotecsv}},{{grdm_file.data_man_number | quotecsv}},{{grdm_file.data_man_tel | quotecsv}},{{grdm_file.remarks_en | quotecsv}}
+,{{grdm_file.data_type_tooltip_1 | quotecsv}},{{grdm_file.file_size | quotecsv}},{{grdm_file.data_policy_free_tooltip_1 | quotecsv}},{{grdm_file.data_policy_license | quotecsv}},{{grdm_file.data_policy_cite_en | quotecsv}},{{grdm_file.access_rights_tooltip_1 | quotecsv}},{{grdm_file.repo_information_en | quotecsv}},{{grdm_file.repo_url_doi_link | quotecsv}},{{grdm_file.creators | map(attribute="name_en") | join(";") | quotecsv}},{{grdm_file.creators | map(attribute="number") | join(";") | quotecsv}},{{grdm_file.hosting_inst_en | quotecsv}},{{grdm_file.data_man_name_en | quotecsv}},{{grdm_file.data_man_number | quotecsv}},{{grdm_file.data_man_tel | quotecsv}},{{grdm_file.remarks_en | quotecsv}}
 {% endfor %}

--- a/addons/metadata/report_format/report_ja.csv.j2
+++ b/addons/metadata/report_format/report_ja.csv.j2
@@ -1,10 +1,10 @@
 資金配分機関情報,e-Radの課題番号,プロジェクト名,データNo.,データの名称,掲載日・掲載更新日,データの説明,データの分野,データ種別,概略データ量,管理対象データの利活用・提供方針 (有償/無償),管理対象データの利活用・提供方針(ライセンス),管理対象データの利活用・提供方針(引用方法等),アクセス権,リポジトリ情報,リポジトリURL・DOIリンク,データ作成者,データ作成者の研究者番号,データ管理組織,データ管理者,データ管理者の研究者番号,データ管理者の連絡先,備考
 {% for grdm_file in grdm_files -%}
-{{funder | quotecsv}},{{e_rad_project_id | quotecsv}},{{project_name_ja | quotecsv}},{{grdm_file.data_number | quotecsv}},{{grdm_file.title_ja | quotecsv}},{{grdm_file.date_issued_updated | quotecsv}},{{grdm_file.data_description_ja | quotecsv}},
+{{funder_tooltip_0 | quotecsv}},{{e_rad_project_id | quotecsv}},{{project_name_ja | quotecsv}},{{grdm_file.data_number | quotecsv}},{{grdm_file.title_ja | quotecsv}},{{grdm_file.date_issued_updated | quotecsv}},{{grdm_file.data_description_ja | quotecsv}},
     {%- if grdm_file.data_research_field == 'project' -%}
-        {{grdm_file.data_research_field | quotecsv}}
+        {{project_research_field_tooltip_0 | quotecsv}}
     {%- else -%}
-        {{grdm_file.project_research_field | quotecsv}}
+        {{grdm_file.data_research_field_tooltip_0 | quotecsv}}
     {%- endif -%}
-,{{grdm_file.data_type | quotecsv}},{{grdm_file.file_size | quotecsv}},{{grdm_file.data_policy_free | quotecsv}},{{grdm_file.data_policy_license | quotecsv}},{{grdm_file.data_policy_cite_ja | quotecsv}},{{grdm_file.access_rights | quotecsv}},{{grdm_file.repo_information_ja | quotecsv}},{{grdm_file.repo_url_doi_link | quotecsv}},{{grdm_file.creators | map(attribute="name_ja") | join(";") | quotecsv}},{{grdm_file.creators | map(attribute="number") | join(";") | quotecsv}},{{grdm_file.hosting_inst_ja | quotecsv}},{{grdm_file.data_man_name_ja | quotecsv}},{{grdm_file.data_man_number | quotecsv}},{{grdm_file.data_man_tel | quotecsv}},{{grdm_file.remarks_ja | quotecsv}}
+,{{grdm_file.data_type_tooltip_0 | quotecsv}},{{grdm_file.file_size | quotecsv}},{{grdm_file.data_policy_free_tooltip_0 | quotecsv}},{{grdm_file.data_policy_license | quotecsv}},{{grdm_file.data_policy_cite_ja | quotecsv}},{{grdm_file.access_rights_tooltip_0 | quotecsv}},{{grdm_file.repo_information_ja | quotecsv}},{{grdm_file.repo_url_doi_link | quotecsv}},{{grdm_file.creators | map(attribute="name_ja") | join(";") | quotecsv}},{{grdm_file.creators | map(attribute="number") | join(";") | quotecsv}},{{grdm_file.hosting_inst_ja | quotecsv}},{{grdm_file.data_man_name_ja | quotecsv}},{{grdm_file.data_man_number | quotecsv}},{{grdm_file.data_man_tel | quotecsv}},{{grdm_file.remarks_ja | quotecsv}}
 {% endfor %}

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -215,14 +215,21 @@ function MetadataButtons() {
     if (!self.lastFields) {
       return;
     }
+    const fieldSetsAndValues = [];
     self.lastFields.forEach(function(fieldSet) {
       const value = fieldSet.field.getValue(fieldSet.input);
+      fieldSetsAndValues.push({ fieldSet: fieldSet, value: value });
+    });
+    fieldSetsAndValues.forEach(function(fieldSetAndValue) {
+      const fieldSet = fieldSetAndValue.fieldSet;
+      const value = fieldSetAndValue.value;
       var error = null;
       try {
         metadataFields.validateField(
           self.erad,
           fieldSet.question,
-          value
+          value,
+          fieldSetsAndValues
         );
       } catch(e) {
         error = e.message;
@@ -890,34 +897,44 @@ function MetadataButtons() {
     container.empty();
     var errors = 0;
     self.lastFields = [];
+    const fieldSetsAndValues = [];
     fields.forEach(function(fieldSet) {
       const errorContainer = $('<div></div>')
         .css('color', 'red').hide();
       const input = fieldSet.field.addElementTo(container, errorContainer);
       const value = fieldSet.field.getValue(input);
+      fieldSetsAndValues.push({
+        fieldSet: {
+          field: fieldSet.field,
+          question: fieldSet.question,
+          input: input,
+          lastError: null,
+          errorContainer: errorContainer
+        },
+        value: value
+      });
+    });
+    fieldSetsAndValues.forEach(function(fieldSetAndValue) {
+      const fieldSet = fieldSetAndValue.fieldSet;
+      const value = fieldSetAndValue.value;
       var error = null;
       try {
         metadataFields.validateField(
           self.erad,
           fieldSet.question,
-          value
+          value,
+          fieldSetsAndValues
         );
       } catch(e) {
         error = e.message;
       }
       if (error) {
-        errorContainer.text(error).show()
+        fieldSet.errorContainer.text(error).show()
         errors ++;
       } else {
-        errorContainer.hide().text('')
+        fieldSet.errorContainer.hide().text('')
       }
-      self.lastFields.push({
-        field: fieldSet.field,
-        question: fieldSet.question,
-        input: input,
-        lastError: error,
-        errorContainer: errorContainer
-      });
+      self.lastFields.push(fieldSet);
     });
     const message = $('<div></div>');
     if (errors) {

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -316,7 +316,7 @@ function MetadataButtons() {
   }
 
   self.createSchemaSelector = function(targetItem) {
-    const label = $('<label></label>').text(_('Data Schema:'));
+    const label = $('<label></label>').text(_('Metadata Schema:'));
     const schema = $('<select></select>');
     const activeSchemas = (self.registrationSchemas.schemas || [])
       .filter(function(s) {
@@ -837,7 +837,7 @@ function MetadataButtons() {
     });
     if (empty) {
       registrations.append($('<li></li>')
-        .append($('<span></span>').text(_('There is no draft metadata compliant with the schema. Create new draft metadata from the Metadata tab:')))
+        .append($('<span></span>').text(_('There is no draft project metadata compliant with the schema. Create new draft project metadata from the Metadata tab:')))
         .append($('<a></a>')
           .text(_('Open'))
           .attr('href', contextVars.node.urls.web + 'metadata'))
@@ -976,7 +976,7 @@ function MetadataButtons() {
       .attr('disabled', true)
       .attr('data-dismiss', false);
     const message = $('<div></div>');
-    message.text(_('Select the destination draft for the file metadata.'));
+    message.text(_('Select the destination for the file metadata.'));
     self.selectDraftDialog.container.empty();
     self.selectDraftDialog.container.append(selector.group);
     self.selectDraftDialog.container.append(message);
@@ -1530,7 +1530,7 @@ function MetadataButtons() {
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')
           .append($('<div class="modal-header"></div>')
-            .append($('<h3></h3>').text(editable ? _('Edit Metadata') : _('View Metadata'))))
+            .append($('<h3></h3>').text(editable ? _('Edit File Metadata') : _('View File Metadata'))))
           .append($('<form></form>')
             .append($('<div class="modal-body"></div>')
               .append($('<div class="row"></div>')
@@ -1566,7 +1566,7 @@ function MetadataButtons() {
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')
           .append($('<div class="modal-header"></div>')
-            .append($('<h3></h3>').text(_('Delete Metadata'))))
+            .append($('<h3></h3>').text(_('Delete File Metadata'))))
           .append($('<form></form>')
             .append($('<div class="modal-body"></div>')
               .append($('<div class="row"></div>')
@@ -1588,7 +1588,7 @@ function MetadataButtons() {
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')
           .append($('<div class="modal-header"></div>')
-            .append($('<h3></h3>').text(_('Select draft registration'))))
+            .append($('<h3></h3>').text(_('Select a destination for file metadata registration'))))
           .append($('<form></form>')
             .append($('<div class="modal-body"></div>')
               .append($('<div class="row"></div>')
@@ -1620,7 +1620,7 @@ function MetadataButtons() {
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')
           .append($('<div class="modal-header"></div>')
-            .append($('<h3></h3>').text(_('Resolve metadata'))))
+            .append($('<h3></h3>').text(_('Fix file metadata'))))
           .append($('<form></form>')
             .append($('<div class="modal-body"></div>')
               .append($('<div class="row"></div>')

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -1526,7 +1526,7 @@ function MetadataButtons() {
         .css('color', 'red')
         .text(_('Renaming, moving the file/directory, or changing the directory hierarchy can break the association of the metadata you have added.'));
     }
-    const dialog = $('<div class="modal fade"></div>')
+    const dialog = $('<div class="modal fade" data-backdrop="static"></div>')
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')
           .append($('<div class="modal-header"></div>')
@@ -1548,6 +1548,11 @@ function MetadataButtons() {
               .append(notice)
               .append(close)
               .append(save)))));
+    $(window).on('beforeunload', function() {
+      if ($(dialog).data('bs.modal').isShown) {
+        return _('You have unsaved changes.');
+      }
+    });
     dialog.appendTo($('#treeGrid'));
     return {
       dialog: dialog,

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -34,7 +34,10 @@ function createField(erad, question, valueEntry, options, callback) {
   throw new Error('Unsupported type: ' + question.type);
 }
 
-function validateField(erad, question, value) {
+function validateField(erad, question, value, fieldSetAndValues) {
+  if (question.qid == 'grdm-file:available-date') {
+    return validateAvailableDateField(erad, question, value, fieldSetAndValues);
+  }
   if (!value) {
     if (question.required) {
       throw new Error(_("This field can't be blank."))
@@ -173,6 +176,17 @@ function validateStringField(erad, question, value) {
 }
 
 function validateChooseField(erad, question, value) {
+}
+
+function validateAvailableDateField(erad, question, value, fieldSetAndValues) {
+  const accessRightsPair = fieldSetAndValues.find(function(fieldSetAndValue) {
+    return fieldSetAndValue.fieldSet.question.qid === 'grdm-file:access-rights';
+  })
+  if (!accessRightsPair) return;
+  const requiredDateAccessRights = ['embargoed access'];
+  if (requiredDateAccessRights.includes(accessRightsPair.value) && !value) {
+    throw new Error(_("This field can't be blank."));
+  }
 }
 
 function createChooser(options) {

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -185,6 +185,9 @@ function createChooser(options) {
       return;
     }
     const optElem = $('<option></option>').attr('value', opt.text).text(getLocalizedText(opt.tooltip));
+    if (opt.default) {
+      optElem.attr('selected', true);
+    }
     select.append(optElem);
   });
   return select;

--- a/addons/metadata/tests/test_utils.py
+++ b/addons/metadata/tests/test_utils.py
@@ -52,3 +52,40 @@ class TestMakeReportAsCsv(OsfTestCase):
         filename, result = make_report_as_csv(format, data, schema)
         assert_equal(filename, 'report.csv')
         assert_equal(result, '"TEST,DATA"')
+
+    def test_choose_tooltip(self):
+        format = RegistrationReportFormat.objects.create(
+            csv_template='{{example}},{{example_tooltip}},{{example_tooltip_0}},{{example_tooltip_1}},{{example_tooltip_2}},{{example_tooltip_3}}',
+        )
+        data = {
+            'example': {
+                'value': '2',
+            }
+        }
+        schema = {'pages': [
+            {
+                'questions': [
+                    {
+                        'qid': 'example',
+                        'type': 'choose',
+                        'options': [
+                            {
+                                'text': '1',
+                                'tooltip': '一|one',
+                            },
+                            {
+                                'text': '2',
+                                'tooltip': '二|two',
+                            },
+                            {
+                                'text': '3',
+                                'tooltip': '三|three',
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]}
+        filename, result = make_report_as_csv(format, data, schema)
+        assert_equal(filename, 'report.csv')
+        assert_equal(result, '2,二|two,二,two,,')

--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -41,6 +41,7 @@ class RegistrationSchemaBlockSerializer(JSONAPISerializer):
     help_text = ser.CharField(read_only=True)
     example_text = ser.CharField(read_only=True)
     required = ser.BooleanField(read_only=True)
+    default = ser.BooleanField(read_only=True)
     index = ser.IntegerField(read_only=True, source='_order')
 
     links = LinksField({

--- a/osf/migrations/0222_add_default_to_registration_schema_block.py
+++ b/osf/migrations/0222_add_default_to_registration_schema_block.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0221_ensure_schema_and_reports'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='registrationschemablock',
+            name='default',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/osf/migrations/0223_ensure_schema_and_reports.py
+++ b/osf/migrations/0223_ensure_schema_and_reports.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
+
+
+def ensure_registration_reports(*args):
+    from api.base import settings
+    from addons.metadata import FULL_NAME
+    from addons.metadata.utils import ensure_registration_report
+    from addons.metadata.report_format import REPORT_FORMATS
+    if FULL_NAME not in settings.INSTALLED_APPS:
+        return
+    for schema_name, report_name, csv_template in REPORT_FORMATS:
+        ensure_registration_report(schema_name, report_name, csv_template)
+
+def noop(*args):
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0222_add_default_to_registration_schema_block'),
+    ]
+
+    operations = [
+        UpdateRegistrationSchemasAndSchemaBlocks(),
+        migrations.RunPython(ensure_registration_reports, noop),
+    ]

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -189,6 +189,7 @@ class RegistrationSchemaBlock(ObjectIDMixin, BaseModel):
     block_type = models.CharField(max_length=31, db_index=True, choices=SCHEMABLOCK_TYPES)
     display_text = models.TextField()
     required = models.BooleanField(default=False)
+    default = models.BooleanField(default=False)
 
     @property
     def absolute_api_v2_url(self):

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -133,7 +133,7 @@
           "title": "データ No.|Data No.",
           "type": "string",
           "format": "text",
-          "required": true
+          "required": false
         },
         {
           "qid": "grdm-file:title-ja",
@@ -157,7 +157,7 @@
           "title": "掲載日・掲載更新日|Date (Issued / Updated)",
           "type": "string",
           "format": "date",
-          "required": true
+          "required": false
         },
         {
           "qid": "grdm-file:data-description-ja",
@@ -184,7 +184,8 @@
           "options": [
               {
                 "text": "project",
-                "tooltip": "プロジェクトに指定された分野|The field specified for the project"
+                "tooltip": "プロジェクトの研究分野|Research field of the project",
+                "default": true
               },
               {
                 "text": "189",
@@ -242,7 +243,8 @@
           "options": [
               {
                 "text": "dataset",
-                "tooltip": "データセット|dataset"
+                "tooltip": "データセット|dataset",
+                "default": true
               },
               {
                   "text": "conference paper",
@@ -521,7 +523,7 @@
           "title": "リポジトリ情報 (日本語)|Repository information (Japanese)",
           "type": "string",
           "format": "text",
-          "required": true
+          "required": false
         },
         {
           "qid": "grdm-file:repo-information-en",
@@ -529,7 +531,7 @@
           "title": "Repository information (English)",
           "type": "string",
           "format": "text",
-          "required": true
+          "required": false
         },
         {
           "qid": "grdm-file:repo-url-doi-link",

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -29,7 +29,7 @@
             },
             {
               "text": "BRAIN",
-              "tooltip": "国立研究開発法人農業・食品産業技術総合研究機構|National Agriculture and Food Research Organization|1205"
+              "tooltip": "生物系特定産業技術研究支援センター|Bio-oriented Technology Research Advancement Institution|1205"
             }
           ],
           "required": true

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -6,7 +6,7 @@
     {
       "id": "page1",
       "title": "メタデータ登録|Metadata Registration",
-      "description": "ムーンショット型研究開発制度における研究プロジェクトの成果報告用のメタデータ入力画面です。GakuNin RDMをお使いの方は、登録することで資金配分機関へデータ提出するフォーマットでダウンロードできます。",
+      "description": "ムーンショット型研究開発制度における研究プロジェクトの成果報告用のメタデータ入力画面です。GakuNin RDMをお使いの方は、登録することで資金配分機関へデータ提出するフォーマットでダウンロードできます。|This is the metadata input form for reporting the progress of a research project in the Moonshot R&D Program. You may download the file in the format that can be submitted to the funding agencies by registering this form.",
       "questions": [
         {
           "qid": "funder",
@@ -117,7 +117,7 @@
     {
       "id": "page2",
       "title": "登録データ|Registered Data",
-      "description": "ムーンショット型研究開発制度における研究プロジェクトの成果報告用のメタデータ入力画面です。GakuNin RDMをお使いの方は、登録することで資金配分機関へデータ提出するフォーマットでダウンロードできます。",
+      "description": "ムーンショット型研究開発制度における研究プロジェクトの成果報告用のメタデータ入力画面です。GakuNin RDMをお使いの方は、登録することで資金配分機関へデータ提出するフォーマットでダウンロードできます。|This is the metadata input form for reporting the progress of a research project in the Moonshot R&D Program. You may download the file in the format that can be submitted to the funding agencies by registering this form.",
       "questions": [
         {
           "qid": "grdm-files",

--- a/website/translations/en/LC_MESSAGES/js_messages.po
+++ b/website/translations/en/LC_MESSAGES/js_messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.6.0\n"
 "Report-Msgid-Bugs-To: rocs-office@nii.ac.jp\n"
-"POT-Creation-Date: 2022-04-12 12:37+0000\n"
+"POT-Creation-Date: 2022-07-15 01:31+0000\n"
 "PO-Revision-Date: 2020-11-16 20:17+0900\n"
 "Last-Translator: Hiroki Ohashi\n"
 "Language: en\n"
@@ -22,94 +22,94 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: addons/metadata/static/files.js:312
-msgid "Data Schema:"
+#: addons/metadata/static/files.js:319
+msgid "Metadata Schema:"
 msgstr ""
 
-#: addons/metadata/static/files.js:470
+#: addons/metadata/static/files.js:477
 msgid "Paste from Clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:495 addons/metadata/static/files.js:509
+#: addons/metadata/static/files.js:502 addons/metadata/static/files.js:516
 #: website/static/js/fangorn.js:1516
 msgid "Could not copy text"
 msgstr ""
 
-#: addons/metadata/static/files.js:507 website/static/js/clipboard.js:27
+#: addons/metadata/static/files.js:514 website/static/js/clipboard.js:27
 #: website/static/js/fangorn.js:1510 website/static/js/fangorn.js:1514
 msgid "Copied!"
 msgstr ""
 
-#: addons/metadata/static/files.js:524 addons/metadata/static/files.js:537
-#: addons/metadata/static/files.js:544
+#: addons/metadata/static/files.js:531 addons/metadata/static/files.js:544
+#: addons/metadata/static/files.js:551
 msgid "Could not paste text"
 msgstr ""
 
-#: addons/metadata/static/files.js:594 addons/metadata/static/files.js:608
-#: addons/metadata/static/files.js:942
+#: addons/metadata/static/files.js:601 addons/metadata/static/files.js:615
+#: addons/metadata/static/files.js:964
 msgid "Loading..."
 msgstr ""
 
-#: addons/metadata/static/files.js:606
+#: addons/metadata/static/files.js:613
 msgid "Select the destination of the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:611
+#: addons/metadata/static/files.js:618
 msgid "Current Metadata:"
 msgstr ""
 
-#: addons/metadata/static/files.js:667
+#: addons/metadata/static/files.js:674
 msgid "Delete metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:670
+#: addons/metadata/static/files.js:677
 msgid "Could not list hashes"
 msgstr ""
 
-#: addons/metadata/static/files.js:678
-#: addons/metadata/static/metadata-fields.js:326
-#: addons/metadata/static/metadata-fields.js:331
+#: addons/metadata/static/files.js:685
+#: addons/metadata/static/metadata-fields.js:343
+#: addons/metadata/static/metadata-fields.js:348
 msgid "Could not list files"
 msgstr ""
 
-#: addons/metadata/static/files.js:761 addons/metadata/static/files.js:768
+#: addons/metadata/static/files.js:773 addons/metadata/static/files.js:780
 msgid "No name"
 msgstr ""
 
-#: addons/metadata/static/files.js:828
+#: addons/metadata/static/files.js:840
 msgid ""
-"There is no draft metadata compliant with the schema. Create new draft "
-"metadata from the Metadata tab:"
+"There is no draft project metadata compliant with the schema. Create new "
+"draft project metadata from the Metadata tab:"
 msgstr ""
 
-#: addons/metadata/static/files.js:830 addons/metadata/static/files.js:986
+#: addons/metadata/static/files.js:842 addons/metadata/static/files.js:1008
 msgid "Open"
 msgstr ""
 
-#: addons/metadata/static/files.js:919
+#: addons/metadata/static/files.js:941
 msgid "There are errors in some fields."
 msgstr ""
 
-#: addons/metadata/static/files.js:953 addons/metadata/static/files.js:1535
-#: addons/metadata/static/files.js:1560 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:975 addons/metadata/static/files.js:1584
+#: addons/metadata/static/files.js:1609 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr ""
 
-#: addons/metadata/static/files.js:957
-msgid "Select the destination draft for the file metadata."
+#: addons/metadata/static/files.js:979
+msgid "Select the destination for the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:978
+#: addons/metadata/static/files.js:1000
 msgid "Registering..."
 msgstr ""
 
-#: addons/metadata/static/files.js:978
+#: addons/metadata/static/files.js:1000
 msgid "Deleting..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1018 addons/metadata/static/files.js:1456
-#: addons/metadata/static/files.js:1512 addons/metadata/static/files.js:1533
-#: addons/metadata/static/files.js:1558
+#: addons/metadata/static/files.js:1040 addons/metadata/static/files.js:1505
+#: addons/metadata/static/files.js:1561 addons/metadata/static/files.js:1582
+#: addons/metadata/static/files.js:1607
 #: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
@@ -117,101 +117,114 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: addons/metadata/static/files.js:1070 addons/metadata/static/files.js:1484
+#: addons/metadata/static/files.js:1092
 msgid "View Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1080 addons/metadata/static/files.js:1484
+#: addons/metadata/static/files.js:1102
 msgid "Edit Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1089
+#: addons/metadata/static/files.js:1111
 msgid "Register Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1097 addons/metadata/static/files.js:1520
+#: addons/metadata/static/files.js:1119
 msgid "Delete Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1234
+#: addons/metadata/static/files.js:1256
 msgid "Metadata is defined"
 msgstr ""
 
-#: addons/metadata/static/files.js:1243
+#: addons/metadata/static/files.js:1265
 msgid "Some of the children have metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1253
+#: addons/metadata/static/files.js:1275
 msgid "File not found: "
 msgstr ""
 
-#: addons/metadata/static/files.js:1460 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1509 website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr ""
 
-#: addons/metadata/static/files.js:1465 addons/metadata/static/files.js:1564
+#: addons/metadata/static/files.js:1514 addons/metadata/static/files.js:1613
 msgid "Copy to clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:1478
+#: addons/metadata/static/files.js:1527
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr ""
 
-#: addons/metadata/static/files.js:1514 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1533
+msgid "Edit File Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1533
+msgid "View File Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1563 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr ""
 
-#: addons/metadata/static/files.js:1525
-msgid "Do you want to delete metadata? This operation cannot be undone."
-msgstr ""
-
-#: addons/metadata/static/files.js:1542
-msgid "Select draft registration"
+#: addons/metadata/static/files.js:1569
+msgid "Delete File Metadata"
 msgstr ""
 
 #: addons/metadata/static/files.js:1574
-msgid "Resolve metadata"
+msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:40
+#: addons/metadata/static/files.js:1591
+msgid "Select a destination for file metadata registration"
+msgstr ""
+
+#: addons/metadata/static/files.js:1623
+msgid "Fix file metadata"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:43
+#: addons/metadata/static/metadata-fields.js:188
 msgid "This field can't be blank."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:180
+#: addons/metadata/static/metadata-fields.js:194
 msgid "Choose..."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:354
+#: addons/metadata/static/metadata-fields.js:371
 msgid "Calculate"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:405
+#: addons/metadata/static/metadata-fields.js:422
 msgid "Fill"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:432
+#: addons/metadata/static/metadata-fields.js:449
 msgid "No members"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:499
+#: addons/metadata/static/metadata-fields.js:516
 msgid "e-Rad Researcher Number"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:500
+#: addons/metadata/static/metadata-fields.js:517
 msgid "Name (Japanese)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:501
+#: addons/metadata/static/metadata-fields.js:518
 msgid "Name (English)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:515
+#: addons/metadata/static/metadata-fields.js:532
 #: website/static/js/myProjects.js:1565
 msgid "Add"
 msgstr ""

--- a/website/translations/ja/LC_MESSAGES/js_messages.po
+++ b/website/translations/ja/LC_MESSAGES/js_messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.6.0\n"
 "Report-Msgid-Bugs-To: rocs-office@nii.ac.jp\n"
-"POT-Creation-Date: 2022-04-12 12:37+0000\n"
+"POT-Creation-Date: 2022-07-15 01:31+0000\n"
 "PO-Revision-Date: 2020-11-23 09:30+0900\n"
 "Last-Translator: Hidetoshi Yoshimoto\n"
 "Language: ja\n"
@@ -22,94 +22,94 @@ msgstr ""
 msgid "Launch"
 msgstr "起動"
 
-#: addons/metadata/static/files.js:312
-msgid "Data Schema:"
-msgstr "データスキーマ:"
+#: addons/metadata/static/files.js:319
+msgid "Metadata Schema:"
+msgstr "メタデータ様式:"
 
-#: addons/metadata/static/files.js:470
+#: addons/metadata/static/files.js:477
 msgid "Paste from Clipboard"
 msgstr "クリップボードから貼り付け"
 
-#: addons/metadata/static/files.js:495 addons/metadata/static/files.js:509
+#: addons/metadata/static/files.js:502 addons/metadata/static/files.js:516
 #: website/static/js/fangorn.js:1516
 msgid "Could not copy text"
 msgstr "テキストをコピーできませんでした"
 
-#: addons/metadata/static/files.js:507 website/static/js/clipboard.js:27
+#: addons/metadata/static/files.js:514 website/static/js/clipboard.js:27
 #: website/static/js/fangorn.js:1510 website/static/js/fangorn.js:1514
 msgid "Copied!"
 msgstr "コピーされました！"
 
-#: addons/metadata/static/files.js:524 addons/metadata/static/files.js:537
-#: addons/metadata/static/files.js:544
+#: addons/metadata/static/files.js:531 addons/metadata/static/files.js:544
+#: addons/metadata/static/files.js:551
 msgid "Could not paste text"
 msgstr "テキストを貼り付けできませんでした"
 
-#: addons/metadata/static/files.js:594 addons/metadata/static/files.js:608
-#: addons/metadata/static/files.js:942
+#: addons/metadata/static/files.js:601 addons/metadata/static/files.js:615
+#: addons/metadata/static/files.js:964
 msgid "Loading..."
 msgstr "読み込み中..."
 
-#: addons/metadata/static/files.js:606
+#: addons/metadata/static/files.js:613
 msgid "Select the destination of the file metadata."
 msgstr "ファイルメタデータの移動先を選択してください。"
 
-#: addons/metadata/static/files.js:611
+#: addons/metadata/static/files.js:618
 msgid "Current Metadata:"
 msgstr "現在のメタデータ:"
 
-#: addons/metadata/static/files.js:667
+#: addons/metadata/static/files.js:674
 msgid "Delete metadata"
 msgstr "メタデータを削除"
 
-#: addons/metadata/static/files.js:670
+#: addons/metadata/static/files.js:677
 msgid "Could not list hashes"
 msgstr "ハッシュ情報の一覧を取得できませんでした"
 
-#: addons/metadata/static/files.js:678
-#: addons/metadata/static/metadata-fields.js:326
-#: addons/metadata/static/metadata-fields.js:331
+#: addons/metadata/static/files.js:685
+#: addons/metadata/static/metadata-fields.js:343
+#: addons/metadata/static/metadata-fields.js:348
 msgid "Could not list files"
 msgstr "ファイルの一覧を取得できませんでした"
 
-#: addons/metadata/static/files.js:761 addons/metadata/static/files.js:768
+#: addons/metadata/static/files.js:773 addons/metadata/static/files.js:780
 msgid "No name"
 msgstr "名称未設定"
 
-#: addons/metadata/static/files.js:828
+#: addons/metadata/static/files.js:840
 msgid ""
-"There is no draft metadata compliant with the schema. Create new draft "
-"metadata from the Metadata tab:"
-msgstr "スキーマに対応するメタデータがありません。メタデータ タブから新規メタデータを作成してください:"
+"There is no draft project metadata compliant with the schema. Create new "
+"draft project metadata from the Metadata tab:"
+msgstr "スキーマに対応するプロジェクトメタデータの下書きがありません。メタデータ タブから新規プロジェクトメタデータを作成してください:"
 
-#: addons/metadata/static/files.js:830 addons/metadata/static/files.js:986
+#: addons/metadata/static/files.js:842 addons/metadata/static/files.js:1008
 msgid "Open"
 msgstr "開く"
 
-#: addons/metadata/static/files.js:919
+#: addons/metadata/static/files.js:941
 msgid "There are errors in some fields."
 msgstr "いくつかのフィールドにエラーがあります。"
 
-#: addons/metadata/static/files.js:953 addons/metadata/static/files.js:1535
-#: addons/metadata/static/files.js:1560 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:975 addons/metadata/static/files.js:1584
+#: addons/metadata/static/files.js:1609 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr "選択"
 
-#: addons/metadata/static/files.js:957
-msgid "Select the destination draft for the file metadata."
-msgstr "ファイルメタデータの送信先を選択してください。"
+#: addons/metadata/static/files.js:979
+msgid "Select the destination for the file metadata."
+msgstr "ファイルメタデータの登録先を選択してください。"
 
-#: addons/metadata/static/files.js:978
+#: addons/metadata/static/files.js:1000
 msgid "Registering..."
 msgstr "登録中..."
 
-#: addons/metadata/static/files.js:978
+#: addons/metadata/static/files.js:1000
 msgid "Deleting..."
 msgstr "削除中..."
 
-#: addons/metadata/static/files.js:1018 addons/metadata/static/files.js:1456
-#: addons/metadata/static/files.js:1512 addons/metadata/static/files.js:1533
-#: addons/metadata/static/files.js:1558
+#: addons/metadata/static/files.js:1040 addons/metadata/static/files.js:1505
+#: addons/metadata/static/files.js:1561 addons/metadata/static/files.js:1582
+#: addons/metadata/static/files.js:1607
 #: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
@@ -117,101 +117,114 @@ msgstr "削除中..."
 msgid "Close"
 msgstr "閉じる"
 
-#: addons/metadata/static/files.js:1070 addons/metadata/static/files.js:1484
+#: addons/metadata/static/files.js:1092
 msgid "View Metadata"
 msgstr "メタデータ確認"
 
-#: addons/metadata/static/files.js:1080 addons/metadata/static/files.js:1484
+#: addons/metadata/static/files.js:1102
 msgid "Edit Metadata"
 msgstr "メタデータ編集"
 
-#: addons/metadata/static/files.js:1089
+#: addons/metadata/static/files.js:1111
 msgid "Register Metadata"
 msgstr "メタデータ登録"
 
-#: addons/metadata/static/files.js:1097 addons/metadata/static/files.js:1520
+#: addons/metadata/static/files.js:1119
 msgid "Delete Metadata"
 msgstr "メタデータ削除"
 
-#: addons/metadata/static/files.js:1234
+#: addons/metadata/static/files.js:1256
 msgid "Metadata is defined"
 msgstr "メタデータが定義されています"
 
-#: addons/metadata/static/files.js:1243
+#: addons/metadata/static/files.js:1265
 msgid "Some of the children have metadata."
 msgstr "いくつかの子ファイルにメタデータが定義されています。"
 
-#: addons/metadata/static/files.js:1253
+#: addons/metadata/static/files.js:1275
 msgid "File not found: "
 msgstr "ファイルが見つかりません:"
 
-#: addons/metadata/static/files.js:1460 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1509 website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr "保存"
 
-#: addons/metadata/static/files.js:1465 addons/metadata/static/files.js:1564
+#: addons/metadata/static/files.js:1514 addons/metadata/static/files.js:1613
 msgid "Copy to clipboard"
 msgstr "クリップボードにコピー"
 
-#: addons/metadata/static/files.js:1478
+#: addons/metadata/static/files.js:1527
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr "ファイルのリネーム、ファイルやディレクトリの移動、ディレクトリ階層の変更を行うと、入力したメタデータの関連付けが解除される場合があります。"
 
-#: addons/metadata/static/files.js:1514 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1533
+msgid "Edit File Metadata"
+msgstr "ファイルメタデータの編集"
+
+#: addons/metadata/static/files.js:1533
+msgid "View File Metadata"
+msgstr "ファイルメタデータの参照"
+
+#: addons/metadata/static/files.js:1563 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr "削除"
 
-#: addons/metadata/static/files.js:1525
+#: addons/metadata/static/files.js:1569
+msgid "Delete File Metadata"
+msgstr "ファイルメタデータの削除"
+
+#: addons/metadata/static/files.js:1574
 msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr "メタデータを削除してよろしいですか？この操作は元に戻せません。"
 
-#: addons/metadata/static/files.js:1542
-msgid "Select draft registration"
-msgstr "ドラフトレポートの選択"
+#: addons/metadata/static/files.js:1591
+msgid "Select a destination for file metadata registration"
+msgstr "ファイルメタデータ登録先の選択"
 
-#: addons/metadata/static/files.js:1574
-msgid "Resolve metadata"
-msgstr "メタデータの解決"
+#: addons/metadata/static/files.js:1623
+msgid "Fix file metadata"
+msgstr "ファイルメタデータの修正"
 
-#: addons/metadata/static/metadata-fields.js:40
+#: addons/metadata/static/metadata-fields.js:43
+#: addons/metadata/static/metadata-fields.js:188
 msgid "This field can't be blank."
 msgstr "このフィールドは必須項目です。"
 
-#: addons/metadata/static/metadata-fields.js:180
+#: addons/metadata/static/metadata-fields.js:194
 msgid "Choose..."
 msgstr "選択..."
 
-#: addons/metadata/static/metadata-fields.js:354
+#: addons/metadata/static/metadata-fields.js:371
 msgid "Calculate"
 msgstr "集計"
 
-#: addons/metadata/static/metadata-fields.js:405
+#: addons/metadata/static/metadata-fields.js:422
 msgid "Fill"
 msgstr "入力"
 
-#: addons/metadata/static/metadata-fields.js:432
+#: addons/metadata/static/metadata-fields.js:449
 msgid "No members"
 msgstr "作成者が設定されていません"
 
-#: addons/metadata/static/metadata-fields.js:499
+#: addons/metadata/static/metadata-fields.js:516
 msgid "e-Rad Researcher Number"
 msgstr "e-Rad研究者番号"
 
-#: addons/metadata/static/metadata-fields.js:500
+#: addons/metadata/static/metadata-fields.js:517
 msgid "Name (Japanese)"
 msgstr "名前 (日本語)"
 
-#: addons/metadata/static/metadata-fields.js:501
+#: addons/metadata/static/metadata-fields.js:518
 msgid "Name (English)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:515
+#: addons/metadata/static/metadata-fields.js:532
 #: website/static/js/myProjects.js:1565
 msgid "Add"
 msgstr "追加"

--- a/website/translations/js_messages.pot
+++ b/website/translations/js_messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-12 12:37+0000\n"
+"POT-Creation-Date: 2022-07-15 01:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,94 +21,94 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: addons/metadata/static/files.js:312
-msgid "Data Schema:"
+#: addons/metadata/static/files.js:319
+msgid "Metadata Schema:"
 msgstr ""
 
-#: addons/metadata/static/files.js:470
+#: addons/metadata/static/files.js:477
 msgid "Paste from Clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:495 addons/metadata/static/files.js:509
+#: addons/metadata/static/files.js:502 addons/metadata/static/files.js:516
 #: website/static/js/fangorn.js:1516
 msgid "Could not copy text"
 msgstr ""
 
-#: addons/metadata/static/files.js:507 website/static/js/clipboard.js:27
+#: addons/metadata/static/files.js:514 website/static/js/clipboard.js:27
 #: website/static/js/fangorn.js:1510 website/static/js/fangorn.js:1514
 msgid "Copied!"
 msgstr ""
 
-#: addons/metadata/static/files.js:524 addons/metadata/static/files.js:537
-#: addons/metadata/static/files.js:544
+#: addons/metadata/static/files.js:531 addons/metadata/static/files.js:544
+#: addons/metadata/static/files.js:551
 msgid "Could not paste text"
 msgstr ""
 
-#: addons/metadata/static/files.js:594 addons/metadata/static/files.js:608
-#: addons/metadata/static/files.js:942
+#: addons/metadata/static/files.js:601 addons/metadata/static/files.js:615
+#: addons/metadata/static/files.js:964
 msgid "Loading..."
 msgstr ""
 
-#: addons/metadata/static/files.js:606
+#: addons/metadata/static/files.js:613
 msgid "Select the destination of the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:611
+#: addons/metadata/static/files.js:618
 msgid "Current Metadata:"
 msgstr ""
 
-#: addons/metadata/static/files.js:667
+#: addons/metadata/static/files.js:674
 msgid "Delete metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:670
+#: addons/metadata/static/files.js:677
 msgid "Could not list hashes"
 msgstr ""
 
-#: addons/metadata/static/files.js:678
-#: addons/metadata/static/metadata-fields.js:326
-#: addons/metadata/static/metadata-fields.js:331
+#: addons/metadata/static/files.js:685
+#: addons/metadata/static/metadata-fields.js:343
+#: addons/metadata/static/metadata-fields.js:348
 msgid "Could not list files"
 msgstr ""
 
-#: addons/metadata/static/files.js:761 addons/metadata/static/files.js:768
+#: addons/metadata/static/files.js:773 addons/metadata/static/files.js:780
 msgid "No name"
 msgstr ""
 
-#: addons/metadata/static/files.js:828
+#: addons/metadata/static/files.js:840
 msgid ""
-"There is no draft metadata compliant with the schema. Create new draft "
-"metadata from the Metadata tab:"
+"There is no draft project metadata compliant with the schema. Create new "
+"draft project metadata from the Metadata tab:"
 msgstr ""
 
-#: addons/metadata/static/files.js:830 addons/metadata/static/files.js:986
+#: addons/metadata/static/files.js:842 addons/metadata/static/files.js:1008
 msgid "Open"
 msgstr ""
 
-#: addons/metadata/static/files.js:919
+#: addons/metadata/static/files.js:941
 msgid "There are errors in some fields."
 msgstr ""
 
-#: addons/metadata/static/files.js:953 addons/metadata/static/files.js:1535
-#: addons/metadata/static/files.js:1560 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:975 addons/metadata/static/files.js:1584
+#: addons/metadata/static/files.js:1609 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr ""
 
-#: addons/metadata/static/files.js:957
-msgid "Select the destination draft for the file metadata."
+#: addons/metadata/static/files.js:979
+msgid "Select the destination for the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:978
+#: addons/metadata/static/files.js:1000
 msgid "Registering..."
 msgstr ""
 
-#: addons/metadata/static/files.js:978
+#: addons/metadata/static/files.js:1000
 msgid "Deleting..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1018 addons/metadata/static/files.js:1456
-#: addons/metadata/static/files.js:1512 addons/metadata/static/files.js:1533
-#: addons/metadata/static/files.js:1558
+#: addons/metadata/static/files.js:1040 addons/metadata/static/files.js:1505
+#: addons/metadata/static/files.js:1561 addons/metadata/static/files.js:1582
+#: addons/metadata/static/files.js:1607
 #: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
@@ -116,101 +116,114 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: addons/metadata/static/files.js:1070 addons/metadata/static/files.js:1484
+#: addons/metadata/static/files.js:1092
 msgid "View Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1080 addons/metadata/static/files.js:1484
+#: addons/metadata/static/files.js:1102
 msgid "Edit Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1089
+#: addons/metadata/static/files.js:1111
 msgid "Register Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1097 addons/metadata/static/files.js:1520
+#: addons/metadata/static/files.js:1119
 msgid "Delete Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1234
+#: addons/metadata/static/files.js:1256
 msgid "Metadata is defined"
 msgstr ""
 
-#: addons/metadata/static/files.js:1243
+#: addons/metadata/static/files.js:1265
 msgid "Some of the children have metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1253
+#: addons/metadata/static/files.js:1275
 msgid "File not found: "
 msgstr ""
 
-#: addons/metadata/static/files.js:1460 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1509 website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr ""
 
-#: addons/metadata/static/files.js:1465 addons/metadata/static/files.js:1564
+#: addons/metadata/static/files.js:1514 addons/metadata/static/files.js:1613
 msgid "Copy to clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:1478
+#: addons/metadata/static/files.js:1527
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr ""
 
-#: addons/metadata/static/files.js:1514 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1533
+msgid "Edit File Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1533
+msgid "View File Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1563 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr ""
 
-#: addons/metadata/static/files.js:1525
-msgid "Do you want to delete metadata? This operation cannot be undone."
-msgstr ""
-
-#: addons/metadata/static/files.js:1542
-msgid "Select draft registration"
+#: addons/metadata/static/files.js:1569
+msgid "Delete File Metadata"
 msgstr ""
 
 #: addons/metadata/static/files.js:1574
-msgid "Resolve metadata"
+msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:40
+#: addons/metadata/static/files.js:1591
+msgid "Select a destination for file metadata registration"
+msgstr ""
+
+#: addons/metadata/static/files.js:1623
+msgid "Fix file metadata"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:43
+#: addons/metadata/static/metadata-fields.js:188
 msgid "This field can't be blank."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:180
+#: addons/metadata/static/metadata-fields.js:194
 msgid "Choose..."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:354
+#: addons/metadata/static/metadata-fields.js:371
 msgid "Calculate"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:405
+#: addons/metadata/static/metadata-fields.js:422
 msgid "Fill"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:432
+#: addons/metadata/static/metadata-fields.js:449
 msgid "No members"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:499
+#: addons/metadata/static/metadata-fields.js:516
 msgid "e-Rad Researcher Number"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:500
+#: addons/metadata/static/metadata-fields.js:517
 msgid "Name (Japanese)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:501
+#: addons/metadata/static/metadata-fields.js:518
 msgid "Name (English)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:515
+#: addons/metadata/static/metadata-fields.js:532
 #: website/static/js/myProjects.js:1565
 msgid "Add"
 msgstr ""


### PR DESCRIPTION
## Purpose

メタデータアドオンの修正。

## Changes

- [GRDM-31419] e-rad メタデータスキーマの修正
- [GRDM-32613] e-rad メタデータスキーマの修正
- [GRDM-32614]
    - メタデータスキーマのデフォルトオプションの実装とスキーマ修正
    - アクセス権が embagoed access のときのみ 公開予定日 が必須になるよう修正
- [GRDM-32169] メッセージの修正
- メタデータ編集画面を誤って閉じてしまわないよう修正

## QA Notes
あわせて https://github.com/RCOSDP/RDM-ember-osf-web/pull/74 のマージもお願いします。

## Documentation
None

## Side Effects
None

## Ticket
GRDM-31419, GRDM-32613, GRDM-32614, GRDM-32169
