### PR TITLE
[GRDM-33467, GRDM-33468] メタデータアドオンの修正

### DIFF
--- a/addons/metadata/migrations/0005_add_index_erad_record.py
+++ b/addons/metadata/migrations/0005_add_index_erad_record.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('addons_metadata', '0004_remove_usersettings_erad_researcher_number'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='eradrecord',
+            name='kenkyusha_no',
+            field=models.TextField(blank=True, db_index=True, null=True),
+        ),
+        migrations.AddIndex(
+            model_name='eradrecord',
+            index=models.Index(fields=['kenkyusha_no', 'kadai_id', 'nendo'], name='addons_meta_kenkyus_1e859e_idx'),
+        ),
+    ]

--- a/addons/metadata/models.py
+++ b/addons/metadata/models.py
@@ -64,7 +64,7 @@ class ERadRecord(BaseModel):
                                   db_index=True, null=True, blank=True,
                                   on_delete=models.CASCADE)
 
-    kenkyusha_no = models.TextField(blank=True, null=True)
+    kenkyusha_no = models.TextField(blank=True, null=True, db_index=True)
     kenkyusha_shimei = EncryptedTextField(blank=True, null=True)
 
     kenkyukikan_cd = models.TextField(blank=True, null=True)
@@ -86,6 +86,11 @@ class ERadRecord(BaseModel):
 
     bunya_cd = models.TextField(blank=True, null=True)
     bunya_mei = models.TextField(blank=True, null=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=['kenkyusha_no', 'kadai_id', 'nendo'])
+        ]
 
 
 class RegistrationReportFormat(BaseModel):
@@ -348,7 +353,10 @@ class FileMetadata(BaseModel):
         if provider == 'osfstorage':
             # materialized path -> object path
             content_type = ContentType.objects.get_for_model(node)
-            filenode = [fn for fn in OsfStorageFileNode.objects.filter(target_content_type=content_type) if fn.materialized_path == path]
+            filenode = [fn for fn in OsfStorageFileNode.objects.filter(
+                target_content_type=content_type,
+                target_object_id=node.id
+            ) if fn.materialized_path == path]
             if len(filenode) == 0:
                 logger.warn('No files: ' + self.path)
                 return None

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -707,17 +707,9 @@ function MetadataButtons() {
     self.resolveConsistencyDialog.dialog.modal('show');
   }
 
-  self.resolveConsistency = function() {
-    const matchedFiles = self.targetFiles.filter(function(file, fileIndex) {
-      return $('#metadata-target-' + fileIndex).is(':checked');
-    });
-    console.log('matchedFiles', matchedFiles, self.currentMetadata);
-    if (matchedFiles.length === 0) {
-      self.deleteMetadata(self.currentContext, self.currentMetadata.path);
-      return;
-    }
+  self.resolveConsistency = function(path) {
     const newMetadata = Object.assign({}, self.currentMetadata, {
-      path: matchedFiles[0].path
+      path: path
     });
     const url = self.currentContext.baseUrl + 'files/' + newMetadata.path;
     return new Promise(function(resolve, reject) {
@@ -1665,8 +1657,17 @@ function MetadataButtons() {
     close.on('click', self.closeModal);
     const select = $('<a href="#" class="btn btn-success"></a>').text(_('Select'));
     select.on('click', function() {
+      const matchedFiles = self.targetFiles.filter(function(file, fileIndex) {
+        return $('#metadata-target-' + fileIndex).is(':checked');
+      });
+      console.log('matchedFiles', matchedFiles, self.currentMetadata);
+      if (matchedFiles.length === 0) {
+        $(dialog).modal('hide');
+        self.deleteMetadata(self.currentContext, self.currentMetadata.path);
+        return;
+      }
       osfBlock.block();
-      self.resolveConsistency()
+      self.resolveConsistency(matchedFiles[0].path)
         .finally(function() {
           osfBlock.unblock();
           $(dialog).modal('hide');

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -87,6 +87,7 @@ function MetadataButtons() {
     const loadedCallback = function() {
       self.loading = false;
       const path = self.processHash();
+      m.redraw();
       if (!callback) {
         return;
       }

--- a/website/translations/ja/LC_MESSAGES/js_messages.po
+++ b/website/translations/ja/LC_MESSAGES/js_messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.6.0\n"
 "Report-Msgid-Bugs-To: rocs-office@nii.ac.jp\n"
-"POT-Creation-Date: 2022-07-15 01:31+0000\n"
+"POT-Creation-Date: 2022-09-19 12:24+0000\n"
 "PO-Revision-Date: 2020-11-23 09:30+0900\n"
 "Last-Translator: Hidetoshi Yoshimoto\n"
 "Language: ja\n"
@@ -22,94 +22,94 @@ msgstr ""
 msgid "Launch"
 msgstr "起動"
 
-#: addons/metadata/static/files.js:319
+#: addons/metadata/static/files.js:335
 msgid "Metadata Schema:"
 msgstr "メタデータ様式:"
 
-#: addons/metadata/static/files.js:477
+#: addons/metadata/static/files.js:493
 msgid "Paste from Clipboard"
 msgstr "クリップボードから貼り付け"
 
-#: addons/metadata/static/files.js:502 addons/metadata/static/files.js:516
+#: addons/metadata/static/files.js:518 addons/metadata/static/files.js:532
 #: website/static/js/fangorn.js:1516
 msgid "Could not copy text"
 msgstr "テキストをコピーできませんでした"
 
-#: addons/metadata/static/files.js:514 website/static/js/clipboard.js:27
+#: addons/metadata/static/files.js:530 website/static/js/clipboard.js:27
 #: website/static/js/fangorn.js:1510 website/static/js/fangorn.js:1514
 msgid "Copied!"
 msgstr "コピーされました！"
 
-#: addons/metadata/static/files.js:531 addons/metadata/static/files.js:544
-#: addons/metadata/static/files.js:551
+#: addons/metadata/static/files.js:547 addons/metadata/static/files.js:560
+#: addons/metadata/static/files.js:567
 msgid "Could not paste text"
 msgstr "テキストを貼り付けできませんでした"
 
-#: addons/metadata/static/files.js:601 addons/metadata/static/files.js:615
-#: addons/metadata/static/files.js:964
+#: addons/metadata/static/files.js:617 addons/metadata/static/files.js:631
+#: addons/metadata/static/files.js:989
 msgid "Loading..."
 msgstr "読み込み中..."
 
-#: addons/metadata/static/files.js:613
+#: addons/metadata/static/files.js:629
 msgid "Select the destination of the file metadata."
 msgstr "ファイルメタデータの移動先を選択してください。"
 
-#: addons/metadata/static/files.js:618
+#: addons/metadata/static/files.js:634
 msgid "Current Metadata:"
 msgstr "現在のメタデータ:"
 
-#: addons/metadata/static/files.js:674
+#: addons/metadata/static/files.js:690
 msgid "Delete metadata"
 msgstr "メタデータを削除"
 
-#: addons/metadata/static/files.js:677
+#: addons/metadata/static/files.js:693
 msgid "Could not list hashes"
 msgstr "ハッシュ情報の一覧を取得できませんでした"
 
-#: addons/metadata/static/files.js:685
+#: addons/metadata/static/files.js:701
 #: addons/metadata/static/metadata-fields.js:343
 #: addons/metadata/static/metadata-fields.js:348
 msgid "Could not list files"
 msgstr "ファイルの一覧を取得できませんでした"
 
-#: addons/metadata/static/files.js:773 addons/metadata/static/files.js:780
+#: addons/metadata/static/files.js:798 addons/metadata/static/files.js:805
 msgid "No name"
 msgstr "名称未設定"
 
-#: addons/metadata/static/files.js:840
+#: addons/metadata/static/files.js:865
 msgid ""
 "There is no draft project metadata compliant with the schema. Create new "
 "draft project metadata from the Metadata tab:"
 msgstr "スキーマに対応するプロジェクトメタデータの下書きがありません。メタデータ タブから新規プロジェクトメタデータを作成してください:"
 
-#: addons/metadata/static/files.js:842 addons/metadata/static/files.js:1008
+#: addons/metadata/static/files.js:867 addons/metadata/static/files.js:1035
 msgid "Open"
 msgstr "開く"
 
-#: addons/metadata/static/files.js:941
+#: addons/metadata/static/files.js:966
 msgid "There are errors in some fields."
 msgstr "いくつかのフィールドにエラーがあります。"
 
-#: addons/metadata/static/files.js:975 addons/metadata/static/files.js:1584
-#: addons/metadata/static/files.js:1609 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:1000 addons/metadata/static/files.js:1640
+#: addons/metadata/static/files.js:1666 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr "選択"
 
-#: addons/metadata/static/files.js:979
+#: addons/metadata/static/files.js:1004
 msgid "Select the destination for the file metadata."
 msgstr "ファイルメタデータの登録先を選択してください。"
 
-#: addons/metadata/static/files.js:1000
+#: addons/metadata/static/files.js:1025
 msgid "Registering..."
 msgstr "登録中..."
 
-#: addons/metadata/static/files.js:1000
+#: addons/metadata/static/files.js:1025
 msgid "Deleting..."
 msgstr "削除中..."
 
-#: addons/metadata/static/files.js:1040 addons/metadata/static/files.js:1505
-#: addons/metadata/static/files.js:1561 addons/metadata/static/files.js:1582
-#: addons/metadata/static/files.js:1607
+#: addons/metadata/static/files.js:1068 addons/metadata/static/files.js:1541
+#: addons/metadata/static/files.js:1610 addons/metadata/static/files.js:1638
+#: addons/metadata/static/files.js:1664
 #: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
@@ -117,77 +117,85 @@ msgstr "削除中..."
 msgid "Close"
 msgstr "閉じる"
 
-#: addons/metadata/static/files.js:1092
+#: addons/metadata/static/files.js:1102
+msgid "Loading Metadata"
+msgstr "メタデータ読み込み中"
+
+#: addons/metadata/static/files.js:1127
 msgid "View Metadata"
 msgstr "メタデータ確認"
 
-#: addons/metadata/static/files.js:1102
+#: addons/metadata/static/files.js:1137
 msgid "Edit Metadata"
 msgstr "メタデータ編集"
 
-#: addons/metadata/static/files.js:1111
+#: addons/metadata/static/files.js:1146
 msgid "Register Metadata"
 msgstr "メタデータ登録"
 
-#: addons/metadata/static/files.js:1119
+#: addons/metadata/static/files.js:1154
 msgid "Delete Metadata"
 msgstr "メタデータ削除"
 
-#: addons/metadata/static/files.js:1256
+#: addons/metadata/static/files.js:1291
 msgid "Metadata is defined"
 msgstr "メタデータが定義されています"
 
-#: addons/metadata/static/files.js:1265
+#: addons/metadata/static/files.js:1300
 msgid "Some of the children have metadata."
 msgstr "いくつかの子ファイルにメタデータが定義されています。"
 
-#: addons/metadata/static/files.js:1275
+#: addons/metadata/static/files.js:1310
 msgid "File not found: "
 msgstr "ファイルが見つかりません:"
 
-#: addons/metadata/static/files.js:1509 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1545 website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr "保存"
 
-#: addons/metadata/static/files.js:1514 addons/metadata/static/files.js:1613
+#: addons/metadata/static/files.js:1557 addons/metadata/static/files.js:1677
 msgid "Copy to clipboard"
 msgstr "クリップボードにコピー"
 
-#: addons/metadata/static/files.js:1527
+#: addons/metadata/static/files.js:1570
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr "ファイルのリネーム、ファイルやディレクトリの移動、ディレクトリ階層の変更を行うと、入力したメタデータの関連付けが解除される場合があります。"
 
-#: addons/metadata/static/files.js:1533
+#: addons/metadata/static/files.js:1576
 msgid "Edit File Metadata"
 msgstr "ファイルメタデータの編集"
 
-#: addons/metadata/static/files.js:1533
+#: addons/metadata/static/files.js:1576
 msgid "View File Metadata"
 msgstr "ファイルメタデータの参照"
 
-#: addons/metadata/static/files.js:1563 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1596 website/static/js/saveManager.js:24
+msgid "You have unsaved changes."
+msgstr "未保存の変更があります。"
+
+#: addons/metadata/static/files.js:1612 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr "削除"
 
-#: addons/metadata/static/files.js:1569
+#: addons/metadata/static/files.js:1625
 msgid "Delete File Metadata"
 msgstr "ファイルメタデータの削除"
 
-#: addons/metadata/static/files.js:1574
+#: addons/metadata/static/files.js:1630
 msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr "メタデータを削除してよろしいですか？この操作は元に戻せません。"
 
-#: addons/metadata/static/files.js:1591
+#: addons/metadata/static/files.js:1647
 msgid "Select a destination for file metadata registration"
 msgstr "ファイルメタデータ登録先の選択"
 
-#: addons/metadata/static/files.js:1623
+#: addons/metadata/static/files.js:1687
 msgid "Fix file metadata"
 msgstr "ファイルメタデータの修正"
 

--- a/website/translations/js_messages.pot
+++ b/website/translations/js_messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-07-15 01:31+0000\n"
+"POT-Creation-Date: 2022-09-19 12:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,94 +21,94 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: addons/metadata/static/files.js:319
+#: addons/metadata/static/files.js:335
 msgid "Metadata Schema:"
 msgstr ""
 
-#: addons/metadata/static/files.js:477
+#: addons/metadata/static/files.js:493
 msgid "Paste from Clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:502 addons/metadata/static/files.js:516
+#: addons/metadata/static/files.js:518 addons/metadata/static/files.js:532
 #: website/static/js/fangorn.js:1516
 msgid "Could not copy text"
 msgstr ""
 
-#: addons/metadata/static/files.js:514 website/static/js/clipboard.js:27
+#: addons/metadata/static/files.js:530 website/static/js/clipboard.js:27
 #: website/static/js/fangorn.js:1510 website/static/js/fangorn.js:1514
 msgid "Copied!"
 msgstr ""
 
-#: addons/metadata/static/files.js:531 addons/metadata/static/files.js:544
-#: addons/metadata/static/files.js:551
+#: addons/metadata/static/files.js:547 addons/metadata/static/files.js:560
+#: addons/metadata/static/files.js:567
 msgid "Could not paste text"
 msgstr ""
 
-#: addons/metadata/static/files.js:601 addons/metadata/static/files.js:615
-#: addons/metadata/static/files.js:964
+#: addons/metadata/static/files.js:617 addons/metadata/static/files.js:631
+#: addons/metadata/static/files.js:989
 msgid "Loading..."
 msgstr ""
 
-#: addons/metadata/static/files.js:613
+#: addons/metadata/static/files.js:629
 msgid "Select the destination of the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:618
+#: addons/metadata/static/files.js:634
 msgid "Current Metadata:"
 msgstr ""
 
-#: addons/metadata/static/files.js:674
+#: addons/metadata/static/files.js:690
 msgid "Delete metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:677
+#: addons/metadata/static/files.js:693
 msgid "Could not list hashes"
 msgstr ""
 
-#: addons/metadata/static/files.js:685
+#: addons/metadata/static/files.js:701
 #: addons/metadata/static/metadata-fields.js:343
 #: addons/metadata/static/metadata-fields.js:348
 msgid "Could not list files"
 msgstr ""
 
-#: addons/metadata/static/files.js:773 addons/metadata/static/files.js:780
+#: addons/metadata/static/files.js:798 addons/metadata/static/files.js:805
 msgid "No name"
 msgstr ""
 
-#: addons/metadata/static/files.js:840
+#: addons/metadata/static/files.js:865
 msgid ""
 "There is no draft project metadata compliant with the schema. Create new "
 "draft project metadata from the Metadata tab:"
 msgstr ""
 
-#: addons/metadata/static/files.js:842 addons/metadata/static/files.js:1008
+#: addons/metadata/static/files.js:867 addons/metadata/static/files.js:1035
 msgid "Open"
 msgstr ""
 
-#: addons/metadata/static/files.js:941
+#: addons/metadata/static/files.js:966
 msgid "There are errors in some fields."
 msgstr ""
 
-#: addons/metadata/static/files.js:975 addons/metadata/static/files.js:1584
-#: addons/metadata/static/files.js:1609 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:1000 addons/metadata/static/files.js:1640
+#: addons/metadata/static/files.js:1666 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr ""
 
-#: addons/metadata/static/files.js:979
+#: addons/metadata/static/files.js:1004
 msgid "Select the destination for the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1000
+#: addons/metadata/static/files.js:1025
 msgid "Registering..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1000
+#: addons/metadata/static/files.js:1025
 msgid "Deleting..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1040 addons/metadata/static/files.js:1505
-#: addons/metadata/static/files.js:1561 addons/metadata/static/files.js:1582
-#: addons/metadata/static/files.js:1607
+#: addons/metadata/static/files.js:1068 addons/metadata/static/files.js:1541
+#: addons/metadata/static/files.js:1610 addons/metadata/static/files.js:1638
+#: addons/metadata/static/files.js:1664
 #: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
@@ -116,77 +116,85 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: addons/metadata/static/files.js:1092
+#: addons/metadata/static/files.js:1102
+msgid "Loading Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1127
 msgid "View Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1102
+#: addons/metadata/static/files.js:1137
 msgid "Edit Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1111
+#: addons/metadata/static/files.js:1146
 msgid "Register Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1119
+#: addons/metadata/static/files.js:1154
 msgid "Delete Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1256
+#: addons/metadata/static/files.js:1291
 msgid "Metadata is defined"
 msgstr ""
 
-#: addons/metadata/static/files.js:1265
+#: addons/metadata/static/files.js:1300
 msgid "Some of the children have metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1275
+#: addons/metadata/static/files.js:1310
 msgid "File not found: "
 msgstr ""
 
-#: addons/metadata/static/files.js:1509 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1545 website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr ""
 
-#: addons/metadata/static/files.js:1514 addons/metadata/static/files.js:1613
+#: addons/metadata/static/files.js:1557 addons/metadata/static/files.js:1677
 msgid "Copy to clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:1527
+#: addons/metadata/static/files.js:1570
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr ""
 
-#: addons/metadata/static/files.js:1533
+#: addons/metadata/static/files.js:1576
 msgid "Edit File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1533
+#: addons/metadata/static/files.js:1576
 msgid "View File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1563 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1596 website/static/js/saveManager.js:24
+msgid "You have unsaved changes."
+msgstr ""
+
+#: addons/metadata/static/files.js:1612 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr ""
 
-#: addons/metadata/static/files.js:1569
+#: addons/metadata/static/files.js:1625
 msgid "Delete File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1574
+#: addons/metadata/static/files.js:1630
 msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr ""
 
-#: addons/metadata/static/files.js:1591
+#: addons/metadata/static/files.js:1647
 msgid "Select a destination for file metadata registration"
 msgstr ""
 
-#: addons/metadata/static/files.js:1623
+#: addons/metadata/static/files.js:1687
 msgid "Fix file metadata"
 msgstr ""
 


### PR DESCRIPTION
## Purpose

- メタデータアドオンの修正

## Changes

- [GRDM-33467] Metadata アドオンのAPIのパフォーマンスを改善しました。
- [GRDM-33468] メタデータの初期化中に、ローディングボタンを配置し、ローディング中であることがわかるようにしました。
- [GRDM-33468] メタデータのAPIアクセス中(メタデータの編集や保存時)にブロックUIを表示し、意図しない操作や離脱を防ぐようにしました。
- Metadata アドオンに関する国際化設定を更新しました。


## QA Notes
None


## Documentation
None


## Side Effects
None


## Ticket
GRDM-33467, GRDM-33468
