### PR TITLE
[GRDM-33465] メタデータ編集画面でクリップボードから貼り付けできないバグの修正

### DIFF
--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -491,6 +491,7 @@ function MetadataButtons() {
         .css('margin-left', 'auto')
         .append($('<i></i>').addClass('fa fa-paste'))
         .append(_('Paste from Clipboard'))
+        .attr('type', 'button')
         .on('click', self.pasteFromClipboard);
       dialog.toolbar.append($('<div></div>')
         .css('display', 'flex')
@@ -1550,7 +1551,8 @@ function MetadataButtons() {
     }
     const copyToClipboard = $('<button class="btn btn-default"></button>')
       .append($('<i></i>').addClass('fa fa-copy'))
-      .append(_('Copy to clipboard'));
+      .append(_('Copy to clipboard'))
+      .attr('type', 'button');
     const copyStatus = $('<div></div>');
     copyToClipboard.on('click', function(event) {
       self.copyToClipboard(event, copyStatus);

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -543,26 +543,15 @@ function MetadataButtons() {
   self.pasteFromClipboard = function(event) {
     event.preventDefault();
     console.log(logPrefix, 'paste from clipboard');
-    if (!navigator.clipboard) {
-      Raven.captureMessage(_('Could not paste text'), {
-        extra: {
-          error: 'navigator.clipboard API is not supported.',
-        },
-      });
+    if (!navigator.clipboard || !navigator.clipboard.readText) {
+      if (!self.pasteMetadataDialog) {
+        self.pasteMetadataDialog = self.initPasteMetadataDialog();
+      }
+      self.pasteMetadataDialog.modal('show');
+      return;
     }
     navigator.clipboard.readText().then(function(text) {
-      try {
-        const jsonObject = JSON.parse(text);
-        (self.lastFields || []).forEach(function(fieldSet) {
-          fieldSet.field.setValue(fieldSet.input, jsonObject[fieldSet.question.qid] || '');
-        });
-      } catch(e) {
-        Raven.captureMessage(_('Could not paste text'), {
-          extra: {
-            error: e.toString(),
-          },
-        });
-        }
+      self.setMetadataFromJson(text);
     }, function(err) {
       Raven.captureMessage(_('Could not paste text'), {
         extra: {
@@ -571,6 +560,21 @@ function MetadataButtons() {
       });
     });
   };
+
+  self.setMetadataFromJson = function(jsonText) {
+    try {
+      const jsonObject = JSON.parse(jsonText);
+      (self.lastFields || []).forEach(function(fieldSet) {
+        fieldSet.field.setValue(fieldSet.input, jsonObject[fieldSet.question.qid] || '');
+      });
+    } catch(err) {
+      Raven.captureMessage(_('Could not paste text'), {
+        extra: {
+          error: err.toString(),
+        },
+      });
+    }
+  }
 
   self.registerMetadata = function(context, filepath, item) {
     self.registeringFilepath = filepath;
@@ -1705,6 +1709,39 @@ function MetadataButtons() {
       select: select,
       copyStatus: copyStatus,
     };
+  };
+
+  self.initPasteMetadataDialog = function() {
+    const dialog = $('<div class="modal fade"></div>');
+    const close = $('<a href="#" class="btn btn-default" data-dismiss="modal"></a>').text(_('Close'));
+    close.click(self.closeModal);
+    dialog
+      .append($('<div class="modal-dialog modal-lg"></div>')
+        .append($('<div class="modal-content"></div>')
+          .append($('<div class="modal-header"></div>')
+            .append($('<h3></h3>').text(_('Paste Metadata'))))
+          .append($('<form></form>')
+            .append($('<div class="modal-body"></div>')
+              .append($('<div class="row"></div>')
+                .append($('<div class="col-sm-12"></div>')
+                  .append(_('Press Ctrl-V (Command-V) again to paste.')))))
+            .append($('<div class="modal-footer"></div>')
+              .append(close)))));
+    dialog.appendTo($('#treeGrid'));
+    if (!self.pasteMetadataEvent) {
+      self.pasteMetadataEvent = function pasteEvent(event) {
+        event.preventDefault();
+        if (!dialog.hasClass('in')) {
+          return;
+        }
+        const text = (event.clipboardData || window.clipboardData).getData('text');
+        self.setMetadataFromJson(text);
+        dialog.modal('hide');
+        self.closeModal();
+      }
+      document.addEventListener('paste', self.pasteMetadataEvent);
+    }
+    return dialog;
   };
 }
 

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -1724,7 +1724,11 @@ function MetadataButtons() {
             .append($('<div class="modal-body"></div>')
               .append($('<div class="row"></div>')
                 .append($('<div class="col-sm-12"></div>')
-                  .append(_('Press Ctrl-V (Command-V) again to paste.')))))
+                  .append(_('Press Ctrl-V (Command-V) to paste.'))
+                  .append($('<br/>'))
+                  .append(_('[Why is this needed?] In this browser, retrieving clipboard values with ' +
+                    'button operations is prohibited. Therefore, you must explicitly indicate clipboard operations ' +
+                    'by using the shortcut key or by pasting in the browser menu.')))))
             .append($('<div class="modal-footer"></div>')
               .append(close)))));
     dialog.appendTo($('#treeGrid'));

--- a/website/translations/ja/LC_MESSAGES/js_messages.po
+++ b/website/translations/ja/LC_MESSAGES/js_messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  0.6.0\n"
 "Report-Msgid-Bugs-To: rocs-office@nii.ac.jp\n"
-"POT-Creation-Date: 2022-09-19 12:24+0000\n"
+"POT-Creation-Date: 2022-10-25 03:07+0000\n"
 "PO-Revision-Date: 2020-11-23 09:30+0900\n"
 "Last-Translator: Hidetoshi Yoshimoto\n"
 "Language: ja\n"
@@ -40,76 +40,75 @@ msgstr "テキストをコピーできませんでした"
 msgid "Copied!"
 msgstr "コピーされました！"
 
-#: addons/metadata/static/files.js:547 addons/metadata/static/files.js:560
-#: addons/metadata/static/files.js:567
+#: addons/metadata/static/files.js:556 addons/metadata/static/files.js:571
 msgid "Could not paste text"
 msgstr "テキストを貼り付けできませんでした"
 
-#: addons/metadata/static/files.js:617 addons/metadata/static/files.js:631
-#: addons/metadata/static/files.js:989
+#: addons/metadata/static/files.js:621 addons/metadata/static/files.js:635
+#: addons/metadata/static/files.js:985
 msgid "Loading..."
 msgstr "読み込み中..."
 
-#: addons/metadata/static/files.js:629
+#: addons/metadata/static/files.js:633
 msgid "Select the destination of the file metadata."
 msgstr "ファイルメタデータの移動先を選択してください。"
 
-#: addons/metadata/static/files.js:634
+#: addons/metadata/static/files.js:638
 msgid "Current Metadata:"
 msgstr "現在のメタデータ:"
 
-#: addons/metadata/static/files.js:690
+#: addons/metadata/static/files.js:694
 msgid "Delete metadata"
 msgstr "メタデータを削除"
 
-#: addons/metadata/static/files.js:693
+#: addons/metadata/static/files.js:697
 msgid "Could not list hashes"
 msgstr "ハッシュ情報の一覧を取得できませんでした"
 
-#: addons/metadata/static/files.js:701
+#: addons/metadata/static/files.js:705
 #: addons/metadata/static/metadata-fields.js:343
 #: addons/metadata/static/metadata-fields.js:348
 msgid "Could not list files"
 msgstr "ファイルの一覧を取得できませんでした"
 
-#: addons/metadata/static/files.js:798 addons/metadata/static/files.js:805
+#: addons/metadata/static/files.js:794 addons/metadata/static/files.js:801
 msgid "No name"
 msgstr "名称未設定"
 
-#: addons/metadata/static/files.js:865
+#: addons/metadata/static/files.js:861
 msgid ""
 "There is no draft project metadata compliant with the schema. Create new "
 "draft project metadata from the Metadata tab:"
 msgstr "スキーマに対応するプロジェクトメタデータの下書きがありません。メタデータ タブから新規プロジェクトメタデータを作成してください:"
 
-#: addons/metadata/static/files.js:867 addons/metadata/static/files.js:1035
+#: addons/metadata/static/files.js:863 addons/metadata/static/files.js:1031
 msgid "Open"
 msgstr "開く"
 
-#: addons/metadata/static/files.js:966
+#: addons/metadata/static/files.js:962
 msgid "There are errors in some fields."
 msgstr "いくつかのフィールドにエラーがあります。"
 
-#: addons/metadata/static/files.js:1000 addons/metadata/static/files.js:1640
-#: addons/metadata/static/files.js:1666 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:996 addons/metadata/static/files.js:1636
+#: addons/metadata/static/files.js:1662 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr "選択"
 
-#: addons/metadata/static/files.js:1004
+#: addons/metadata/static/files.js:1000
 msgid "Select the destination for the file metadata."
 msgstr "ファイルメタデータの登録先を選択してください。"
 
-#: addons/metadata/static/files.js:1025
+#: addons/metadata/static/files.js:1021
 msgid "Registering..."
 msgstr "登録中..."
 
-#: addons/metadata/static/files.js:1025
+#: addons/metadata/static/files.js:1021
 msgid "Deleting..."
 msgstr "削除中..."
 
-#: addons/metadata/static/files.js:1068 addons/metadata/static/files.js:1541
-#: addons/metadata/static/files.js:1610 addons/metadata/static/files.js:1638
-#: addons/metadata/static/files.js:1664
+#: addons/metadata/static/files.js:1064 addons/metadata/static/files.js:1537
+#: addons/metadata/static/files.js:1606 addons/metadata/static/files.js:1634
+#: addons/metadata/static/files.js:1660 addons/metadata/static/files.js:1716
 #: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
@@ -117,87 +116,105 @@ msgstr "削除中..."
 msgid "Close"
 msgstr "閉じる"
 
-#: addons/metadata/static/files.js:1102
+#: addons/metadata/static/files.js:1098
 msgid "Loading Metadata"
 msgstr "メタデータ読み込み中"
 
-#: addons/metadata/static/files.js:1127
+#: addons/metadata/static/files.js:1123
 msgid "View Metadata"
 msgstr "メタデータ確認"
 
-#: addons/metadata/static/files.js:1137
+#: addons/metadata/static/files.js:1133
 msgid "Edit Metadata"
 msgstr "メタデータ編集"
 
-#: addons/metadata/static/files.js:1146
+#: addons/metadata/static/files.js:1142
 msgid "Register Metadata"
 msgstr "メタデータ登録"
 
-#: addons/metadata/static/files.js:1154
+#: addons/metadata/static/files.js:1150
 msgid "Delete Metadata"
 msgstr "メタデータ削除"
 
-#: addons/metadata/static/files.js:1291
+#: addons/metadata/static/files.js:1287
 msgid "Metadata is defined"
 msgstr "メタデータが定義されています"
 
-#: addons/metadata/static/files.js:1300
+#: addons/metadata/static/files.js:1296
 msgid "Some of the children have metadata."
 msgstr "いくつかの子ファイルにメタデータが定義されています。"
 
-#: addons/metadata/static/files.js:1310
+#: addons/metadata/static/files.js:1306
 msgid "File not found: "
 msgstr "ファイルが見つかりません:"
 
-#: addons/metadata/static/files.js:1545 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1541 website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr "保存"
 
-#: addons/metadata/static/files.js:1557 addons/metadata/static/files.js:1677
+#: addons/metadata/static/files.js:1553 addons/metadata/static/files.js:1682
 msgid "Copy to clipboard"
 msgstr "クリップボードにコピー"
 
-#: addons/metadata/static/files.js:1570
+#: addons/metadata/static/files.js:1566
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr "ファイルのリネーム、ファイルやディレクトリの移動、ディレクトリ階層の変更を行うと、入力したメタデータの関連付けが解除される場合があります。"
 
-#: addons/metadata/static/files.js:1576
+#: addons/metadata/static/files.js:1572
 msgid "Edit File Metadata"
 msgstr "ファイルメタデータの編集"
 
-#: addons/metadata/static/files.js:1576
+#: addons/metadata/static/files.js:1572
 msgid "View File Metadata"
 msgstr "ファイルメタデータの参照"
 
-#: addons/metadata/static/files.js:1596 website/static/js/saveManager.js:24
+#: addons/metadata/static/files.js:1592 website/static/js/saveManager.js:24
 msgid "You have unsaved changes."
 msgstr "未保存の変更があります。"
 
-#: addons/metadata/static/files.js:1612 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1608 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr "削除"
 
-#: addons/metadata/static/files.js:1625
+#: addons/metadata/static/files.js:1621
 msgid "Delete File Metadata"
 msgstr "ファイルメタデータの削除"
 
-#: addons/metadata/static/files.js:1630
+#: addons/metadata/static/files.js:1626
 msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr "メタデータを削除してよろしいですか？この操作は元に戻せません。"
 
-#: addons/metadata/static/files.js:1647
+#: addons/metadata/static/files.js:1643
 msgid "Select a destination for file metadata registration"
 msgstr "ファイルメタデータ登録先の選択"
 
-#: addons/metadata/static/files.js:1687
+#: addons/metadata/static/files.js:1692
 msgid "Fix file metadata"
 msgstr "ファイルメタデータの修正"
+
+#: addons/metadata/static/files.js:1722
+msgid "Paste Metadata"
+msgstr "メタデータ貼り付け"
+
+#: addons/metadata/static/files.js:1727
+msgid "Press Ctrl-V (Command-V) to paste."
+msgstr "クリップボードから貼り付けるために Ctrl-V (Command-V) を押してください。"
+
+#: addons/metadata/static/files.js:1729
+msgid ""
+"[Why is this needed?] In this browser, retrieving clipboard values with "
+"button operations is prohibited. Therefore, you must explicitly indicate "
+"clipboard operations by using the shortcut key or by pasting in the "
+"browser menu."
+msgstr ""
+"[この操作が必要な理由] "
+"このブラウザでは、ボタン操作でのクリップボードの値取得が禁止されています。そのため、ショートカットキーまたはブラウザメニューの貼り付けにより明示的にクリップボード操作を指示する必要があります。"
 
 #: addons/metadata/static/metadata-fields.js:43
 #: addons/metadata/static/metadata-fields.js:188

--- a/website/translations/js_messages.pot
+++ b/website/translations/js_messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-19 12:24+0000\n"
+"POT-Creation-Date: 2022-10-25 03:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,76 +39,75 @@ msgstr ""
 msgid "Copied!"
 msgstr ""
 
-#: addons/metadata/static/files.js:547 addons/metadata/static/files.js:560
-#: addons/metadata/static/files.js:567
+#: addons/metadata/static/files.js:556 addons/metadata/static/files.js:571
 msgid "Could not paste text"
 msgstr ""
 
-#: addons/metadata/static/files.js:617 addons/metadata/static/files.js:631
-#: addons/metadata/static/files.js:989
+#: addons/metadata/static/files.js:621 addons/metadata/static/files.js:635
+#: addons/metadata/static/files.js:985
 msgid "Loading..."
 msgstr ""
 
-#: addons/metadata/static/files.js:629
+#: addons/metadata/static/files.js:633
 msgid "Select the destination of the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:634
+#: addons/metadata/static/files.js:638
 msgid "Current Metadata:"
 msgstr ""
 
-#: addons/metadata/static/files.js:690
+#: addons/metadata/static/files.js:694
 msgid "Delete metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:693
+#: addons/metadata/static/files.js:697
 msgid "Could not list hashes"
 msgstr ""
 
-#: addons/metadata/static/files.js:701
+#: addons/metadata/static/files.js:705
 #: addons/metadata/static/metadata-fields.js:343
 #: addons/metadata/static/metadata-fields.js:348
 msgid "Could not list files"
 msgstr ""
 
-#: addons/metadata/static/files.js:798 addons/metadata/static/files.js:805
+#: addons/metadata/static/files.js:794 addons/metadata/static/files.js:801
 msgid "No name"
 msgstr ""
 
-#: addons/metadata/static/files.js:865
+#: addons/metadata/static/files.js:861
 msgid ""
 "There is no draft project metadata compliant with the schema. Create new "
 "draft project metadata from the Metadata tab:"
 msgstr ""
 
-#: addons/metadata/static/files.js:867 addons/metadata/static/files.js:1035
+#: addons/metadata/static/files.js:863 addons/metadata/static/files.js:1031
 msgid "Open"
 msgstr ""
 
-#: addons/metadata/static/files.js:966
+#: addons/metadata/static/files.js:962
 msgid "There are errors in some fields."
 msgstr ""
 
-#: addons/metadata/static/files.js:1000 addons/metadata/static/files.js:1640
-#: addons/metadata/static/files.js:1666 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:996 addons/metadata/static/files.js:1636
+#: addons/metadata/static/files.js:1662 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr ""
 
-#: addons/metadata/static/files.js:1004
+#: addons/metadata/static/files.js:1000
 msgid "Select the destination for the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1025
+#: addons/metadata/static/files.js:1021
 msgid "Registering..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1025
+#: addons/metadata/static/files.js:1021
 msgid "Deleting..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1068 addons/metadata/static/files.js:1541
-#: addons/metadata/static/files.js:1610 addons/metadata/static/files.js:1638
-#: addons/metadata/static/files.js:1664
+#: addons/metadata/static/files.js:1064 addons/metadata/static/files.js:1537
+#: addons/metadata/static/files.js:1606 addons/metadata/static/files.js:1634
+#: addons/metadata/static/files.js:1660 addons/metadata/static/files.js:1716
 #: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
@@ -116,86 +115,102 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: addons/metadata/static/files.js:1102
+#: addons/metadata/static/files.js:1098
 msgid "Loading Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1127
+#: addons/metadata/static/files.js:1123
 msgid "View Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1137
+#: addons/metadata/static/files.js:1133
 msgid "Edit Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1146
+#: addons/metadata/static/files.js:1142
 msgid "Register Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1154
+#: addons/metadata/static/files.js:1150
 msgid "Delete Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1291
+#: addons/metadata/static/files.js:1287
 msgid "Metadata is defined"
 msgstr ""
 
-#: addons/metadata/static/files.js:1300
+#: addons/metadata/static/files.js:1296
 msgid "Some of the children have metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1310
+#: addons/metadata/static/files.js:1306
 msgid "File not found: "
 msgstr ""
 
-#: addons/metadata/static/files.js:1545 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1541 website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr ""
 
-#: addons/metadata/static/files.js:1557 addons/metadata/static/files.js:1677
+#: addons/metadata/static/files.js:1553 addons/metadata/static/files.js:1682
 msgid "Copy to clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:1570
+#: addons/metadata/static/files.js:1566
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr ""
 
-#: addons/metadata/static/files.js:1576
+#: addons/metadata/static/files.js:1572
 msgid "Edit File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1576
+#: addons/metadata/static/files.js:1572
 msgid "View File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1596 website/static/js/saveManager.js:24
+#: addons/metadata/static/files.js:1592 website/static/js/saveManager.js:24
 msgid "You have unsaved changes."
 msgstr ""
 
-#: addons/metadata/static/files.js:1612 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1608 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr ""
 
-#: addons/metadata/static/files.js:1625
+#: addons/metadata/static/files.js:1621
 msgid "Delete File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1630
+#: addons/metadata/static/files.js:1626
 msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr ""
 
-#: addons/metadata/static/files.js:1647
+#: addons/metadata/static/files.js:1643
 msgid "Select a destination for file metadata registration"
 msgstr ""
 
-#: addons/metadata/static/files.js:1687
+#: addons/metadata/static/files.js:1692
 msgid "Fix file metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1722
+msgid "Paste Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1727
+msgid "Press Ctrl-V (Command-V) to paste."
+msgstr ""
+
+#: addons/metadata/static/files.js:1729
+msgid ""
+"[Why is this needed?] In this browser, retrieving clipboard values with "
+"button operations is prohibited. Therefore, you must explicitly indicate "
+"clipboard operations by using the shortcut key or by pasting in the "
+"browser menu."
 msgstr ""
 
 #: addons/metadata/static/metadata-fields.js:43


### PR DESCRIPTION
## Purpose

Firefox を使っていると、メタデータ編集画面でクリップボードから貼り付けできないバグを修正しました。

## Changes

- [GRDM-33465] paste イベントを利用したクリップボード貼り付けを実装

## QA Notes
None

## Documentation
None

## Side Effects
None

## Ticket
GRDM-33465
