### PR TITLE
(2)4.2.CLI(プロジェクト/コンポーネントの新規作成)

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -798,6 +798,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
             validated_data.pop('creator')
             changed_data = {template_from: validated_data}
             node = template_node.use_as_template(auth=get_user_auth(request), changes=changed_data)
+            node._parent = validated_data.pop('parent', None)
         else:
             node = Node(**validated_data)
         try:

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -762,6 +762,7 @@ class NodeChildrenList(BaseChildrenList, bulk_views.ListBulkCreateJSONAPIView, N
     required_read_scopes = [CoreScopes.NODE_CHILDREN_READ]
     required_write_scopes = [CoreScopes.NODE_CHILDREN_WRITE]
 
+    parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
     serializer_class = NodeSerializer
     view_category = 'nodes'
     view_name = 'node-children'


### PR DESCRIPTION
## Purpose
- Fix the error in API Create a child node (a Component) with license information.
- Fix the error in API Create a child node (a Component) with template_from specified in attributes. This support is only for CLI, not yet for the website UI.
- This fixes for CLI support at [RDM-cli](https://github.com/RCOSDP/RDM-cli) repo.
- The related PR is [PR#3](https://github.com/RCOSDP/RDM-cli/pull/3).
## Changes
- API Create a child node (a Component) with license information
  Add `parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)` into the `NodeChildrenList` class.
  The `relationships` object in the request body will be parsed by the `JSONAPIMultipleRelationshipsParserForRegularJSON` class.
- API Create a child node (a Component) with template_from specified
  Set the `node._parent = validated_data.pop('parent', None)` right after `template_node.use_as_template` is called in `api.nodes.serializers.NodeSerializer.create` method
## QA Notes
## Documentation
## Side Effects
## Ticket
