### PR TITLE
Fixed bug: Fail when uploading folder on macOS

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1287,7 +1287,7 @@ function _uploadFolderEvent(event, item, mode, col) {
             // });
             var child = null;
             for(var j = 0; j < node_parent.children.length; j++){
-                if(node_parent.children[j].data.materialized === currentFolderPath){
+                if(encodeURI(node_parent.children[j].data.materialized) === encodeURI(currentFolderPath)){
                     child = node_parent.children[j];
                     break;
                 }
@@ -1301,7 +1301,7 @@ function _uploadFolderEvent(event, item, mode, col) {
             if (currentFolder && created_path.includes(currentFolderPath)) {
                 // console.log('currentFolder.parent', currentFolder.parent);
                 var new_next_folder_index = ++index;
-                return next(currentFolder.parent, new_next_folder_index, list_paths, file, file_index, next);
+                return next(currentFolder.node_parent, new_next_folder_index, list_paths, file, file_index, next);
             }
 
             created_path.push(currentFolderPath);


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Error case:
On macOS, in the folder upload function, if the folder name contains an NFD normalized concatenated string, the process fails.
When checking whether a folder has been created or not, we compare the current folder with the folders uploaded.
The difference between the two is that the folder name uses a Japanese character string that includes voiced sounds.

Fixed bug.
- Correct unicode normalization method for Japanese character strings.
- Correct the attribute name is taken wrongly

## Changes

website/static/js/fangorn.js
L1290: use encodeURI function
L1304: `currentFolder.parent` -> `currentFolder.node_parent`

## QA Notes

  - No data migration?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
