### PR TITLE
To prevent access if the user is not authenticated

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -156,12 +156,12 @@
                       <li><a href="{% url 'users:known-ham' %}"><i class="fa fa-star"></i><span> {% trans "Known Ham" %}</span> </a></li>
                   </ul>
               </div>
+              <li class="{% if request.resolver_match.url_name == 'search' %}active{% endif %}">
+                  <a href="{% url 'user-emails:search' %}">
+                      <i class='fa fa-link'></i> <span> {% trans "RDM" %} {% trans "User Emails" %}</span>
+                  </a>
+              </li>
           {% endif %}
-          <li>
-              <a href="{% url 'user-emails:search' %}">
-                  <i class='fa fa-link'></i> <span> {% trans "RDM" %} {% trans "User Emails" %}</span>
-              </a>
-          </li>
           {% if perms.osf.view_spam %}
             <li><a href="{% url 'spam:spam' %}"><i class='fa fa-link'></i> <span>{% trans "RDM Spam" %}</span></a></li>
           {% endif %}

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -156,6 +156,8 @@
                       <li><a href="{% url 'users:known-ham' %}"><i class="fa fa-star"></i><span> {% trans "Known Ham" %}</span> </a></li>
                   </ul>
               </div>
+          {% endif %}
+          {% if user.is_superuser or user.is_staff %}
               <li class="{% if request.resolver_match.url_name == 'search' %}active{% endif %}">
                   <a href="{% url 'user-emails:search' %}">
                       <i class='fa fa-link'></i> <span> {% trans "RDM" %} {% trans "User Emails" %}</span>

--- a/admin/templates/user_emails/user_emails.html
+++ b/admin/templates/user_emails/user_emails.html
@@ -73,15 +73,15 @@
                     <tbody>
                     <tr>
                         <td class="w-label nowrap"><strong>{% trans "Name" %}</strong></td>
-                        <td>{{ user.name }}</td>
+                        <td>{{ osf_user.name }}</td>
                     </tr>
                     <tr>
                         <td class="w-label nowrap"><strong>{% trans "Username" %}</strong></td>
-                        <td>{{ user.username }}</td>
+                        <td>{{ osf_user.username }}</td>
                     </tr>
                     <tr>
                         <td class="w-label nowrap"><strong>{% trans "EPPN" %}</strong></td>
-                        <td>{{ user.eppn }}</td>
+                        <td>{{ osf_user.eppn }}</td>
                     </tr>
                     </tbody>
                 </table>
@@ -93,9 +93,9 @@
                     <tr>
                         <td class="w-label nowrap"><strong>{% trans "Affiliation" %}</strong></td>
                         <td>
-                            {% if user.affiliations is not None %}
+                            {% if osf_user.affiliations is not None %}
                                 <ul style="max-height: 6em; overflow: auto; padding-left: 1em; margin: 0;">
-                                    {% for affiliation in user.affiliations %}
+                                    {% for affiliation in osf_user.affiliations %}
                                         <li>{{ affiliation.name }}</li>
                                     {% endfor %}
                                 </ul>
@@ -113,7 +113,7 @@
             </div>
             <div class="col-md-12 clearfix">
                 <form class="form-inline flex-container"
-                      method="POST" action="{% url 'user-emails:primary' user.id %}"
+                      method="POST" action="{% url 'user-emails:primary' osf_user.id %}"
                       onsubmit="return validateForm()"
                       style="margin-top: 15px; margin-bottom: 15px; ">
                     <div class="form-group flex-item">
@@ -137,13 +137,13 @@
                 <table class="table table-striped table-hover table-responsive">
                     <thead></thead>
                     <tbody>
-                    {% for email in user.emails %}
+                    {% for email in osf_user.emails %}
                         <tr>
                             <td>
-                                {% if email == user.username %}
+                                {% if email == osf_user.username %}
                                     <button type="button" class="btn btn-default disabled">{% trans "Primary" %}</button>
                                 {% else %}
-                                    <form id="set_primary_{{ email.id }}" method="POST" action="{% url 'user-emails:primary' user.id %}">
+                                    <form id="set_primary_{{ email.id }}" method="POST" action="{% url 'user-emails:primary' osf_user.id %}">
                                         {% csrf_token %}
                                         <input type="hidden" name="primary_email" value="{{ email }}">
                                         <button type="submit" class="btn btn-primary">{% trans "Set Primary" %}</button>

--- a/admin/user_emails/views.py
+++ b/admin/user_emails/views.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import logging
 
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db.models import Q
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -23,10 +24,10 @@ from website import settings
 logger = logging.getLogger(__name__)
 
 
-class UserEmailsFormView(RdmPermissionMixin, FormView):
+class UserEmailsFormView(PermissionRequiredMixin, RdmPermissionMixin, FormView):
     template_name = 'user_emails/search.html'
     object_type = 'osfuser'
-    permission_required = ()
+    permission_required = 'osf.view_osfuser'
     raise_exception = True
     form_class = UserEmailsSearchForm
 
@@ -67,7 +68,7 @@ class UserEmailsFormView(RdmPermissionMixin, FormView):
         return self.redirect_url
 
 
-class UserEmailsSearchList(RdmPermissionMixin, ListView):
+class UserEmailsSearchList(PermissionRequiredMixin, RdmPermissionMixin, ListView):
     template_name = 'user_emails/user_list.html'
     permission_required = 'osf.view_osfuser'
     raise_exception = True
@@ -109,7 +110,7 @@ class UserEmailsSearchList(RdmPermissionMixin, ListView):
         return super(UserEmailsSearchList, self).get_context_data(**kwargs)
 
 
-class UserEmailsView(RdmPermissionMixin, GuidView):
+class UserEmailsView(PermissionRequiredMixin, RdmPermissionMixin, GuidView):
     template_name = 'user_emails/user_emails.html'
     context_object_name = 'user'
     permission_required = 'osf.view_osfuser'
@@ -144,7 +145,7 @@ class UserEmailsView(RdmPermissionMixin, GuidView):
         }
 
 
-class UserPrimaryEmail(RdmPermissionMixin, View):
+class UserPrimaryEmail(PermissionRequiredMixin, RdmPermissionMixin, View):
     permission_required = 'osf.view_osfuser'
     raise_exception = True
 

--- a/admin/user_emails/views.py
+++ b/admin/user_emails/views.py
@@ -148,8 +148,7 @@ class UserEmailsView(RdmAdminRequiredMixin, GuidView):
 
         if self.is_admin:
             now_institutions_id = list(request_user.affiliated_institutions.all().values_list('pk', flat=True))
-            all_institution_users_id = list(
-                OSFUser.objects.filter(affiliated_institutions__in=now_institutions_id).distinct().values_list('pk', flat=True))
+            all_institution_users_id = list(OSFUser.objects.filter(affiliated_institutions__in=now_institutions_id).distinct().values_list('pk', flat=True))
 
             if user.pk not in all_institution_users_id:
                 return self.handle_no_permission()
@@ -175,8 +174,7 @@ class UserPrimaryEmail(RdmAdminRequiredMixin, View):
 
         if self.is_admin:
             now_institutions_id = list(request_user.affiliated_institutions.all().values_list('pk', flat=True))
-            all_institution_users_id = list(
-                OSFUser.objects.filter(affiliated_institutions__in=now_institutions_id).distinct().values_list('pk', flat=True))
+            all_institution_users_id = list(OSFUser.objects.filter(affiliated_institutions__in=now_institutions_id).distinct().values_list('pk', flat=True))
 
             if user.pk not in all_institution_users_id:
                 return permission_denied(self.request, Exception('You cannot access this specific page'))

--- a/admin_tests/user_emails/test_views.py
+++ b/admin_tests/user_emails/test_views.py
@@ -162,8 +162,8 @@ class TestUserEmailsFormView(AdminTestCase):
         email = 'test@mail.com'
         data = {'name': name, 'email': email}
 
-        mockOSFUser.filter.return_value.filter.return_value. \
-            distinct.return_value.get. \
+        mockOSFUser.filter.return_value.filter.return_value.\
+            distinct.return_value.get.\
             side_effect = OSFUser.MultipleObjectsReturned
 
         form = UserEmailsSearchForm(data=data)

--- a/admin_tests/user_emails/test_views.py
+++ b/admin_tests/user_emails/test_views.py
@@ -365,7 +365,6 @@ class TestUserEmailsView(AdminTestCase):
         self.user.is_staff = True
         self.request.user = self.user
         self.view.request = self.request
-        view = views.UserEmailsView
 
         with nt.assert_raises(PermissionDenied):
             self.view.get_object()

--- a/admin_tests/user_emails/test_views.py
+++ b/admin_tests/user_emails/test_views.py
@@ -339,7 +339,9 @@ class TestUserEmailsView(AdminTestCase):
         self.view.request = self.request
         result = self.view.get_object()
         view = views.UserEmailsView
-        view.is_admin = True
+        view_permission = Permission.objects.get(codename='view_osfuser')
+        self.user.user_permissions.add(view_permission)
+        self.user.save()
 
         response = view.as_view()(
             self.request,
@@ -483,8 +485,9 @@ class TestUserPrimaryEmail(AdminTestCase):
         user.affiliated_institutions.add(institution)
         request.user = user
 
-        # view = views.UserPrimaryEmail
-        # view.is_admin = True
+        view_permission = Permission.objects.get(codename='view_osfuser')
+        user.user_permissions.add(view_permission)
+        user.save()
 
         response = self.view(
             request,


### PR DESCRIPTION
Fixed bug: check user permissions to prevent access if the user is not authenticated

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fixed bug.
- To prevent access if the user is not authenticated.
- Only permitted if the superuser or administrator
- On User detail screen, display menu on header and left-sidebar for authenticated user

## Changes

~Add permission definition `permission_required = 'osf.view_osfuser'`, and add `PermissionRequiredMixin` to the inherited class list of the following View classes.~
Use the `UserPassesTestMixin`, and `RdmPermissionMixin` classes to check the permission of the authenticated users whose `is_super_admin == True` or `is_admin == True`
  - UserEmailsFormView
  - UserEmailsSearchList
  - UserEmailsView
  - UserPrimaryEmail

## QA Notes

  - No data migration


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
