### PR TITLE
Feature/202303 multi inst storage/not called anywhere2.1.4

### DIFF
--- a/addons/base/tests/utils.py
+++ b/addons/base/tests/utils.py
@@ -1,11 +1,14 @@
 import pytest
-from addons.base.utils import get_mfr_url
+from addons.base.utils import get_mfr_url, get_root_institutional_storage
 
 from addons.osfstorage.tests.utils import StorageTestCase
 from tests.base import OsfTestCase
-from osf_tests.factories import ProjectFactory, UserFactory, RegionFactory, CommentFactory
+from osf_tests.factories import ProjectFactory, UserFactory, RegionFactory, CommentFactory, AuthUserFactory
 from website.settings import MFR_SERVER_URL
 
+from tests.test_websitefiles import TestFolder, TestFile
+from framework.exceptions import HTTPError
+from unittest import mock
 
 class MockFolder(dict, object):
 
@@ -29,7 +32,31 @@ class MockLibrary(dict, object):
 
 
 @pytest.mark.django_db
-class TestAddonsUtils(OsfTestCase):
+class TestAddonsBaseUtils(OsfTestCase):
+
+    def setUp(self):
+        super(TestAddonsBaseUtils, self).setUp()
+        self.user = AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.parent = TestFolder(
+            _path='aparent',
+            name='parent',
+            target=self.node,
+            provider='osf_storage',
+            materialized_path='/long/path/to/name',
+            is_root=True,
+        )
+        self.parent.save()
+        self.file_child = TestFile(
+            _path='afile',
+            name='child',
+            target=self.node,
+            parent_id=self.parent.id,
+            provider='osf_storage',
+            materialized_path='/long/path/to/name',
+        )
+        self.file_child.save()
+
     def test_mfr_url(self):
         user = UserFactory()
         project = ProjectFactory(creator=user)
@@ -37,3 +64,13 @@ class TestAddonsUtils(OsfTestCase):
         assert get_mfr_url(project, 'github') == MFR_SERVER_URL
         assert get_mfr_url(project, 'osfstorage') == project.osfstorage_region.mfr_url
         assert get_mfr_url(comment, 'osfstorage') == MFR_SERVER_URL
+
+    def test_get_root_institutional_storage_exception(self):
+        with pytest.raises(HTTPError):
+            get_root_institutional_storage(self.file_child.id)
+
+    def test_get_root_institutional_storage(self):
+        with mock.patch('osf.models.files.BaseFileNode.objects.get', side_effect=[self.file_child, self.parent]):
+            res = get_root_institutional_storage(self.file_child.id)
+            assert res.name == self.parent.name
+            assert res.target == self.parent.target

--- a/addons/base/utils.py
+++ b/addons/base/utils.py
@@ -1,6 +1,8 @@
 import markupsafe
 from os.path import basename
 from website.settings import MFR_SERVER_URL
+from rest_framework import status as http_status
+from framework.exceptions import HTTPError
 
 from website import settings
 
@@ -54,3 +56,15 @@ def format_last_known_metadata(auth, node, file, error_type):
         ]
         return ''.join(parts)
     return msg
+
+def get_root_institutional_storage(file_id):
+    # This method returns the root storage folder based on the file id
+    from osf.models import BaseFileNode
+    try:
+        file_node = BaseFileNode.objects.get(_id=file_id)
+        while file_node.is_root is None:
+            parent_id = file_node.parent_id
+            file_node = BaseFileNode.objects.get(id=parent_id)
+        return file_node
+    except BaseFileNode.DoesNotExist:
+        raise HTTPError(http_status.HTTP_404_NOT_FOUND)

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -524,7 +524,9 @@ class RestartStuckRegistrationsView(StuckRegistrationsView):
         stuck_reg = self.get_object()
         if verify(stuck_reg):
             try:
-                archive(stuck_reg)
+                # Get region id from query params
+                region_id = self.request.GET.get('region', None)
+                archive(stuck_reg, region_id)
                 messages.success(request, 'Registration archive processes has restarted')
             except Exception as exc:
                 messages.error(request, 'This registration cannot be unstuck due to {} '

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -483,7 +483,6 @@ class TestRestartStuckRegistrationsView(AdminTestCase):
 
         nt.assert_equal(self.registration.archive_job.status, u'SUCCESS')
 
-
     def test_restart_stuck_registration_exception(self):
         # Prevents circular import that prevents admin app from starting up
         from django.contrib.messages.storage.fallback import FallbackStorage

--- a/osf/models/archive.py
+++ b/osf/models/archive.py
@@ -146,9 +146,17 @@ class ArchiveJob(ObjectIDMixin, BaseModel):
 
     def set_targets(self):
         addons = []
-        for addon in [self.src_node.get_addon(name)
-                      for name in settings.ADDONS_ARCHIVABLE
-                      if settings.ADDONS_ARCHIVABLE[name] != 'none']:
+        result = []
+        for name in settings.ADDONS_ARCHIVABLE:
+            if settings.ADDONS_ARCHIVABLE[name] != 'none':
+                try:
+                    addon = self.src_node.get_addon(name)
+                except Exception:
+                    # Get the first addon if multiple values are returned
+                    addon = self.src_node.get_first_addon(name)
+                result.append(addon)
+
+        for addon in result:
             if not addon or not isinstance(addon, BaseStorageAddon) or not addon.complete:
                 continue
             archive_errors = getattr(addon, 'archive_errors', None)

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -1101,7 +1101,7 @@ class BrandFactory(DjangoModelFactory):
     class Meta:
         model = models.Brand
 
-    name = factory.Faker('company')
+    name = factory.LazyAttribute(lambda n: fake.sentence()[:10])
     hero_logo_image = factory.Faker('url')
     topnav_logo_image = factory.Faker('url')
     hero_background_image = factory.Faker('url')

--- a/osf_tests/management_commands/test_force_archive.py
+++ b/osf_tests/management_commands/test_force_archive.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import mock  # noqa
+import pytest
+
+from addons.osfstorage.tests import factories
+from framework.exceptions import HTTPError
+from osf.management.commands.force_archive import archive
+from osf_tests.factories import RegionFactory, NodeFactory, RegistrationFactory
+from tests.base import OsfTestCase
+
+
+@pytest.mark.django_db
+class TestArchiveUtils(OsfTestCase):
+
+    def setUp(self):
+        super(TestArchiveUtils, self).setUp()
+        self.config = {
+            'storage': {
+                'provider': 'osfstorage',
+                'container': 'osf_storage',
+                'use_public': True,
+            }
+        }
+        self.user = factories.AuthUserFactory()
+        self.region = RegionFactory(waterbutler_settings=self.config)
+
+    def test_archive_exception(self):
+        proj = NodeFactory()
+        NodeFactory(parent=proj)
+        comp2 = NodeFactory(parent=proj)
+        NodeFactory(parent=comp2)
+        reg = RegistrationFactory(project=proj)
+        with pytest.raises(HTTPError):
+            res = archive(reg, self.region.id)

--- a/osf_tests/management_commands/test_force_archive.py
+++ b/osf_tests/management_commands/test_force_archive.py
@@ -31,4 +31,4 @@ class TestArchiveUtils(OsfTestCase):
         NodeFactory(parent=comp2)
         reg = RegistrationFactory(project=proj)
         with pytest.raises(HTTPError):
-            res = archive(reg, self.region.id)
+            archive(reg, self.region.id)

--- a/osf_tests/test_archive_utils.py
+++ b/osf_tests/test_archive_utils.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import mock  # noqa
+import pytest
+
+from addons.osfstorage.tests import factories
+from osf_tests.factories import ProjectFactory, RegionFactory, NodeFactory
+from tests.base import OsfTestCase
+from website.archiver.utils import archive_provider_for, link_archive_provider
+
+
+@pytest.mark.django_db
+class TestArchiveUtils(OsfTestCase):
+
+    def setUp(self):
+        super(TestArchiveUtils, self).setUp()
+        self.config = {
+            'storage': {
+                'provider': 'osfstorage',
+                'container': 'osf_storage',
+                'use_public': True,
+            }
+        }
+        self.user = factories.AuthUserFactory()
+        self.project = ProjectFactory(creator=self.user)
+        self.region = RegionFactory(waterbutler_settings=self.config)
+        self.new_component = NodeFactory(parent=self.project)
+        self.component_node_settings = self.new_component.get_addon('osfstorage')
+        self.component_node_settings.region = self.region
+        self.component_node_settings.full_name = self.config['storage']['provider']
+        self.component_node_settings.save()
+
+    def test_archive_provider_for(self):
+        res = archive_provider_for(self.new_component, self.user)
+        assert res.region_id == self.new_component.get_addon('osfstorage').region_id
+
+    def test_archive_provider_for_excpetion(self):
+        with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=Exception('mocked error')):
+            res = archive_provider_for(self.new_component, self.user)
+            assert res.region_id == self.new_component.get_first_addon('osfstorage').region_id
+
+    def test_link_archive_provider(self):
+        with mock.patch('osf.models.node.AbstractNode.get_addon', return_value=None):
+            with mock.patch('osf.models.node.AbstractNode.add_addon', return_value=self.component_node_settings):
+                link_archive_provider(self.new_component, self.user)
+
+    def test_link_archive_provider_exception(self):
+        with mock.patch('osf.models.node.AbstractNode.get_addon', return_value=None):
+            with mock.patch('osf.models.node.AbstractNode.add_addon', side_effect=Exception('mocked error')):
+                with mock.patch('osf.models.node.AbstractNode.get_first_addon', return_value=self.component_node_settings):
+                    link_archive_provider(self.new_component, self.user)

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -605,7 +605,6 @@ class TestArchiverTasks(ArchiverTestCase):
                 )
             ))
 
-
     def test_archive_success(self):
         node = factories.NodeFactory(creator=self.user)
         file_trees, selected_files, node_index = generate_file_tree([node])

--- a/osf_tests/test_mixins.py
+++ b/osf_tests/test_mixins.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import mock  # noqa
+import pytest
+
+from addons.osfstorage.tests import factories
+from osf_tests.factories import ProjectFactory, RegionFactory, NodeFactory
+from tests.base import OsfTestCase
+from django.core.exceptions import MultipleObjectsReturned
+from unittest import mock
+
+
+@pytest.mark.django_db
+class TestAddonModelMixin(OsfTestCase):
+
+    def setUp(self):
+        super(TestAddonModelMixin, self).setUp()
+        self.config = {
+            'storage': {
+                'provider': 'osfstorage',
+                'container': 'osf_storage',
+                'use_public': True,
+            }
+        }
+        self.user = factories.AuthUserFactory()
+        self.project = ProjectFactory(creator=self.user)
+        self.region = RegionFactory(waterbutler_settings=self.config)
+        self.new_component = NodeFactory(parent=self.project)
+
+    def test_get_addon_region_not_exist(self):
+        res = self.new_component.get_addon('osfstorage', False, self.region.id)
+        assert res == None
+
+    def test_get_addon_not_region_id(self):
+        res = self.new_component.get_addon('osfstorage', False, None)
+        assert res != None
+
+    def test_get_addon_exception(self):
+        res = self.new_component.get_addon(None)
+        assert res == None
+
+    def test_get_addon_return_none(self):
+        with mock.patch('osf.models.mixins.AddonModelMixin._settings_model', return_value=None):
+            res = self.new_component.get_addon('osfstorage')
+            assert res == None
+
+    def test_get_first_addon(self):
+        res = self.new_component.get_first_addon('osfstorage', is_deleted=False)
+        assert res != None
+
+    def test_get_first_addon_key_error(self):
+        res = self.new_component.get_first_addon('osfstorage')
+        assert res != None
+
+    def test_get_first_addon_exception(self):
+        res = self.new_component.get_first_addon(None)
+        assert res == None
+
+    def test_get_first_addon_return_none(self):
+        with mock.patch('osf.models.mixins.AddonModelMixin._settings_model', return_value=None):
+            res = self.new_component.get_first_addon('osfstorage')
+            assert res == None
+
+    def test_add_addon(self):
+        with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=MultipleObjectsReturned('mocked error')):
+            res = self.new_component.add_addon('osfstorage', None, False, self.region.id)
+            assert res != None
+
+    def test_delete_addon(self):
+        with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', return_value=None):
+            res = self.new_component.delete_addon('node', auth=self.user.auth)
+            assert res == False

--- a/osf_tests/test_mixins.py
+++ b/osf_tests/test_mixins.py
@@ -65,7 +65,7 @@ class TestAddonModelMixin(OsfTestCase):
         mock_node_settings.on_add.return_value = None
         mock_node_settings.save.return_value = None
         temp_region = RegionFactory(name='Frankfort', _id='eu-central-1')
-        with mock.patch('addons.osfstorage.models.NodeSettings', mock_node_settings):
+        with mock.patch('osf.models.mixins.AddonModelMixin._settings_model', return_value=mock_node_settings):
             with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=MultipleObjectsReturned('mocked error')):
                 res = AddonModelMixin.add_addon(self.new_component, 'osfstorage', None, False, temp_region.id)
                 assert res is not None

--- a/osf_tests/test_mixins.py
+++ b/osf_tests/test_mixins.py
@@ -26,6 +26,11 @@ class TestAddonModelMixin(OsfTestCase):
         self.region = RegionFactory(waterbutler_settings=self.config)
         self.new_component = NodeFactory(parent=self.project)
 
+    def test_get_addon_region(self):
+        root_id = 1
+        res = self.new_component.get_addon('osfstorage', False, self.region.id, root_id)
+        assert res is None
+
     def test_get_addon_region_not_exist(self):
         res = self.new_component.get_addon('osfstorage', False, self.region.id)
         assert res is None

--- a/osf_tests/test_mixins.py
+++ b/osf_tests/test_mixins.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import mock  # noqa
 import pytest
 
 from addons.osfstorage.tests import factories
@@ -7,6 +6,7 @@ from osf_tests.factories import ProjectFactory, RegionFactory, NodeFactory
 from tests.base import OsfTestCase
 from django.core.exceptions import MultipleObjectsReturned
 from unittest import mock
+from osf.models.mixins import AddonModelMixin
 
 
 @pytest.mark.django_db
@@ -28,44 +28,44 @@ class TestAddonModelMixin(OsfTestCase):
 
     def test_get_addon_region_not_exist(self):
         res = self.new_component.get_addon('osfstorage', False, self.region.id)
-        assert res == None
+        assert res is None
 
     def test_get_addon_not_region_id(self):
         res = self.new_component.get_addon('osfstorage', False, None)
-        assert res != None
+        assert res is not None
 
     def test_get_addon_exception(self):
         res = self.new_component.get_addon(None)
-        assert res == None
+        assert res is None
 
     def test_get_addon_return_none(self):
         with mock.patch('osf.models.mixins.AddonModelMixin._settings_model', return_value=None):
             res = self.new_component.get_addon('osfstorage')
-            assert res == None
+            assert res is None
 
     def test_get_first_addon(self):
         res = self.new_component.get_first_addon('osfstorage', is_deleted=False)
-        assert res != None
+        assert res is not None
 
     def test_get_first_addon_key_error(self):
         res = self.new_component.get_first_addon('osfstorage')
-        assert res != None
+        assert res is not None
 
     def test_get_first_addon_exception(self):
         res = self.new_component.get_first_addon(None)
-        assert res == None
+        assert res is None
 
     def test_get_first_addon_return_none(self):
         with mock.patch('osf.models.mixins.AddonModelMixin._settings_model', return_value=None):
             res = self.new_component.get_first_addon('osfstorage')
-            assert res == None
+            assert res is None
 
     def test_add_addon(self):
         with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=MultipleObjectsReturned('mocked error')):
-            res = self.new_component.add_addon('osfstorage', None, False, self.region.id)
-            assert res != None
+            res = AddonModelMixin.add_addon(self.new_component, 'osfstorage', None, False, self.region.id)
+            assert res is not None
 
     def test_delete_addon(self):
         with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', return_value=None):
             res = self.new_component.delete_addon('node', auth=self.user.auth)
-            assert res == False
+            assert res is False

--- a/osf_tests/test_mixins.py
+++ b/osf_tests/test_mixins.py
@@ -61,10 +61,13 @@ class TestAddonModelMixin(OsfTestCase):
             assert res is None
 
     def test_add_addon(self):
+        mock_on_add = mock.MagicMock()
+        mock_on_add.return_value = None
         temp_region = RegionFactory(name='Frankfort', _id='eu-central-1')
-        with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=MultipleObjectsReturned('mocked error')):
-            res = AddonModelMixin.add_addon(self.new_component, 'osfstorage', None, False, temp_region.id)
-            assert res is not None
+        with mock.patch('addons.osfstorage.models.NodeSettings.on_add', mock_on_add):
+            with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=MultipleObjectsReturned('mocked error')):
+                res = AddonModelMixin.add_addon(self.new_component, 'osfstorage', None, False, temp_region.id)
+                assert res is not None
 
     def test_delete_addon(self):
         with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', return_value=None):

--- a/osf_tests/test_mixins.py
+++ b/osf_tests/test_mixins.py
@@ -61,10 +61,11 @@ class TestAddonModelMixin(OsfTestCase):
             assert res is None
 
     def test_add_addon(self):
-        mock_on_add = mock.MagicMock()
-        mock_on_add.return_value = None
+        mock_node_settings = mock.MagicMock()
+        mock_node_settings.on_add.return_value = None
+        mock_node_settings.save.return_value = None
         temp_region = RegionFactory(name='Frankfort', _id='eu-central-1')
-        with mock.patch('addons.osfstorage.models.NodeSettings.on_add', mock_on_add):
+        with mock.patch('addons.osfstorage.models.NodeSettings', mock_node_settings):
             with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=MultipleObjectsReturned('mocked error')):
                 res = AddonModelMixin.add_addon(self.new_component, 'osfstorage', None, False, temp_region.id)
                 assert res is not None

--- a/osf_tests/test_mixins.py
+++ b/osf_tests/test_mixins.py
@@ -61,8 +61,9 @@ class TestAddonModelMixin(OsfTestCase):
             assert res is None
 
     def test_add_addon(self):
+        temp_region = RegionFactory(name='Frankfort', _id='eu-central-1')
         with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=MultipleObjectsReturned('mocked error')):
-            res = AddonModelMixin.add_addon(self.new_component, 'osfstorage', None, False, self.region.id)
+            res = AddonModelMixin.add_addon(self.new_component, 'osfstorage', None, False, temp_region.id)
             assert res is not None
 
     def test_delete_addon(self):

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1968,34 +1968,54 @@ class TestLegacyViews(OsfTestCase):
                     assert_urls_equal(res.location, expected_url)
 
     def test_other_addon_redirect(self):
+        mock_request = mock.MagicMock()
+        mock_request.return_value = {'region_id': '123', 'action': 'view'}
         url = '/project/{0}/mycooladdon/files/{1}/'.format(
             self.project._id,
-            self.path,
+            self.file._id,
         )
-        res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 301)
-        expected_url = self.project.web_url_for(
-            'addon_view_or_download_file',
-            action='view',
-            path=self.path,
-            provider='mycooladdon',
-        )
-        assert_urls_equal(res.location, expected_url)
+        with mock.patch('addons.twofactor.models.UserSettings.verify_code', return_value=True):
+            with mock.patch('addons.base.views.request', mock_request):
+                with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=[self.user_addon, self.node_addon]):
+                    res = self.app.get(
+                        url,
+                        auth=self.user.auth,
+                        headers={'X-OSF-OTP': 'fake_otp'},
+                        expect_errors=True
+                    )
+                    assert_equal(res.status_code, 301)
+                    expected_url = self.project.web_url_for(
+                        'addon_view_or_download_file',
+                        path=self.file._id,
+                        action='download',
+                        provider='mycooladdon',
+                    )
+                    assert_urls_equal(res.location, expected_url)
 
     def test_other_addon_redirect_download(self):
+        mock_request = mock.MagicMock()
+        mock_request.return_value = {'region_id': '123', 'action': 'view'}
         url = '/project/{0}/mycooladdon/files/{1}/download/'.format(
             self.project._id,
-            self.path,
+            self.file._id,
         )
-        res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 301)
-        expected_url = self.project.web_url_for(
-            'addon_view_or_download_file',
-            path=self.path,
-            action='download',
-            provider='mycooladdon',
-        )
-        assert_urls_equal(res.location, expected_url)
+        with mock.patch('addons.twofactor.models.UserSettings.verify_code', return_value=True):
+            with mock.patch('addons.base.views.request', mock_request):
+                with mock.patch('osf.models.mixins.AddonModelMixin.get_addon', side_effect=[self.user_addon, self.node_addon]):
+                    res = self.app.get(
+                        url,
+                        auth=self.user.auth,
+                        headers={'X-OSF-OTP': 'fake_otp'},
+                        expect_errors=True
+                    )
+                    assert_equal(res.status_code, 301)
+                    expected_url = self.project.web_url_for(
+                        'addon_view_or_download_file',
+                        path=self.file._id,
+                        action='download',
+                        provider='mycooladdon',
+                    )
+                    assert_urls_equal(res.location, expected_url)
 
 class TestViewUtils(OsfTestCase):
 

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -125,7 +125,11 @@ def stat_addon(addon_short_name, job_pk):
     create_app_context()
     job = ArchiveJob.load(job_pk)
     src, dst, user = job.info()
-    src_addon = src.get_addon(addon_name)
+    try:
+        src_addon = src.get_addon(addon_name)
+    except Exception:
+        # Get the first addon if multiple values are returned
+        src_addon = src.get_first_addon(addon_name)
     if hasattr(src_addon, 'configured') and not src_addon.configured:
         # Addon enabled but not configured - no file trees, nothing to archive.
         return AggregateStatResult(src_addon._id, addon_short_name)
@@ -202,7 +206,11 @@ def archive_addon(addon_short_name, job_pk):
         params['revision'] = 'latest' if addon_short_name.split('-')[-1] == 'draft' else 'latest-published'
         rename_suffix = ' (draft)' if addon_short_name.split('-')[-1] == 'draft' else ' (published)'
         addon_short_name = 'dataverse'
-    src_provider = src.get_addon(addon_short_name)
+    try:
+        src_provider = src.get_addon(addon_short_name)
+    except Exception:
+        # Get the first addon if multiple values are returned
+        src_provider = src.get_first_addon(addon_short_name)
     folder_name = src_provider.archive_folder_name
     rename = '{}{}'.format(folder_name, rename_suffix)
     url = waterbutler_api_url_for(src._id, addon_short_name, _internal=True, base_url=src.osfstorage_region.waterbutler_url, **params)

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -150,7 +150,7 @@ def link_archive_provider(node, user):
         addon = node.get_addon(settings.ARCHIVE_PROVIDER, auth=Auth(user), log=False)
         if addon is None:
             addon = node.add_addon(settings.ARCHIVE_PROVIDER, auth=Auth(user), log=False)
-    except Exception as ex:
+    except Exception:
         # Get the first addon if multiple values are returned
         addon = node.get_first_addon(settings.ARCHIVE_PROVIDER)
     if hasattr(addon, 'on_add'):

--- a/website/notifications/events/files.py
+++ b/website/notifications/events/files.py
@@ -134,7 +134,11 @@ class ComplexFileEvent(FileEvent):
 
         source_nid = self.payload['source']['node']['_id']
         self.source_node = AbstractNode.load(source_nid) or Preprint.load(source_nid)
-        self.addon = self.node.get_addon(self.payload['destination']['provider'])
+        try:
+            self.addon = self.node.get_addon(self.payload['destination']['provider'])
+        except Exception:
+            # Get the first addon if multiple values are returned
+            self.addon = self.node.get_first_addon(self.payload['destination']['provider'])
 
     def _build_message(self, lang, html=False):
         addon, f_type, action = tuple(self.action.split('_'))


### PR DESCRIPTION
## Purpose

- Handle API and function Not called anywhere (Regarding: Investigation_node_setting_table)

## Changes

- addons/base/utils.py
- addons/base/views.py
- admin/nodes/views.py
- osf/management/commands/force_archive.py
- osf/models/archive.py
- osf/models/mixins.py
- website/archiver/tasks.py
- website/archiver/utils.py
- website/notifications/events/files.py

- addons/base/tests/utils.py
- addons/base/tests/views.py
- admin_tests/nodes/test_views.py
- osf_tests/management_commands/test_force_archive.py
- osf_tests/test_archive_utils.py
- osf_tests/test_archiver.py
- osf_tests/test_mixins.py
- tests/test_websitefiles.py

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
  -> No data migration.

## Documentation

## Side Effects

## Ticket
