### PR TITLE
[GRDM-34192, GRDM-34193, GRDM-34195] メタデータアドオンの修正

### DIFF
--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -1802,7 +1802,7 @@ function MetadataButtons() {
       self.copyToClipboard(event, copyStatus);
     });
     const toolbar = $('<div></div>');
-    const container = $('<ul></ul>');
+    const container = $('<ul></ul>').css('padding', '0 20px');
     var notice = $('<span></span>');
     if (editable) {
       notice = $('<div></div>')
@@ -1865,7 +1865,7 @@ function MetadataButtons() {
       });
     });
     const toolbar = $('<div></div>');
-    const container = $('<ul></ul>');
+    const container = $('<ul></ul>').css('padding', '0 20px');
     dialog
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')
@@ -1932,7 +1932,7 @@ function MetadataButtons() {
     close.click(self.closeModal);
     var select = $('<a href="#" class="btn btn-success"></a>').text(_('Select'));
     select.click(self.selectDraftModal);
-    var container = $('<ul></ul>');
+    var container = $('<ul></ul>').css('padding', '0 20px');
     var dialog = $('<div class="modal fade"></div>')
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')
@@ -1981,7 +1981,7 @@ function MetadataButtons() {
     copyToClipboard.on('click', function(event) {
       self.copyToClipboard(event, copyStatus);
     });
-    const container = $('<ul></ul>');
+    const container = $('<ul></ul>').css('padding', '0 20px');
     dialog
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -207,7 +207,7 @@ function MetadataButtons() {
 
   self.createFields = function(schema, item, options, callback) {
     const fields = [];
-    const itemData = item.data || {};
+    const itemData = options.multiple ? {} : item.data || {};
     (schema.pages || []).forEach(function(page) {
       (page.questions || []).forEach(function(question) {
         if (!question.qid || !question.qid.match(/^grdm-file:.+/)) {
@@ -227,7 +227,7 @@ function MetadataButtons() {
     return fields;
   };
 
-  self.fieldsChanged = function() {
+  self.fieldsChanged = function(event, options) {
     if (!self.lastFields) {
       return;
     }
@@ -245,7 +245,8 @@ function MetadataButtons() {
           self.erad,
           fieldSet.question,
           value,
-          fieldSetsAndValues
+          fieldSetsAndValues,
+          options,
         );
       } catch(e) {
         error = e.message;
@@ -262,18 +263,21 @@ function MetadataButtons() {
     });
   }
 
-  self.prepareFields = function(context, container, schema, filepath, fileitem) {
-    const lastMetadataItems = (self.lastMetadata.items || []).filter(function(item) {
-      const resolved = self.resolveActiveSchemaId(item.schema) || self.currentSchemaId;
-      return resolved === schema.id;
-    });
-    const lastMetadataItem = lastMetadataItems[0] || {};
+  self.prepareFields = function(context, container, schema, filepath, fileitem, options) {
+    let lastMetadataItem = {};
+    if (!options.multiple) {
+      lastMetadataItem = (self.lastMetadata.items || []).filter(function(item) {
+        const resolved = self.resolveActiveSchemaId(item.schema) || self.currentSchemaId;
+        return resolved === schema.id;
+      })[0] || {};
+    }
     container.empty();
     const fields = self.createFields(
       schema.attributes.schema,
       lastMetadataItem,
       {
         readonly: !((context.projectMetadata || {}).editable),
+        multiple: options.multiple,
         context: context,
         filepath: filepath,
         wbcache: context.wbcache,
@@ -294,7 +298,7 @@ function MetadataButtons() {
         errorContainer: errorContainer
       });
     });
-    self.fieldsChanged();
+    self.fieldsChanged(null, options);
   }
 
   self.findSchemaById = function(schemaId) {
@@ -480,7 +484,8 @@ function MetadataButtons() {
         fieldContainer,
         self.findSchemaById(self.currentSchemaId),
         filepath,
-        item
+        item,
+        {},
       );
     });
     dialog.toolbar.append(selector.group);
@@ -502,9 +507,72 @@ function MetadataButtons() {
       fieldContainer,
       self.findSchemaById(self.currentSchemaId),
       filepath,
-      item
+      item,
+      {},
     );
     dialog.container.append(fieldContainer);
+    dialog.dialog.modal('show');
+  };
+
+
+  /**
+   * Start editing multiple metadata.
+   */
+  self.editMultipleMetadata = function(context, filepaths, items) {
+    if (!self.editMultipleMetadataDialog) {
+      self.editMultipleMetadataDialog = self.initEditMultipleMetadataDialog();
+    }
+    const dialog = self.editMultipleMetadataDialog;
+    console.log(logPrefix, 'edit multiple metadata: ', filepaths, items);
+    self.currentItem = items;
+    self.lastMetadata = {
+      path: filepaths,
+      items: [],
+    };
+    self.editingContext = context;
+
+    // toolbar
+    const currentMetadatas = filepaths.map(function(filepath) {
+      return self.findMetadataByPath(context.nodeId, filepath);
+    }).filter(Boolean);
+    const targetItems = currentMetadatas.map(function(currentMedatata) {
+      return (currentMedatata.items || []).filter(function(item) {
+        return item.active;
+      })[0] || null;
+    });
+    const targetItem = targetItems.filter(Boolean)[0] || {};
+    const selector = self.createSchemaSelector(targetItem);
+    self.currentSchemaId = selector.currentSchemaId;
+    selector.schema.change(function(event) {
+      if (event.target.value === self.currentSchemaId) {
+        return;
+      }
+      self.currentSchemaId = event.target.value;
+      self.prepareFields(
+        context,
+        fieldContainer,
+        self.findSchemaById(self.currentSchemaId),
+        filepaths,
+        items,
+        {multiple: true},
+      );
+    });
+    dialog.toolbar.empty();
+    dialog.toolbar.append(selector.group);
+
+    // container
+    dialog.container.empty();
+    const fieldContainer = $('<div></div>');
+    self.prepareFields(
+      context,
+      fieldContainer,
+      self.findSchemaById(self.currentSchemaId),
+      filepaths,
+      items,
+      {multiple: true},
+    );
+    dialog.container.append(fieldContainer);
+
     dialog.dialog.modal('show');
   };
 
@@ -1091,14 +1159,8 @@ function MetadataButtons() {
     const context = self.findContextByNodeId(item ? item.data.nodeId : contextVars.node.id);
     if (!context) {
       console.warn('Metadata not loaded for project:', item ? item.data.nodeId : null);
-      const viewButton = createButton({
-        onclick: function(event) {
-        },
-        icon: 'fa fa-spinner fa-pulse',
-        className : 'text-default disabled'
-      }, _('Loading Metadata'));
-      viewButton.disabled = true;
-      return [viewButton];
+      const loadingButton = self.createLoadingButton(createButton);
+      return [loadingButton];
     }
     if (!context.addonAttached) {
       return [];
@@ -1152,6 +1214,63 @@ function MetadataButtons() {
       buttons.push(deleteButton)
     }
     return buttons;
+  }
+
+  self.createFangornMultipleItemsButtons = function(filepaths, items) {
+    return self.createMultipleItemsButtonsBase(
+      filepaths,
+      items,
+      function(options, label) {
+        return m.component(Fangorn.Components.button, options, label);
+      }
+    );
+  }
+
+  self.createMultipleItemsButtonsBase = function(filepaths, items, createButton) {
+    // assert filepaths.length > 1
+    // assert filepaths.length == items.length
+    const contexts = items.map(function(item) {
+      return self.findContextByNodeId(item ? item.data.nodeId : contextVars.node.id);
+    });
+    const context = contexts[0];
+    if (!context) {
+      console.warn('Metadata not loaded for project:', items[0] ? items[0].data.nodeId : null);
+      const loadingButton = self.createLoadingButton(createButton);
+      return [loadingButton];
+    }
+    if (!context.addonAttached) {
+      return [];
+    }
+    if (contexts.slice(1).filter(function(context) {
+      return context !== contexts[0];
+    }).length > 0) {
+      // unmatched contexts
+      return [];
+    }
+    const projectMetadata = context.projectMetadata;
+    if (!projectMetadata.editable) {
+      // readonly
+      return [];
+    }
+    const editButton = createButton({
+      onclick: function(event) {
+        self.editMultipleMetadata(context, filepaths, items);
+      },
+      icon: 'fa fa-edit',
+      className : 'text-primary'
+    }, _('Edit Multiple Metadata'));
+    return [editButton];
+  }
+
+  self.createLoadingButton = function(createButton) {
+    const viewButton = createButton({
+      onclick: function(event) {
+      },
+      icon: 'fa fa-spinner fa-pulse',
+      className : 'text-default disabled'
+    }, _('Loading Metadata'));
+    viewButton.disabled = true;
+    return viewButton;
   }
 
   /**
@@ -1425,6 +1544,22 @@ function MetadataButtons() {
                   }
                 };
               };
+            } if (propname == 'multipleItemsButtons') {
+              return function (items) {
+                var base = [];
+                if (target[propname] !== undefined) {
+                  const prop = target[propname];
+                  const baseButtons = typeof prop === 'function' ? prop.apply(this, [items]) : prop;
+                  if (baseButtons !== undefined) {
+                    base = baseButtons;
+                  }
+                }
+                const filepaths = items.map(function(item) {
+                  return item.data.provider + (item.data.materialized || '/');
+                });
+                const buttons = self.createFangornMultipleItemsButtons(filepaths, items);
+                return base.concat(buttons);
+              }
             } else if (propname == 'resolveRows') {
               return function(item) {
                 var base = null;
@@ -1523,6 +1658,114 @@ function MetadataButtons() {
     });
   };
 
+  /**
+   * Save the edited multiple metadata.
+   */
+  self.saveEditMultipleMetadataModal = function() {
+    const context = self.editingContext;
+    if (!self.currentSchemaId) {
+      return Promise.resolve();
+    }
+    const metadatas = self.lastMetadata.path
+      .map(function(filepath, i) {
+        const currentMetadata = self.findMetadataByPath(context.nodeId, filepath);
+        const metadata = Object.assign({}, currentMetadata);
+        if (!currentMetadata) {
+          metadata.path = filepath;
+          metadata.folder = self.currentItem[i].kind === 'folder';
+        }
+        const currentItems = metadata.items || [];
+        // inactivate old items
+        metadata.items = currentItems
+          .filter(function(item) {
+            return item.schema !== self.currentSchemaId;
+          })
+          .map(function(item) {
+            return Object.assign({}, item, {
+              active: false
+            });
+          });
+        // create new item
+        const oldMetacontent = currentItems
+          .filter(function(item) {
+            return item.schema === self.currentSchemaId;
+          })[0] || {};
+        const metacontent = {
+          schema: self.currentSchemaId,
+          active: true,
+          data: Object.assign({}, oldMetacontent.data),
+        };
+        self.lastFields.forEach(function(field) {
+          const value = field.field.getValue(field.input);
+          const clear = field.field.checkedClear && field.field.checkedClear();
+          if (clear) {
+            delete metacontent.data[field.field.label];
+          } else if (value) {
+            metacontent.data[field.field.label] = {
+              extra: [],
+              comments: [],
+              value: value
+            };
+          }
+        });
+        metadata.items.unshift(metacontent);
+        return metadata;
+      });
+    return Promise.all(self.currentItem.map(function(fileitem) {
+      return context.wbcache.computeHash(fileitem);
+    }))
+      .catch(function(error) {
+        self.currentItem = null;
+        return Promise.reject(error);
+      })
+      .then(function(hashes) {
+        return new Promise(function(resolve, reject) {
+          function patchTopMetadata() {
+            const metadata = metadatas.pop();
+            const hash = hashes.pop();
+            const url = context.baseUrl + 'files/' + metadata.path;
+            $.ajax({
+              method: 'PATCH',
+              url: url,
+              contentType: 'application/json',
+              data: JSON.stringify(Object.assign({}, metadata, {
+                hash: hash,
+              })),
+            }).done(function(data) {
+              console.log(logPrefix, 'saved: ', hash, data);
+              if (metadatas.length) {
+                patchTopMetadata();
+              } else {
+                resolve();
+              }
+            }).fail(function(xhr, status, error) {
+              Raven.captureMessage('Error while retrieving addon info', {
+                extra: {
+                  url: url,
+                  status: status,
+                  error: error
+                }
+              });
+              reject(error);
+            });
+          }
+          patchTopMetadata();
+        });
+      })
+      .then(function() {
+        self.currentItem = null;
+        self.editingContext = null;
+        return new Promise(function(resolve) {
+          self.loadMetadata(context.nodeId, context.baseUrl, function() {
+            if (self.fileViewPath) {
+              self.refreshFileViewButtons(self.fileViewPath);
+            }
+            resolve();
+          });
+        });
+      });
+  };
+
   self.closeModal = function() {
     console.log(logPrefix, 'Modal closed');
     self.deleteConfirmingFilepath = null;
@@ -1553,7 +1796,8 @@ function MetadataButtons() {
       .append($('<i></i>').addClass('fa fa-copy'))
       .append(_('Copy to clipboard'))
       .attr('type', 'button');
-    const copyStatus = $('<div></div>');
+    const copyStatus = $('<div></div>')
+      .css('text-align', 'left');
     copyToClipboard.on('click', function(event) {
       self.copyToClipboard(event, copyStatus);
     });
@@ -1600,6 +1844,57 @@ function MetadataButtons() {
       container: container,
       toolbar: toolbar,
       copyStatus: copyStatus,
+    };
+  };
+
+
+  /**
+   * Create the Edit Multiple Metadata dialog.
+   */
+  self.initEditMultipleMetadataDialog = function() {
+    const dialog = $('<div class="modal fade" data-backdrop="static"></div>');
+    const close = $('<a href="#" class="btn btn-default" data-dismiss="modal"></a>').text(_('Close'));
+    close.click(self.closeModal);
+    const save = $('<a href="#" class="btn btn-success"></a>').text(_('Save'));
+    save.click(function() {
+      osfBlock.block();
+      self.saveEditMultipleMetadataModal()
+        .finally(function() {
+          osfBlock.unblock();
+          $(dialog).modal('hide');
+      });
+    });
+    const toolbar = $('<div></div>');
+    const container = $('<ul></ul>');
+    dialog
+      .append($('<div class="modal-dialog modal-lg"></div>')
+        .append($('<div class="modal-content"></div>')
+          .append($('<div class="modal-header"></div>')
+            .append($('<h3></h3>').text(_('Edit Multiple File Metadata'))))
+          .append($('<form></form>')
+            .append($('<div class="modal-body"></div>')
+              .append($('<div class="row"></div>')
+                .append($('<div class="col-sm-12"></div>')
+                  .append(toolbar))
+                .append($('<div class="col-sm-12"></div>')
+                  .css('overflow-y', 'scroll')
+                  .css('height', '70vh')
+                  .append(container))))
+            .append($('<div class="modal-footer"></div>')
+              .css('display', 'flex')
+              .css('align-items', 'center')
+              .append(close)
+              .append(save)))));
+    $(window).on('beforeunload', function() {
+      if ($(dialog).data('bs.modal').isShown) {
+        return _('You have unsaved changes.');
+      }
+    });
+    dialog.appendTo($('#treeGrid'));
+    return {
+      dialog: dialog,
+      container: container,
+      toolbar: toolbar,
     };
   };
 

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -246,7 +246,7 @@ function MetadataButtons() {
           fieldSet.question,
           value,
           fieldSetsAndValues,
-          options,
+          options
         );
       } catch(e) {
         error = e.message;
@@ -264,7 +264,7 @@ function MetadataButtons() {
   }
 
   self.prepareFields = function(context, container, schema, filepath, fileitem, options) {
-    let lastMetadataItem = {};
+    var lastMetadataItem = {};
     if (!options.multiple) {
       lastMetadataItem = (self.lastMetadata.items || []).filter(function(item) {
         const resolved = self.resolveActiveSchemaId(item.schema) || self.currentSchemaId;
@@ -485,7 +485,7 @@ function MetadataButtons() {
         self.findSchemaById(self.currentSchemaId),
         filepath,
         item,
-        {},
+        {}
       );
     });
     dialog.toolbar.append(selector.group);
@@ -508,7 +508,7 @@ function MetadataButtons() {
       self.findSchemaById(self.currentSchemaId),
       filepath,
       item,
-      {},
+      {}
     );
     dialog.container.append(fieldContainer);
     dialog.dialog.modal('show');
@@ -554,7 +554,7 @@ function MetadataButtons() {
         self.findSchemaById(self.currentSchemaId),
         filepaths,
         items,
-        {multiple: true},
+        {multiple: true}
       );
     });
     dialog.toolbar.empty();
@@ -569,7 +569,7 @@ function MetadataButtons() {
       self.findSchemaById(self.currentSchemaId),
       filepaths,
       items,
-      {multiple: true},
+      {multiple: true}
     );
     dialog.container.append(fieldContainer);
 

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -1883,7 +1883,7 @@ function MetadataButtons() {
             .append($('<div class="modal-footer"></div>')
               .css('display', 'flex')
               .css('align-items', 'center')
-              .append(close)
+              .append(close.css('margin-left', 'auto'))
               .append(save)))));
     $(window).on('beforeunload', function() {
       if ($(dialog).data('bs.modal').isShown) {

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -1716,7 +1716,6 @@ function MetadataButtons() {
   self.initPasteMetadataDialog = function() {
     const dialog = $('<div class="modal fade"></div>');
     const close = $('<a href="#" class="btn btn-default" data-dismiss="modal"></a>').text(_('Close'));
-    close.click(self.closeModal);
     dialog
       .append($('<div class="modal-dialog modal-lg"></div>')
         .append($('<div class="modal-content"></div>')
@@ -1743,7 +1742,6 @@ function MetadataButtons() {
         const text = (event.clipboardData || window.clipboardData).getData('text');
         self.setMetadataFromJson(text);
         dialog.modal('hide');
-        self.closeModal();
       }
       document.addEventListener('paste', self.pasteMetadataEvent);
     }

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -251,6 +251,12 @@ function createFormElement(createHandler, options) {
         input.val(value);
       }
     },
+    reset: function(input) {
+      input.val(null);
+    },
+    disable: function(input, disabled) {
+      input.attr('disabled', disabled);
+    },
   };
 }
 
@@ -308,6 +314,14 @@ function SingleElementField(formField, clearField, question, defaultValue, optio
     if (clearField) {
       self.clearField = clearField.create();
       self.clearField.element.css('float', 'right');
+      self.clearField.element.on('change', function() {
+        if (self.clearField.checked()) {
+          self.formField.reset(input);
+          self.formField.disable(input, true);
+        } else {
+          self.formField.disable(input, false);
+        }
+      });
       header.append(self.clearField.element);
     }
     const group = $('<div></div>').addClass('form-group')
@@ -492,6 +506,12 @@ function createFileCapacityFieldElement(createHandler, options) {
     setValue: function(container, value) {
       container.find('input').val(value);
     },
+    reset: function(container) {
+      container.find('input').val(null);
+    },
+    disable: function(container, disabled) {
+      container.find('input').attr('disabled', disabled);
+    },
   };
 }
 
@@ -530,6 +550,12 @@ function createFileURLFieldElement(createHandler, options) {
     },
     setValue: function(container, value) {
       container.find('input').val(value);
+    },
+    reset: function(container) {
+      container.find('input').val(null);
+    },
+    disable: function(container, disabled) {
+      container.find('input').attr('disabled', disabled);
     },
   };
 }
@@ -667,7 +693,18 @@ function createFileCreatorsFieldElement(erad, options) {
       researchers.forEach(function (researcher) {
         addResearcher(container, researcher);
       });
-    }
+    },
+    reset: function(container) {
+      container.find('tbody').empty();
+    },
+    disable: function(container, disabled) {
+      const btn = container.find('.btn');
+      if (disabled) {
+        btn.addClass('disabled');
+      } else {
+        btn.removeClass('disabled');
+      }
+    },
   };
 }
 
@@ -734,6 +771,12 @@ function createERadResearcherNumberFieldElement(erad, options) {
     },
     setValue: function(container, value) {
       container.find('input').val(value);
+    },
+    reset: function(container) {
+      container.find('input').val(null);
+    },
+    disable: function(container, disabled) {
+      container.find('input').attr('disabled', disabled);
     },
   };
 }

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -210,17 +210,26 @@ function createChooser(question, options) {
     defaultOption.text(_('Choose...'));
   }
   select.append(defaultOption);
+  let groupElem = null;
   (question.options || []).forEach(function(opt) {
-    if (opt.text === undefined) {
-      const optElem = $('<option></option>').attr('value', opt).text(opt);
-      select.append(optElem);
-      return;
+    if (opt.text && opt.text === 'group:None') {
+      groupElem = null;
+    } else if (opt.text && opt.text.startsWith('group:')) {
+      groupElem = $('<optgroup></optgroup>').attr('label', getLocalizedText(opt.tooltip));
+      select.append(groupElem);
+    } else {
+      const optElem = $('<option></option>')
+        .attr('value', opt.text === undefined ? opt : opt.text)
+        .text(opt.text === undefined ? opt : getLocalizedText(opt.tooltip));
+      if (!options.multiple && opt.default) {
+        optElem.attr('selected', true);
+      }
+      if (groupElem) {
+        groupElem.append(optElem);
+      } else {
+        select.append(optElem);
+      }
     }
-    const optElem = $('<option></option>').attr('value', opt.text).text(getLocalizedText(opt.tooltip));
-    if (!options.multiple && opt.default) {
-      optElem.attr('selected', true);
-    }
-    select.append(optElem);
   });
   return select;
 }

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -212,7 +212,7 @@ function createChooser(question, options) {
   select.append(defaultOption);
   var groupElem = null;
   (question.options || []).forEach(function(opt) {
-    if (opt.text && opt.text === 'group:None') {
+    if (opt.text && opt.text.startsWith('group:None:')) {
       groupElem = null;
     } else if (opt.text && opt.text.startsWith('group:')) {
       groupElem = $('<optgroup></optgroup>').attr('label', getLocalizedText(opt.tooltip));

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -476,8 +476,9 @@ function createFileCapacityFieldElement(createHandler, options) {
         });
       }
       input.addClass('form-control');
-      const container = $('<div>').css('display', 'flex').append(input);
+      const container = $('<div>').append(input);
       if (!options || (!options.readonly && !options.multiple)) {
+        container.css('display', 'flex');
         const calcIndicator = $('<i class="fa fa-spinner fa-pulse">')
           .hide();
         const calcButton = $('<a class="btn btn-default btn-sm">')
@@ -537,8 +538,9 @@ function createFileURLFieldElement(createHandler, options) {
         });
       }
       input.addClass('form-control');
-      const container = $('<div>').css('display', 'flex').append(input);
+      const container = $('<div>').append(input);
       if (!options || (!options.readonly && !options.multiple)) {
+        container.css('display', 'flex');
         const fillButton = $('<a class="btn btn-default btn-sm">')
           .append($('<i class="fa fa-refresh"></i>'))
           .append($('<span></span>').text(_('Fill')));

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -210,7 +210,7 @@ function createChooser(question, options) {
     defaultOption.text(_('Choose...'));
   }
   select.append(defaultOption);
-  let groupElem = null;
+  var groupElem = null;
   (question.options || []).forEach(function(opt) {
     if (opt.text && opt.text === 'group:None') {
       groupElem = null;
@@ -336,7 +336,7 @@ function SingleElementField(formField, clearField, question, defaultValue, optio
     const group = $('<div></div>').addClass('form-group')
       .append(header);
     if (self.help) {
-      let isDisplayedHelp = false;
+      var isDisplayedHelp = false;
       const helpLink = $('<a></a>')
           .addClass('help-toggle-button')
           .text(_('Show example'));

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -296,6 +296,7 @@ function SingleElementField(formField, clearField, question, defaultValue, optio
   self.clearField = null;
 
   self.createFormGroup = function(input, errorContainer) {
+    const header = $('<div></div>');
     const label = $('<label></label>').text(self.getDisplayText());
     if (question.required) {
       label.append($('<span></span>')
@@ -303,8 +304,14 @@ function SingleElementField(formField, clearField, question, defaultValue, optio
         .css('font-weight', 'bold')
         .text('*'));
     }
+    header.append(label);
+    if (clearField) {
+      self.clearField = clearField.create();
+      self.clearField.element.css('float', 'right');
+      header.append(self.clearField.element);
+    }
     const group = $('<div></div>').addClass('form-group')
-      .append(label);
+      .append(header);
     if (self.help) {
       let isDisplayedHelp = false;
       const helpLink = $('<a></a>')
@@ -361,12 +368,7 @@ function SingleElementField(formField, clearField, question, defaultValue, optio
   self.addElementTo = function(parent, errorContainer) {
     const input = formField.create(
       function(child) {
-        const group = self.createFormGroup(child, errorContainer);
-        if (clearField) {
-          self.clearField = clearField.create();
-          group.append(self.clearField.element);
-        }
-        parent.append(group);
+        parent.append(self.createFormGroup(child, errorContainer));
       },
       callback
     );

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -244,6 +244,7 @@ function SingleElementField(formField, question, defaultValue, options, callback
   self.formField = formField;
   self.label = question.qid;
   self.title = question.title;
+  self.help = question.help;
   self.defaultValue = defaultValue;
 
   self.createFormGroup = function(input, errorContainer) {
@@ -255,7 +256,32 @@ function SingleElementField(formField, question, defaultValue, options, callback
         .text('*'));
     }
     const group = $('<div></div>').addClass('form-group')
-      .append(label)
+      .append(label);
+    if (self.help) {
+      let isDisplayedHelp = false;
+      const helpLink = $('<a></a>')
+          .addClass('help-toggle-button')
+          .text(_('Show example'));
+      const helpLinkBlock = $('<p></p>').append(helpLink);
+      const help = $('<p></p>')
+        .addClass('help-block')
+        .text(self.getHelpText())
+        .hide();
+      helpLink.on('click', function(e) {
+        e.preventDefault();
+        if (isDisplayedHelp) {
+          helpLink.text(_('Show example'));
+          help.hide();
+          isDisplayedHelp = false;
+        } else {
+          helpLink.text(_('Hide example'));
+          help.show();
+          isDisplayedHelp = true;
+        }
+      });
+      group.append(helpLinkBlock).append(help);
+    }
+    group
       .append(input)
       .append(errorContainer);
     return group;
@@ -266,6 +292,10 @@ function SingleElementField(formField, question, defaultValue, options, callback
       return self.label;
     }
     return getLocalizedText(self.title);
+  }
+
+  self.getHelpText = function() {
+    return getLocalizedText(self.help);
   }
 
   self.getValue = function(input) {

--- a/osf/migrations/0224_ensure_schema_and_reports.py
+++ b/osf/migrations/0224_ensure_schema_and_reports.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
+
+
+def ensure_registration_reports(*args):
+    from api.base import settings
+    from addons.metadata import FULL_NAME
+    from addons.metadata.utils import ensure_registration_report
+    from addons.metadata.report_format import REPORT_FORMATS
+    if FULL_NAME not in settings.INSTALLED_APPS:
+        return
+    for schema_name, report_name, csv_template in REPORT_FORMATS:
+        ensure_registration_report(schema_name, report_name, csv_template)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0223_ensure_schema_and_reports'),
+    ]
+
+    operations = [
+        UpdateRegistrationSchemasAndSchemaBlocks(),
+        migrations.RunPython(ensure_registration_reports, ensure_registration_reports),
+    ]

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -468,7 +468,7 @@
           "format": "singleselect",
           "options": [
             {
-              "text": "group:None",
+              "text": "group:None:1",
               "tooltip": "None"
             },
             {
@@ -576,7 +576,7 @@
               "tooltip": "Mozilla Public License 2.0"
             },
             {
-              "text": "group:None",
+              "text": "group:None:2",
               "tooltip": "None"
             },
             {

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -463,9 +463,127 @@
           "qid": "grdm-file:data-policy-license",
           "nav": "管理対象データの利活用・提供方針 (ライセンス)",
           "title": "管理対象データの利活用・提供方針 (ライセンス)|Data utilization and provision policy (License)",
-          "type": "string",
-          "format": "text",
-          "required": true
+          "required": true,
+          "type": "choose",
+          "format": "singleselect",
+          "options": [
+            {
+              "text": "group:None",
+              "tooltip": "None"
+            },
+            {
+              "text": "NO_LICENSE",
+              "tooltip": "ライセンスなし|No license"
+            },
+            {
+              "text": "group:Content",
+              "tooltip": "コンテンツ用|Content"
+            },
+            {
+              "text": "CC0",
+              "tooltip": "CC0 1.0 Universal"
+            },
+            {
+              "text": "CC0PD",
+              "tooltip": "CC0 1.0 パブリック・ドメイン提供|CC0 1.0 Public Domain Dedication"
+            },
+            {
+              "text": "CCBY",
+              "tooltip": "CC BY 4.0 表示 国際|CC BY 4.0 Attribution International"
+            },
+            {
+              "text": "CCBYSA",
+              "tooltip": "CC BY-SA 4.0 表示—継承|CC BY-SA 4.0 Attribution-ShareAlike"
+            },
+            {
+              "text": "CCBYND",
+              "tooltip": "CC BY-ND 4.0 表示—改変禁止|CC BY-ND 4.0 Attribution—NoDerivatives"
+            },
+            {
+              "text": "CCBYNC",
+              "tooltip": "CC BY-NC 4.0 表示—非営利|CC BY-NC 4.0 Attribution—NonCommercial"
+            },
+            {
+              "text": "CCBYNCSA",
+              "tooltip": "CC BY-NC-SA 4.0 表示—非営利—継承|CC BY-NC-SA 4.0 Attribution—NonCommercial—ShareAlike"
+            },
+            {
+              "text": "CCBYNCND",
+              "tooltip": "CC BY-NC-ND 4.0 表示—非営利—改変禁止|CC BY-NC-ND 4.0 Attribution—NonCommercial—NoDerivatives"
+            },
+            {
+              "text": "AFL",
+              "tooltip": "Academic Free License (AFL) 3.0"
+            },
+            {
+              "text": "PD",
+              "tooltip": "パブリックドメイン|Public Domain"
+            },
+            {
+              "text": "group:CodePermissive",
+              "tooltip": "コード用 - 非コピーレフト|Code - Permissive"
+            },
+            {
+              "text": "MIT",
+              "tooltip": "MIT License"
+            },
+            {
+              "text": "Apache2",
+              "tooltip": "Apache License 2.0"
+            },
+            {
+              "text": "BSD2",
+              "tooltip": "BSD 2-Clause \"Simplified\" License"
+            },
+            {
+              "text": "BSD3",
+              "tooltip": "BSD 3-Clause \"New\"/\"Revised\" License"
+            },
+            {
+              "text": "group:CodeCopyleft",
+              "tooltip": "コード用 - コピーレフト|Code - Copyleft"
+            },
+            {
+              "text": "GPL3",
+              "tooltip": "GNU General Public License (GPL) 3.0"
+            },
+            {
+              "text": "GPL2",
+              "tooltip": "GNU General Public License (GPL) 2.0"
+            },
+            {
+              "text": "group:CodeOther",
+              "tooltip": "コード用 - その他|Code - Other"
+            },
+            {
+              "text": "Artistic2",
+              "tooltip": "Artistic License 2.0"
+            },
+            {
+              "text": "Eclipse1",
+              "tooltip": "Eclipse Public License 1.0"
+            },
+            {
+              "text": "LGPL3",
+              "tooltip": "GNU Lesser General Public License (LGPL) 3.0"
+            },
+            {
+              "text": "LGPL2_1",
+              "tooltip": "GNU Lesser General Public License (LGPL) 2.1"
+            },
+            {
+              "text": "Mozilla2",
+              "tooltip": "Mozilla Public License 2.0"
+            },
+            {
+              "text": "group:None",
+              "tooltip": "None"
+            },
+            {
+              "text": "OTHER",
+              "tooltip": "その他|Other"
+            }
+          ]
         },
         {
           "qid": "grdm-file:data-policy-cite-ja",

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2279,27 +2279,34 @@ var FGToolbar = {
             );
         }
         // multiple selection icons
-        // Special cased to not show 'delete multiple' for github or published dataverses
         if(
-            (items.length > 1) &&
-            (ctrl.tb.multiselected()[0].data.provider !== 'github') &&
-            (ctrl.tb.options.placement !== 'fileview') &&
-            !(
+          (items.length > 1) &&
+          (ctrl.tb.options.placement !== 'fileview')
+        ) {
+            var addonItemsButtons = resolveconfigOption.call(ctrl.tb, items[0], 'multipleItemsButtons', [items]) || [];
+            addonItemsButtons.forEach(function(addonButton) {
+                generalButtons.push(addonButton);
+            });
+            // Special cased to not show 'delete multiple' for github or published dataverses
+            if (
+              (ctrl.tb.multiselected()[0].data.provider !== 'github') &&
+              !(
                 (ctrl.tb.multiselected()[0].data.provider === 'dataverse') &&
                 (ctrl.tb.multiselected()[0].parent().data.version === 'latest-published')
-            )
-        ) {
-            if (showDeleteMultiple(items)) {
-                generalButtons.push(
-                    m.component(FGButton, {
-                        onclick: function(event) {
-                            var configOption = resolveconfigOption.call(ctrl.tb, item, 'removeEvent', [event, items]); // jshint ignore:line
-                            if(!configOption){ _removeEvent.call(ctrl.tb, null, items); }
-                        },
-                        icon: 'fa fa-trash',
-                        className : 'text-danger'
-                    }, gettext('Delete Multiple'))
-                );
+              )
+            ) {
+                if (showDeleteMultiple(items)) {
+                    generalButtons.push(
+                      m.component(FGButton, {
+                          onclick: function(event) {
+                              var configOption = resolveconfigOption.call(ctrl.tb, item, 'removeEvent', [event, items]); // jshint ignore:line
+                              if(!configOption){ _removeEvent.call(ctrl.tb, null, items); }
+                          },
+                          icon: 'fa fa-trash',
+                          className : 'text-danger'
+                      }, gettext('Delete Multiple'))
+                    );
+                }
             }
         }
         generalButtons.push(

--- a/website/translations/en/LC_MESSAGES/js_messages.po
+++ b/website/translations/en/LC_MESSAGES/js_messages.po
@@ -22,209 +22,260 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: addons/metadata/static/files.js:319
+#: addons/metadata/static/files.js:339
 msgid "Metadata Schema:"
 msgstr ""
 
-#: addons/metadata/static/files.js:477
+#: addons/metadata/static/files.js:498
 msgid "Paste from Clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:502 addons/metadata/static/files.js:516
+#: addons/metadata/static/files.js:587 addons/metadata/static/files.js:601
 #: website/static/js/fangorn.js:1516
 msgid "Could not copy text"
 msgstr ""
 
-#: addons/metadata/static/files.js:514 website/static/js/clipboard.js:27
+#: addons/metadata/static/files.js:599 website/static/js/clipboard.js:27
 #: website/static/js/fangorn.js:1510 website/static/js/fangorn.js:1514
 msgid "Copied!"
 msgstr ""
 
-#: addons/metadata/static/files.js:531 addons/metadata/static/files.js:544
-#: addons/metadata/static/files.js:551
+#: addons/metadata/static/files.js:625 addons/metadata/static/files.js:640
 msgid "Could not paste text"
 msgstr ""
 
-#: addons/metadata/static/files.js:601 addons/metadata/static/files.js:615
-#: addons/metadata/static/files.js:964
+#: addons/metadata/static/files.js:690 addons/metadata/static/files.js:704
+#: addons/metadata/static/files.js:1054
 msgid "Loading..."
 msgstr ""
 
-#: addons/metadata/static/files.js:613
+#: addons/metadata/static/files.js:702
 msgid "Select the destination of the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:618
+#: addons/metadata/static/files.js:707
 msgid "Current Metadata:"
 msgstr ""
 
-#: addons/metadata/static/files.js:674
+#: addons/metadata/static/files.js:763
 msgid "Delete metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:677
+#: addons/metadata/static/files.js:766
 msgid "Could not list hashes"
 msgstr ""
 
-#: addons/metadata/static/files.js:685
-#: addons/metadata/static/metadata-fields.js:343
-#: addons/metadata/static/metadata-fields.js:348
+#: addons/metadata/static/files.js:774
+#: addons/metadata/static/metadata-fields.js:455
+#: addons/metadata/static/metadata-fields.js:460
 msgid "Could not list files"
 msgstr ""
 
-#: addons/metadata/static/files.js:773 addons/metadata/static/files.js:780
+#: addons/metadata/static/files.js:863 addons/metadata/static/files.js:870
 msgid "No name"
 msgstr ""
 
-#: addons/metadata/static/files.js:840
+#: addons/metadata/static/files.js:930
 msgid ""
 "There is no draft project metadata compliant with the schema. Create new "
 "draft project metadata from the Metadata tab:"
 msgstr ""
 
-#: addons/metadata/static/files.js:842 addons/metadata/static/files.js:1008
+#: addons/metadata/static/files.js:932 addons/metadata/static/files.js:1100
 msgid "Open"
 msgstr ""
 
-#: addons/metadata/static/files.js:941
+#: addons/metadata/static/files.js:1031
 msgid "There are errors in some fields."
 msgstr ""
 
-#: addons/metadata/static/files.js:975 addons/metadata/static/files.js:1584
-#: addons/metadata/static/files.js:1609 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:1065 addons/metadata/static/files.js:1933
+#: addons/metadata/static/files.js:1959 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr ""
 
-#: addons/metadata/static/files.js:979
+#: addons/metadata/static/files.js:1069
 msgid "Select the destination for the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1000
+#: addons/metadata/static/files.js:1090
 msgid "Registering..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1000
+#: addons/metadata/static/files.js:1090
 msgid "Deleting..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1040 addons/metadata/static/files.js:1505
-#: addons/metadata/static/files.js:1561 addons/metadata/static/files.js:1582
-#: addons/metadata/static/files.js:1607
-#: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
+#: addons/metadata/static/files.js:1133 addons/metadata/static/files.js:1781
+#: addons/metadata/static/files.js:1856 addons/metadata/static/files.js:1903
+#: addons/metadata/static/files.js:1931 addons/metadata/static/files.js:1957
+#: addons/metadata/static/files.js:2013
+#: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2333
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
 #: website/static/js/pages/project-settings-page.js:118
 msgid "Close"
 msgstr ""
 
-#: addons/metadata/static/files.js:1092
+#: addons/metadata/static/files.js:1186
 msgid "View Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1102
+#: addons/metadata/static/files.js:1196
 msgid "Edit Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1111
+#: addons/metadata/static/files.js:1205
 msgid "Register Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1119
+#: addons/metadata/static/files.js:1213
 msgid "Delete Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1256
+#: addons/metadata/static/files.js:1261
+msgid "Edit Multiple Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1271
+msgid "Loading Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1407
 msgid "Metadata is defined"
 msgstr ""
 
-#: addons/metadata/static/files.js:1265
+#: addons/metadata/static/files.js:1416
 msgid "Some of the children have metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1275
+#: addons/metadata/static/files.js:1426
 msgid "File not found: "
 msgstr ""
 
-#: addons/metadata/static/files.js:1509 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1785 addons/metadata/static/files.js:1858
+#: website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr ""
 
-#: addons/metadata/static/files.js:1514 addons/metadata/static/files.js:1613
+#: addons/metadata/static/files.js:1797 addons/metadata/static/files.js:1979
 msgid "Copy to clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:1527
+#: addons/metadata/static/files.js:1812
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr ""
 
-#: addons/metadata/static/files.js:1533
+#: addons/metadata/static/files.js:1818
 msgid "Edit File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1533
+#: addons/metadata/static/files.js:1818
 msgid "View File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1563 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1838 addons/metadata/static/files.js:1890
+#: website/static/js/saveManager.js:24
+msgid "You have unsaved changes."
+msgstr ""
+
+#: addons/metadata/static/files.js:1873
+msgid "Edit Multiple File Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1905 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr ""
 
-#: addons/metadata/static/files.js:1569
+#: addons/metadata/static/files.js:1918
 msgid "Delete File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1574
+#: addons/metadata/static/files.js:1923
 msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr ""
 
-#: addons/metadata/static/files.js:1591
+#: addons/metadata/static/files.js:1940
 msgid "Select a destination for file metadata registration"
 msgstr ""
 
-#: addons/metadata/static/files.js:1623
+#: addons/metadata/static/files.js:1989
 msgid "Fix file metadata"
 msgstr ""
 
+#: addons/metadata/static/files.js:2018
+msgid "Paste Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:2023
+msgid "Press Ctrl-V (Command-V) to paste."
+msgstr ""
+
+#: addons/metadata/static/files.js:2025
+msgid ""
+"[Why is this needed?] In this browser, retrieving clipboard values with "
+"button operations is prohibited. Therefore, you must explicitly indicate "
+"clipboard operations by using the shortcut key or by pasting in the "
+"browser menu."
+msgstr ""
+
 #: addons/metadata/static/metadata-fields.js:43
-#: addons/metadata/static/metadata-fields.js:188
+#: addons/metadata/static/metadata-fields.js:199
 msgid "This field can't be blank."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:194
+#: addons/metadata/static/metadata-fields.js:207
+msgid "(Not Modified)"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:210
 msgid "Choose..."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:371
+#: addons/metadata/static/metadata-fields.js:284
+msgid "Clear"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:342
+#: addons/metadata/static/metadata-fields.js:351
+msgid "Show example"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:355
+msgid "Hide example"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:485
 msgid "Calculate"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:422
+#: addons/metadata/static/metadata-fields.js:544
 msgid "Fill"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:449
+#: addons/metadata/static/metadata-fields.js:577
 msgid "No members"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:516
+#: addons/metadata/static/metadata-fields.js:644
 msgid "e-Rad Researcher Number"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:517
+#: addons/metadata/static/metadata-fields.js:645
 msgid "Name (Japanese)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:518
+#: addons/metadata/static/metadata-fields.js:646
 msgid "Name (English)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:532
+#: addons/metadata/static/metadata-fields.js:660
 #: website/static/js/myProjects.js:1565
 msgid "Add"
 msgstr ""

--- a/website/translations/ja/LC_MESSAGES/js_messages.po
+++ b/website/translations/ja/LC_MESSAGES/js_messages.po
@@ -22,191 +22,202 @@ msgstr ""
 msgid "Launch"
 msgstr "起動"
 
-#: addons/metadata/static/files.js:335
+#: addons/metadata/static/files.js:339
 msgid "Metadata Schema:"
 msgstr "メタデータ様式:"
 
-#: addons/metadata/static/files.js:493
+#: addons/metadata/static/files.js:498
 msgid "Paste from Clipboard"
 msgstr "クリップボードから貼り付け"
 
-#: addons/metadata/static/files.js:518 addons/metadata/static/files.js:532
+#: addons/metadata/static/files.js:587 addons/metadata/static/files.js:601
 #: website/static/js/fangorn.js:1516
 msgid "Could not copy text"
 msgstr "テキストをコピーできませんでした"
 
-#: addons/metadata/static/files.js:530 website/static/js/clipboard.js:27
+#: addons/metadata/static/files.js:599 website/static/js/clipboard.js:27
 #: website/static/js/fangorn.js:1510 website/static/js/fangorn.js:1514
 msgid "Copied!"
 msgstr "コピーされました！"
 
-#: addons/metadata/static/files.js:556 addons/metadata/static/files.js:571
+#: addons/metadata/static/files.js:625 addons/metadata/static/files.js:640
 msgid "Could not paste text"
 msgstr "テキストを貼り付けできませんでした"
 
-#: addons/metadata/static/files.js:621 addons/metadata/static/files.js:635
-#: addons/metadata/static/files.js:985
+#: addons/metadata/static/files.js:690 addons/metadata/static/files.js:704
+#: addons/metadata/static/files.js:1054
 msgid "Loading..."
 msgstr "読み込み中..."
 
-#: addons/metadata/static/files.js:633
+#: addons/metadata/static/files.js:702
 msgid "Select the destination of the file metadata."
 msgstr "ファイルメタデータの移動先を選択してください。"
 
-#: addons/metadata/static/files.js:638
+#: addons/metadata/static/files.js:707
 msgid "Current Metadata:"
 msgstr "現在のメタデータ:"
 
-#: addons/metadata/static/files.js:694
+#: addons/metadata/static/files.js:763
 msgid "Delete metadata"
 msgstr "メタデータを削除"
 
-#: addons/metadata/static/files.js:697
+#: addons/metadata/static/files.js:766
 msgid "Could not list hashes"
 msgstr "ハッシュ情報の一覧を取得できませんでした"
 
-#: addons/metadata/static/files.js:705
-#: addons/metadata/static/metadata-fields.js:343
-#: addons/metadata/static/metadata-fields.js:348
+#: addons/metadata/static/files.js:774
+#: addons/metadata/static/metadata-fields.js:455
+#: addons/metadata/static/metadata-fields.js:460
 msgid "Could not list files"
 msgstr "ファイルの一覧を取得できませんでした"
 
-#: addons/metadata/static/files.js:794 addons/metadata/static/files.js:801
+#: addons/metadata/static/files.js:863 addons/metadata/static/files.js:870
 msgid "No name"
 msgstr "名称未設定"
 
-#: addons/metadata/static/files.js:861
+#: addons/metadata/static/files.js:930
 msgid ""
 "There is no draft project metadata compliant with the schema. Create new "
 "draft project metadata from the Metadata tab:"
 msgstr "スキーマに対応するプロジェクトメタデータの下書きがありません。メタデータ タブから新規プロジェクトメタデータを作成してください:"
 
-#: addons/metadata/static/files.js:863 addons/metadata/static/files.js:1031
+#: addons/metadata/static/files.js:932 addons/metadata/static/files.js:1100
 msgid "Open"
 msgstr "開く"
 
-#: addons/metadata/static/files.js:962
+#: addons/metadata/static/files.js:1031
 msgid "There are errors in some fields."
 msgstr "いくつかのフィールドにエラーがあります。"
 
-#: addons/metadata/static/files.js:996 addons/metadata/static/files.js:1636
-#: addons/metadata/static/files.js:1662 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:1065 addons/metadata/static/files.js:1933
+#: addons/metadata/static/files.js:1959 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr "選択"
 
-#: addons/metadata/static/files.js:1000
+#: addons/metadata/static/files.js:1069
 msgid "Select the destination for the file metadata."
 msgstr "ファイルメタデータの登録先を選択してください。"
 
-#: addons/metadata/static/files.js:1021
+#: addons/metadata/static/files.js:1090
 msgid "Registering..."
 msgstr "登録中..."
 
-#: addons/metadata/static/files.js:1021
+#: addons/metadata/static/files.js:1090
 msgid "Deleting..."
 msgstr "削除中..."
 
-#: addons/metadata/static/files.js:1064 addons/metadata/static/files.js:1537
-#: addons/metadata/static/files.js:1606 addons/metadata/static/files.js:1634
-#: addons/metadata/static/files.js:1660 addons/metadata/static/files.js:1716
-#: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
+#: addons/metadata/static/files.js:1133 addons/metadata/static/files.js:1781
+#: addons/metadata/static/files.js:1856 addons/metadata/static/files.js:1903
+#: addons/metadata/static/files.js:1931 addons/metadata/static/files.js:1957
+#: addons/metadata/static/files.js:2013
+#: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2333
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
 #: website/static/js/pages/project-settings-page.js:118
 msgid "Close"
 msgstr "閉じる"
 
-#: addons/metadata/static/files.js:1098
-msgid "Loading Metadata"
-msgstr "メタデータ読み込み中"
-
-#: addons/metadata/static/files.js:1123
+#: addons/metadata/static/files.js:1186
 msgid "View Metadata"
 msgstr "メタデータ確認"
 
-#: addons/metadata/static/files.js:1133
+#: addons/metadata/static/files.js:1196
 msgid "Edit Metadata"
 msgstr "メタデータ編集"
 
-#: addons/metadata/static/files.js:1142
+#: addons/metadata/static/files.js:1205
 msgid "Register Metadata"
 msgstr "メタデータ登録"
 
-#: addons/metadata/static/files.js:1150
+#: addons/metadata/static/files.js:1213
 msgid "Delete Metadata"
 msgstr "メタデータ削除"
 
-#: addons/metadata/static/files.js:1287
+#: addons/metadata/static/files.js:1261
+msgid "Edit Multiple Metadata"
+msgstr "メタデータ複数編集"
+
+#: addons/metadata/static/files.js:1271
+msgid "Loading Metadata"
+msgstr "メタデータ読み込み中"
+
+#: addons/metadata/static/files.js:1407
 msgid "Metadata is defined"
 msgstr "メタデータが定義されています"
 
-#: addons/metadata/static/files.js:1296
+#: addons/metadata/static/files.js:1416
 msgid "Some of the children have metadata."
 msgstr "いくつかの子ファイルにメタデータが定義されています。"
 
-#: addons/metadata/static/files.js:1306
+#: addons/metadata/static/files.js:1426
 msgid "File not found: "
 msgstr "ファイルが見つかりません:"
 
-#: addons/metadata/static/files.js:1541 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1785 addons/metadata/static/files.js:1858
+#: website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr "保存"
 
-#: addons/metadata/static/files.js:1553 addons/metadata/static/files.js:1682
+#: addons/metadata/static/files.js:1797 addons/metadata/static/files.js:1979
 msgid "Copy to clipboard"
 msgstr "クリップボードにコピー"
 
-#: addons/metadata/static/files.js:1566
+#: addons/metadata/static/files.js:1812
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr "ファイルのリネーム、ファイルやディレクトリの移動、ディレクトリ階層の変更を行うと、入力したメタデータの関連付けが解除される場合があります。"
 
-#: addons/metadata/static/files.js:1572
+#: addons/metadata/static/files.js:1818
 msgid "Edit File Metadata"
 msgstr "ファイルメタデータの編集"
 
-#: addons/metadata/static/files.js:1572
+#: addons/metadata/static/files.js:1818
 msgid "View File Metadata"
 msgstr "ファイルメタデータの参照"
 
-#: addons/metadata/static/files.js:1592 website/static/js/saveManager.js:24
+#: addons/metadata/static/files.js:1838 addons/metadata/static/files.js:1890
+#: website/static/js/saveManager.js:24
 msgid "You have unsaved changes."
 msgstr "未保存の変更があります。"
 
-#: addons/metadata/static/files.js:1608 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1873
+msgid "Edit Multiple File Metadata"
+msgstr "ファイルメタデータの複数編集"
+
+#: addons/metadata/static/files.js:1905 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr "削除"
 
-#: addons/metadata/static/files.js:1621
+#: addons/metadata/static/files.js:1918
 msgid "Delete File Metadata"
 msgstr "ファイルメタデータの削除"
 
-#: addons/metadata/static/files.js:1626
+#: addons/metadata/static/files.js:1923
 msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr "メタデータを削除してよろしいですか？この操作は元に戻せません。"
 
-#: addons/metadata/static/files.js:1643
+#: addons/metadata/static/files.js:1940
 msgid "Select a destination for file metadata registration"
 msgstr "ファイルメタデータ登録先の選択"
 
-#: addons/metadata/static/files.js:1692
+#: addons/metadata/static/files.js:1989
 msgid "Fix file metadata"
 msgstr "ファイルメタデータの修正"
 
-#: addons/metadata/static/files.js:1722
+#: addons/metadata/static/files.js:2018
 msgid "Paste Metadata"
 msgstr "メタデータ貼り付け"
 
-#: addons/metadata/static/files.js:1727
+#: addons/metadata/static/files.js:2023
 msgid "Press Ctrl-V (Command-V) to paste."
 msgstr "クリップボードから貼り付けるために Ctrl-V (Command-V) を押してください。"
 
-#: addons/metadata/static/files.js:1729
+#: addons/metadata/static/files.js:2025
 msgid ""
 "[Why is this needed?] In this browser, retrieving clipboard values with "
 "button operations is prohibited. Therefore, you must explicitly indicate "
@@ -217,39 +228,56 @@ msgstr ""
 "このブラウザでは、ボタン操作でのクリップボードの値取得が禁止されています。そのため、ショートカットキーまたはブラウザメニューの貼り付けにより明示的にクリップボード操作を指示する必要があります。"
 
 #: addons/metadata/static/metadata-fields.js:43
-#: addons/metadata/static/metadata-fields.js:188
+#: addons/metadata/static/metadata-fields.js:199
 msgid "This field can't be blank."
 msgstr "このフィールドは必須項目です。"
 
-#: addons/metadata/static/metadata-fields.js:194
+#: addons/metadata/static/metadata-fields.js:207
+msgid "(Not Modified)"
+msgstr "(変更なし)"
+
+#: addons/metadata/static/metadata-fields.js:210
 msgid "Choose..."
 msgstr "選択..."
 
-#: addons/metadata/static/metadata-fields.js:371
+#: addons/metadata/static/metadata-fields.js:284
+msgid "Clear"
+msgstr "クリア"
+
+#: addons/metadata/static/metadata-fields.js:342
+#: addons/metadata/static/metadata-fields.js:351
+msgid "Show example"
+msgstr "サンプル表示"
+
+#: addons/metadata/static/metadata-fields.js:355
+msgid "Hide example"
+msgstr "サンプル非表示"
+
+#: addons/metadata/static/metadata-fields.js:485
 msgid "Calculate"
 msgstr "集計"
 
-#: addons/metadata/static/metadata-fields.js:422
+#: addons/metadata/static/metadata-fields.js:544
 msgid "Fill"
 msgstr "入力"
 
-#: addons/metadata/static/metadata-fields.js:449
+#: addons/metadata/static/metadata-fields.js:577
 msgid "No members"
 msgstr "作成者が設定されていません"
 
-#: addons/metadata/static/metadata-fields.js:516
+#: addons/metadata/static/metadata-fields.js:644
 msgid "e-Rad Researcher Number"
 msgstr "e-Rad研究者番号"
 
-#: addons/metadata/static/metadata-fields.js:517
+#: addons/metadata/static/metadata-fields.js:645
 msgid "Name (Japanese)"
 msgstr "名前 (日本語)"
 
-#: addons/metadata/static/metadata-fields.js:518
+#: addons/metadata/static/metadata-fields.js:646
 msgid "Name (English)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:532
+#: addons/metadata/static/metadata-fields.js:660
 #: website/static/js/myProjects.js:1565
 msgid "Add"
 msgstr "追加"

--- a/website/translations/js_messages.pot
+++ b/website/translations/js_messages.pot
@@ -21,191 +21,202 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: addons/metadata/static/files.js:335
+#: addons/metadata/static/files.js:339
 msgid "Metadata Schema:"
 msgstr ""
 
-#: addons/metadata/static/files.js:493
+#: addons/metadata/static/files.js:498
 msgid "Paste from Clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:518 addons/metadata/static/files.js:532
+#: addons/metadata/static/files.js:587 addons/metadata/static/files.js:601
 #: website/static/js/fangorn.js:1516
 msgid "Could not copy text"
 msgstr ""
 
-#: addons/metadata/static/files.js:530 website/static/js/clipboard.js:27
+#: addons/metadata/static/files.js:599 website/static/js/clipboard.js:27
 #: website/static/js/fangorn.js:1510 website/static/js/fangorn.js:1514
 msgid "Copied!"
 msgstr ""
 
-#: addons/metadata/static/files.js:556 addons/metadata/static/files.js:571
+#: addons/metadata/static/files.js:625 addons/metadata/static/files.js:640
 msgid "Could not paste text"
 msgstr ""
 
-#: addons/metadata/static/files.js:621 addons/metadata/static/files.js:635
-#: addons/metadata/static/files.js:985
+#: addons/metadata/static/files.js:690 addons/metadata/static/files.js:704
+#: addons/metadata/static/files.js:1054
 msgid "Loading..."
 msgstr ""
 
-#: addons/metadata/static/files.js:633
+#: addons/metadata/static/files.js:702
 msgid "Select the destination of the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:638
+#: addons/metadata/static/files.js:707
 msgid "Current Metadata:"
 msgstr ""
 
-#: addons/metadata/static/files.js:694
+#: addons/metadata/static/files.js:763
 msgid "Delete metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:697
+#: addons/metadata/static/files.js:766
 msgid "Could not list hashes"
 msgstr ""
 
-#: addons/metadata/static/files.js:705
-#: addons/metadata/static/metadata-fields.js:343
-#: addons/metadata/static/metadata-fields.js:348
+#: addons/metadata/static/files.js:774
+#: addons/metadata/static/metadata-fields.js:455
+#: addons/metadata/static/metadata-fields.js:460
 msgid "Could not list files"
 msgstr ""
 
-#: addons/metadata/static/files.js:794 addons/metadata/static/files.js:801
+#: addons/metadata/static/files.js:863 addons/metadata/static/files.js:870
 msgid "No name"
 msgstr ""
 
-#: addons/metadata/static/files.js:861
+#: addons/metadata/static/files.js:930
 msgid ""
 "There is no draft project metadata compliant with the schema. Create new "
 "draft project metadata from the Metadata tab:"
 msgstr ""
 
-#: addons/metadata/static/files.js:863 addons/metadata/static/files.js:1031
+#: addons/metadata/static/files.js:932 addons/metadata/static/files.js:1100
 msgid "Open"
 msgstr ""
 
-#: addons/metadata/static/files.js:962
+#: addons/metadata/static/files.js:1031
 msgid "There are errors in some fields."
 msgstr ""
 
-#: addons/metadata/static/files.js:996 addons/metadata/static/files.js:1636
-#: addons/metadata/static/files.js:1662 website/static/js/folderpicker.js:105
+#: addons/metadata/static/files.js:1065 addons/metadata/static/files.js:1933
+#: addons/metadata/static/files.js:1959 website/static/js/folderpicker.js:105
 msgid "Select"
 msgstr ""
 
-#: addons/metadata/static/files.js:1000
+#: addons/metadata/static/files.js:1069
 msgid "Select the destination for the file metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1021
+#: addons/metadata/static/files.js:1090
 msgid "Registering..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1021
+#: addons/metadata/static/files.js:1090
 msgid "Deleting..."
 msgstr ""
 
-#: addons/metadata/static/files.js:1064 addons/metadata/static/files.js:1537
-#: addons/metadata/static/files.js:1606 addons/metadata/static/files.js:1634
-#: addons/metadata/static/files.js:1660 addons/metadata/static/files.js:1716
-#: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2326
+#: addons/metadata/static/files.js:1133 addons/metadata/static/files.js:1781
+#: addons/metadata/static/files.js:1856 addons/metadata/static/files.js:1903
+#: addons/metadata/static/files.js:1931 addons/metadata/static/files.js:1957
+#: addons/metadata/static/files.js:2013
+#: website/static/js/accountSettings.js:267 website/static/js/fangorn.js:2333
 #: website/static/js/folderPickerNodeConfig.js:591
 #: website/static/js/pages/profile-settings-addons-page.js:72
 #: website/static/js/pages/project-settings-page.js:118
 msgid "Close"
 msgstr ""
 
-#: addons/metadata/static/files.js:1098
-msgid "Loading Metadata"
-msgstr ""
-
-#: addons/metadata/static/files.js:1123
+#: addons/metadata/static/files.js:1186
 msgid "View Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1133
+#: addons/metadata/static/files.js:1196
 msgid "Edit Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1142
+#: addons/metadata/static/files.js:1205
 msgid "Register Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1150
+#: addons/metadata/static/files.js:1213
 msgid "Delete Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1287
+#: addons/metadata/static/files.js:1261
+msgid "Edit Multiple Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1271
+msgid "Loading Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1407
 msgid "Metadata is defined"
 msgstr ""
 
-#: addons/metadata/static/files.js:1296
+#: addons/metadata/static/files.js:1416
 msgid "Some of the children have metadata."
 msgstr ""
 
-#: addons/metadata/static/files.js:1306
+#: addons/metadata/static/files.js:1426
 msgid "File not found: "
 msgstr ""
 
-#: addons/metadata/static/files.js:1541 website/static/js/contribManager.js:440
+#: addons/metadata/static/files.js:1785 addons/metadata/static/files.js:1858
+#: website/static/js/contribManager.js:440
 #: website/static/js/filepage/editor.js:180
 msgid "Save"
 msgstr ""
 
-#: addons/metadata/static/files.js:1553 addons/metadata/static/files.js:1682
+#: addons/metadata/static/files.js:1797 addons/metadata/static/files.js:1979
 msgid "Copy to clipboard"
 msgstr ""
 
-#: addons/metadata/static/files.js:1566
+#: addons/metadata/static/files.js:1812
 msgid ""
 "Renaming, moving the file/directory, or changing the directory hierarchy "
 "can break the association of the metadata you have added."
 msgstr ""
 
-#: addons/metadata/static/files.js:1572
+#: addons/metadata/static/files.js:1818
 msgid "Edit File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1572
+#: addons/metadata/static/files.js:1818
 msgid "View File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1592 website/static/js/saveManager.js:24
+#: addons/metadata/static/files.js:1838 addons/metadata/static/files.js:1890
+#: website/static/js/saveManager.js:24
 msgid "You have unsaved changes."
 msgstr ""
 
-#: addons/metadata/static/files.js:1608 website/static/js/fangorn.js:1226
+#: addons/metadata/static/files.js:1873
+msgid "Edit Multiple File Metadata"
+msgstr ""
+
+#: addons/metadata/static/files.js:1905 website/static/js/fangorn.js:1226
 #: website/static/js/fangorn.js:1249 website/static/js/fangorn.js:2056
 #: website/static/js/fangorn.js:2092 website/static/js/filepage/index.js:204
 #: website/static/js/filepage/index.js:517 website/static/js/myProjects.js:1637
 msgid "Delete"
 msgstr ""
 
-#: addons/metadata/static/files.js:1621
+#: addons/metadata/static/files.js:1918
 msgid "Delete File Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1626
+#: addons/metadata/static/files.js:1923
 msgid "Do you want to delete metadata? This operation cannot be undone."
 msgstr ""
 
-#: addons/metadata/static/files.js:1643
+#: addons/metadata/static/files.js:1940
 msgid "Select a destination for file metadata registration"
 msgstr ""
 
-#: addons/metadata/static/files.js:1692
+#: addons/metadata/static/files.js:1989
 msgid "Fix file metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1722
+#: addons/metadata/static/files.js:2018
 msgid "Paste Metadata"
 msgstr ""
 
-#: addons/metadata/static/files.js:1727
+#: addons/metadata/static/files.js:2023
 msgid "Press Ctrl-V (Command-V) to paste."
 msgstr ""
 
-#: addons/metadata/static/files.js:1729
+#: addons/metadata/static/files.js:2025
 msgid ""
 "[Why is this needed?] In this browser, retrieving clipboard values with "
 "button operations is prohibited. Therefore, you must explicitly indicate "
@@ -214,39 +225,56 @@ msgid ""
 msgstr ""
 
 #: addons/metadata/static/metadata-fields.js:43
-#: addons/metadata/static/metadata-fields.js:188
+#: addons/metadata/static/metadata-fields.js:199
 msgid "This field can't be blank."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:194
+#: addons/metadata/static/metadata-fields.js:207
+msgid "(Not Modified)"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:210
 msgid "Choose..."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:371
+#: addons/metadata/static/metadata-fields.js:284
+msgid "Clear"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:342
+#: addons/metadata/static/metadata-fields.js:351
+msgid "Show example"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:355
+msgid "Hide example"
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:485
 msgid "Calculate"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:422
+#: addons/metadata/static/metadata-fields.js:544
 msgid "Fill"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:449
+#: addons/metadata/static/metadata-fields.js:577
 msgid "No members"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:516
+#: addons/metadata/static/metadata-fields.js:644
 msgid "e-Rad Researcher Number"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:517
+#: addons/metadata/static/metadata-fields.js:645
 msgid "Name (Japanese)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:518
+#: addons/metadata/static/metadata-fields.js:646
 msgid "Name (English)"
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:532
+#: addons/metadata/static/metadata-fields.js:660
 #: website/static/js/myProjects.js:1565
 msgid "Add"
 msgstr ""


### PR DESCRIPTION
## Purpose
メタデータアドオンに関する修正です。

## Changes
- [GRDM-34192] ファイルメタデータのライセンス入力フォームをグループ付きのセレクトボックスに変更しました。 4045884
- [GRDM-34192] metadata schema の help プロパティを実装しました 004a67d
- [GRDM-34193] クリップボードコピー押下後のメッセージ表示位置修正を左寄せに修正しました。 fd50f1b
- [GRDM-34195] ファイルメタデータの複数編集機能を実装しました。c78d7de edab4f9 329601d 07cb76d
- metadata schema を変更したため migration file を追加しています。 0762767
- クリップボードから貼り付け後に保存できない不具合があったため修正しました fd50f1b

## QA Notes
None

## Documentation
None

## Side Effects
None

## Ticket
GRDM-34192, GRDM-34193, GRDM-34195