### PR TITLE
[GRDM-36591] パス長が255より長い場合にosf.ioでエラーが起こる不具合の修正

### DIFF
--- a/osf/migrations/0226_alter_filelog_path.py
+++ b/osf/migrations/0226_alter_filelog_path.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0225_add_pattern_and_norm_to_registration_schema_block'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='FileLog',
+            name='path',
+            field=models.TextField(null=True),
+        ),
+    ]

--- a/osf/models/filelog.py
+++ b/osf/models/filelog.py
@@ -46,7 +46,7 @@ class FileLog(ObjectIDMixin, BaseModel):
     # TODO build action choices on the fly with the addon stuff
     action = models.CharField(max_length=255, db_index=True)  # , choices=action_choices)
     user = models.ForeignKey('OSFUser', related_name='filelogs', db_index=True, null=True, blank=True)
-    path = models.CharField(max_length=255, db_index=True, null=True)
+    path = models.TextField(null=True)
 
     def __unicode__(self):
         return ('({self.action!r}, user={self.user!r},, file={self.file!r}, params={self.params!r}) '


### PR DESCRIPTION
## Purpose

パス長が255より長い場合にosf.ioでエラーが起こる不具合を修正しました。

## Changes

- [GRDM-36591] FileLog.path を CharField から TextField に変更しました。

## QA Notes
None

## Documentation
None

## Side Effects
None

## Ticket
GRDM-36591
