### PR TITLE
set Dropzone.parallelUploads to 1.(for Dropbox)

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -3489,7 +3489,7 @@ tbOptions = {
         clickable : '#treeGrid',
         addRemoveLinks : false,
         previewTemplate : '<div></div>',
-        parallelUploads : 5,
+        parallelUploads : 1,
         acceptDirectories : false,
         createImageThumbnails : false,
         fallback: function(){},


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Dropboxアドオン利用時にDropboxサーバから `429 too_many_write_operations` のエラーが返却されることがある。
Dropbox側の多重アップロードの制限に抵触しているようなので、フロントエンドからの並列アップロード数を1にする暫定対処を行う。

## Changes

ツリービューコンポーネント内で利用されている `Dropzone` の `parallelUploads` を `1` に変更した。

## Side Effects

ユーザクライアント側から見えるアップロード時のスループットが低下する場合がある。

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/35682
