### PR TITLE
[GRDM-37149] 「拡張ストレージマウント方式」機関ストレージにおいてWeb UIとAPIの間で一貫性がない状態

### DIFF
--- a/addons/base/institutions_utils.py
+++ b/addons/base/institutions_utils.py
@@ -8,6 +8,7 @@ from django.db import models
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
 
+from osf.models import Institution
 from osf.models.node import Node
 from osf.models.rdm_addons import RdmAddonOption
 from website import settings as website_settings
@@ -48,19 +49,19 @@ class InstitutionsNodeSettings(BaseNodeSettings):
     ###
     @property
     def complete(self):
+        if self._institutions_disabled:
+            return False
         return self.has_auth and self.folder_id
 
     @property
-    def _institutions_enabled(self):
+    def _institutions_disabled(self):
         if not self.config.for_institutions:
-            raise ValueError('_institution_enabled is only valid for institutional storage addons')
+            raise ValueError('_institutions_disabled is only valid for institutional storage addons')
         _, region_provider = get_region_provider(self.owner)
-        return region_provider == self.config.short_name
+        return region_provider != self.config.short_name
 
     @property
     def has_auth(self):
-        if not self._institutions_enabled:
-            return False
         return self.addon_option
 
     @property
@@ -483,19 +484,23 @@ def check_existence_and_create(node, ns, op_name):
         logger.warning(u'{}: cannot create external storage folder: addon_name={}, project title={}, GUID={}: {}'.format(op_name, ns.SHORT_NAME, node.title, node._id, str(e)))
         return False
 
+# get region_provider information ... in_institutions, region_disabled, region_provider
 def get_region_provider(node):
     osfstorage = node.get_addon('osfstorage')
     if not osfstorage:
         return False, None
-    region_disabled = False
-    region_provider = None
     region = osfstorage.region
-    if region and region.waterbutler_settings:
-        region_disabled = region.waterbutler_settings.get(
-            'disabled', False)
-        storage = region.waterbutler_settings.get('storage', None)
-        if storage:
-            region_provider = storage.get('provider', None)
+    if not region or not region.waterbutler_settings:
+        return False, None  # No valid regions
+    region_id = region._id
+    if not Institution.objects.filter(_id=region_id).exists():
+        return False, None  # No regions for institutional storage
+    region_provider = None
+    region_disabled = region.waterbutler_settings.get(
+        'disabled', False)
+    storage = region.waterbutler_settings.get('storage', None)
+    if storage:
+        region_provider = storage.get('provider', None)
     return region_disabled, region_provider
 
 # sleep time (sec.) to limit API calls

--- a/addons/base/models.py
+++ b/addons/base/models.py
@@ -382,6 +382,15 @@ class BaseNodeSettings(BaseAddonSettings):
         """Whether the node has added credentials for this addon."""
         return False
 
+    @property
+    def _institutions_enabled(self):
+        # GRDM-37149: Display only configured institutional providers
+        from addons.base import institutions_utils
+        if not self.config.for_institutions:
+            raise ValueError('institution_enabled is only valid for institutional storage addons')
+        _, region_provider = institutions_utils.get_region_provider(self.owner)
+        return region_provider == self.config.short_name
+
     def to_json(self, user):
         ret = super(BaseNodeSettings, self).to_json(user)
         ret.update({

--- a/addons/base/models.py
+++ b/addons/base/models.py
@@ -383,13 +383,13 @@ class BaseNodeSettings(BaseAddonSettings):
         return False
 
     @property
-    def _institutions_enabled(self):
+    def _institutions_disabled(self):
         # GRDM-37149: Display only configured institutional providers
         from addons.base import institutions_utils
         if not self.config.for_institutions:
-            raise ValueError('institution_enabled is only valid for institutional storage addons')
+            raise ValueError('_institutions_disabled is only valid for institutional storage addons')
         _, region_provider = institutions_utils.get_region_provider(self.owner)
-        return region_provider == self.config.short_name
+        return region_provider != self.config.short_name
 
     def to_json(self, user):
         ret = super(BaseNodeSettings, self).to_json(user)

--- a/addons/dropboxbusiness/apps.py
+++ b/addons/dropboxbusiness/apps.py
@@ -12,7 +12,9 @@ TEMPLATE_PATH = os.path.join(
 
 def dropboxbusiness_root(addon_config, node_settings, auth, **kwargs):
     from addons.osfstorage.models import Region
-
+    # GRDM-37149: Hide deactivated institutional storage
+    if not node_settings.complete:
+        return None
     node = node_settings.owner
     institution = node_settings.fileaccess_option.institution
     if Region.objects.filter(_id=institution._id).exists():

--- a/addons/dropboxbusiness/models.py
+++ b/addons/dropboxbusiness/models.py
@@ -330,6 +330,8 @@ class NodeSettings(BaseNodeSettings, BaseStorageAddon):
 
     @property
     def complete(self):
+        if self._institutions_disabled:
+            return False
         return self.has_auth and self.group_id and self.team_folder_id
 
     @property
@@ -338,8 +340,6 @@ class NodeSettings(BaseNodeSettings, BaseStorageAddon):
 
     @property
     def has_auth(self):
-        if not self._institutions_enabled:
-            return False
         return self.fileaccess_token and self.management_token and \
             self.admin_dbmid
 

--- a/addons/dropboxbusiness/models.py
+++ b/addons/dropboxbusiness/models.py
@@ -338,6 +338,8 @@ class NodeSettings(BaseNodeSettings, BaseStorageAddon):
 
     @property
     def has_auth(self):
+        if not self._institutions_enabled:
+            return False
         return self.fileaccess_token and self.management_token and \
             self.admin_dbmid
 

--- a/addons/dropboxbusiness/tests/test_automount.py
+++ b/addons/dropboxbusiness/tests/test_automount.py
@@ -12,7 +12,8 @@ from osf_tests.factories import (
     InstitutionFactory,
     ExternalAccountFactory,
     UserFactory,
-    ProjectFactory
+    ProjectFactory,
+    RegionFactory
 )
 from addons.dropboxbusiness.models import NodeSettings
 from admin_tests.rdm_addons import factories as rdm_addon_factories
@@ -22,6 +23,7 @@ pytestmark = pytest.mark.django_db
 class DropboxBusinessAccountFactory(ExternalAccountFactory):
     provider = 'dropboxbusiness'
 
+SHORT_NAME = 'dropboxbusiness'
 FILEACCESS_NAME = 'dropboxbusiness'
 MANAGEMENT_NAME = 'dropboxbusiness_manage'
 DBXBIZ = 'addons.dropboxbusiness'
@@ -59,6 +61,19 @@ class TestDropboxBusiness(unittest.TestCase):
             mock3.return_value = 'dbmid:dummy'
             mock4.return_value = ('dbtid:dummy', 'g:dummy')
             self.project = ProjectFactory(creator=self.user)
+            self.osfstorage = self.project.get_addon('osfstorage')
+            new_region = RegionFactory(
+                _id=self.institution._id,
+                name='Institutional Storage',
+                waterbutler_settings={
+                    'storage': {
+                        'provider': SHORT_NAME,
+                    },
+                }
+            )
+            self.osfstorage.region = new_region
+            self.osfstorage.save()
+            self.project.save()
 
     def _allowed(self):
         self.f_option.is_allowed = True

--- a/addons/dropboxbusiness/tests/test_institutions.py
+++ b/addons/dropboxbusiness/tests/test_institutions.py
@@ -1,0 +1,112 @@
+import mock
+import pytest
+from framework.auth import Auth
+from osf_tests.factories import ProjectFactory, InstitutionFactory, RegionFactory
+
+from addons.osfstorage.tests import factories
+from addons.osfstorage.tests.utils import StorageTestCase
+
+SHORT_NAME = 'dropboxbusiness'
+
+@pytest.mark.django_db
+class TestNonInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.group_id = 'some_group'
+        self.node_settings.team_folder_id = 'some_folder'
+        self.node_settings._admin_dbmid = 'some_dbmid'
+        self.node_settings.save()
+        self.mock_get_token = mock.patch('addons.dropboxbusiness.models.NodeSettings._get_token')
+        self.mock_get_token.return_value = True
+        self.mock_get_token.start()
+
+    def tearDown(self):
+        self.mock_get_token.stop()
+        super(TestNonInstitutionalNodeSettings, self).tearDown()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False
+
+@pytest.mark.django_db
+class TestTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.group_id = 'some_group'
+        self.node_settings.team_folder_id = 'some_folder'
+        self.node_settings._admin_dbmid = 'some_dbmid'
+        self.node_settings.save()
+        self.mock_get_token = mock.patch('addons.dropboxbusiness.models.NodeSettings._get_token')
+        self.mock_get_token.return_value = True
+        self.mock_get_token.start()
+
+    def tearDown(self):
+        self.mock_get_token.stop()
+        super(TestTargetInstitutionalNodeSettings, self).tearDown()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is not False
+
+@pytest.mark.django_db
+class TestNonTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage for Another Addon',
+            waterbutler_settings={
+                'storage': {
+                    'provider': 'another_provider',
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.group_id = 'some_group'
+        self.node_settings.team_folder_id = 'some_folder'
+        self.node_settings._admin_dbmid = 'some_dbmid'
+        self.node_settings.save()
+        self.mock_get_token = mock.patch('addons.dropboxbusiness.models.NodeSettings._get_token')
+        self.mock_get_token.return_value = True
+        self.mock_get_token.start()
+
+    def tearDown(self):
+        self.mock_get_token.stop()
+        super(TestNonTargetInstitutionalNodeSettings, self).tearDown()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False

--- a/addons/nextcloudinstitutions/apps.py
+++ b/addons/nextcloudinstitutions/apps.py
@@ -17,7 +17,9 @@ TEMPLATE_PATH = os.path.join(
 
 def nextcloudinstitutions_root(addon_config, node_settings, auth, **kwargs):
     from addons.osfstorage.models import Region
-
+    # GRDM-37149: Hide deactivated institutional storage
+    if not node_settings.complete:
+        return None
     node = node_settings.owner
     institution = node_settings.addon_option.institution
     if Region.objects.filter(_id=institution._id).exists():

--- a/addons/nextcloudinstitutions/tests/test_automount.py
+++ b/addons/nextcloudinstitutions/tests/test_automount.py
@@ -14,8 +14,10 @@ from osf_tests.factories import (
     InstitutionFactory,
     ExternalAccountFactory,
     UserFactory,
-    ProjectFactory
+    ProjectFactory,
+    RegionFactory,
 )
+from addons.nextcloudinstitutions.apps import SHORT_NAME
 from addons.nextcloudinstitutions.models import NodeSettings
 from admin_tests.rdm_addons import factories as rdm_addon_factories
 
@@ -74,6 +76,18 @@ class TestNextcloudinstitutions(unittest.TestCase):
                 self.project = ProjectFactory(creator=self.user)
         else:
             self.project = ProjectFactory(creator=self.user)
+        self.osfstorage = self.project.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
 
     def _allow(self, save=True):
         self.option.is_allowed = True

--- a/addons/nextcloudinstitutions/tests/test_institutions.py
+++ b/addons/nextcloudinstitutions/tests/test_institutions.py
@@ -1,0 +1,88 @@
+import pytest
+from framework.auth import Auth
+from osf_tests.factories import ProjectFactory, InstitutionFactory, RegionFactory
+from admin_tests.rdm_addons.factories import RdmAddonOptionFactory
+
+from osf.models.rdm_addons import RdmAddonOption
+from addons.osfstorage.tests import factories
+from addons.osfstorage.tests.utils import StorageTestCase
+from addons.nextcloudinstitutions.apps import SHORT_NAME
+
+@pytest.mark.django_db
+class TestNonInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False
+
+@pytest.mark.django_db
+class TestTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is not False
+
+@pytest.mark.django_db
+class TestNonTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage for Another Addon',
+            waterbutler_settings={
+                'storage': {
+                    'provider': 'another_provider',
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False

--- a/addons/ociinstitutions/apps.py
+++ b/addons/ociinstitutions/apps.py
@@ -17,7 +17,9 @@ TEMPLATE_PATH = os.path.join(
 
 def ociinstitutions_root(addon_config, node_settings, auth, **kwargs):
     from addons.osfstorage.models import Region
-
+    # GRDM-37149: Hide deactivated institutional storage
+    if not node_settings.complete:
+        return None
     node = node_settings.owner
     institution = node_settings.addon_option.institution
     if Region.objects.filter(_id=institution._id).exists():

--- a/addons/ociinstitutions/tests/test_automount.py
+++ b/addons/ociinstitutions/tests/test_automount.py
@@ -14,8 +14,10 @@ from osf_tests.factories import (
     InstitutionFactory,
     ExternalAccountFactory,
     UserFactory,
-    ProjectFactory
+    ProjectFactory,
+    RegionFactory,
 )
+from addons.ociinstitutions.apps import SHORT_NAME
 from addons.ociinstitutions.models import NodeSettings
 from admin_tests.rdm_addons import factories as rdm_addon_factories
 
@@ -69,6 +71,18 @@ class TestOCIinstitutions(unittest.TestCase):
                 self.project = ProjectFactory(creator=self.user)
         else:
             self.project = ProjectFactory(creator=self.user)
+        self.osfstorage = self.project.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
 
     def _allow(self, save=True):
         self.option.is_allowed = True

--- a/addons/ociinstitutions/tests/test_institutions.py
+++ b/addons/ociinstitutions/tests/test_institutions.py
@@ -1,0 +1,88 @@
+import pytest
+from framework.auth import Auth
+from osf_tests.factories import ProjectFactory, InstitutionFactory, RegionFactory
+from admin_tests.rdm_addons.factories import RdmAddonOptionFactory
+
+from osf.models.rdm_addons import RdmAddonOption
+from addons.osfstorage.tests import factories
+from addons.osfstorage.tests.utils import StorageTestCase
+from addons.ociinstitutions.apps import SHORT_NAME
+
+@pytest.mark.django_db
+class TestNonInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False
+
+@pytest.mark.django_db
+class TestTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is not False
+
+@pytest.mark.django_db
+class TestNonTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage for Another Addon',
+            waterbutler_settings={
+                'storage': {
+                    'provider': 'another_provider',
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False

--- a/addons/onedrivebusiness/apps.py
+++ b/addons/onedrivebusiness/apps.py
@@ -1,10 +1,9 @@
 import os
 
-from addons.base.apps import BaseAddonAppConfig, generic_root_folder
+from addons.base.apps import BaseAddonAppConfig
 from addons.onedrivebusiness import SHORT_NAME, FULL_NAME
 from addons.onedrivebusiness import settings
-
-onedrivebusiness_root_folder = generic_root_folder('onedrivebusiness')
+from website.util import rubeus
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_PATH = os.path.join(
@@ -12,6 +11,21 @@ TEMPLATE_PATH = os.path.join(
     'templates'
 )
 
+def onedrivebusiness_root_folder(node_settings, auth, **kwargs):
+    """Return the Rubeus/HGrid-formatted response for the root folder only."""
+    # GRDM-37149: Hide deactivated institutional storage
+    if not node_settings.complete:
+        return None
+    node = node_settings.owner
+    root = rubeus.build_addon_root(
+        node_settings=node_settings,
+        name=node_settings.fetch_folder_name(),
+        permissions=auth,
+        nodeUrl=node.url,
+        nodeApiUrl=node.api_url,
+        private_key=kwargs.get('view_only', None),
+    )
+    return [root]
 
 class OneDriveBusinessAddonAppConfig(BaseAddonAppConfig):
 

--- a/addons/onedrivebusiness/models.py
+++ b/addons/onedrivebusiness/models.py
@@ -128,6 +128,8 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
 
     @property
     def has_auth(self):
+        if not self._institutions_enabled:
+            return False
         """Instance has *active* permission to use it"""
         return self.user_settings and self.user_settings.has_auth
 

--- a/addons/onedrivebusiness/models.py
+++ b/addons/onedrivebusiness/models.py
@@ -124,12 +124,12 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
 
     @property
     def complete(self):
+        if self._institutions_disabled:
+            return False
         return self.has_auth and self.folder_id is not None
 
     @property
     def has_auth(self):
-        if not self._institutions_enabled:
-            return False
         """Instance has *active* permission to use it"""
         return self.user_settings and self.user_settings.has_auth
 

--- a/addons/onedrivebusiness/tests/factories.py
+++ b/addons/onedrivebusiness/tests/factories.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Factories for the My MinIO addon."""
+"""Factories for the OneDriveBusiness addon."""
 import factory
 from factory.django import DjangoModelFactory
 
@@ -16,7 +16,7 @@ class OneDriveBusinessAccountFactory(ExternalAccountFactory):
     provider_id = factory.Sequence(lambda n: 'id-{0}'.format(n))
     oauth_key = factory.Sequence(lambda n: 'key-{0}'.format(n))
     oauth_secret = factory.Sequence(lambda n: 'secret-{0}'.format(n))
-    display_name = 'My MinIO Fake User'
+    display_name = 'OneDriveBusiness Fake User'
 
 
 class OneDriveBusinessUserSettingsFactory(DjangoModelFactory):

--- a/addons/onedrivebusiness/tests/test_institutions.py
+++ b/addons/onedrivebusiness/tests/test_institutions.py
@@ -1,0 +1,95 @@
+import pytest
+from framework.auth import Auth
+from osf_tests.factories import ProjectFactory, InstitutionFactory, RegionFactory
+
+from addons.osfstorage.tests import factories
+from addons.osfstorage.tests.utils import StorageTestCase
+from addons.onedrivebusiness import SHORT_NAME
+
+@pytest.mark.django_db
+class TestNonInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.node.creator.add_addon(SHORT_NAME)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.user_settings = self.user.get_addon(SHORT_NAME)
+        self.node_settings.user_settings = self.user_settings
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.user_settings
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False
+
+@pytest.mark.django_db
+class TestTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.node.creator.add_addon(SHORT_NAME)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.user_settings = self.user.get_addon(SHORT_NAME)
+        self.node_settings.user_settings = self.user_settings
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.user_settings
+        assert self.node_settings.has_auth is True
+        assert self.node_settings.complete is True
+
+@pytest.mark.django_db
+class TestNonTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.node.creator.add_addon(SHORT_NAME)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage for Another Addon',
+            waterbutler_settings={
+                'storage': {
+                    'provider': 'another_provider',
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.user_settings = self.user.get_addon(SHORT_NAME)
+        self.node_settings.user_settings = self.user_settings
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.user_settings
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False

--- a/addons/onedrivebusiness/tests/test_model.py
+++ b/addons/onedrivebusiness/tests/test_model.py
@@ -19,7 +19,7 @@ from addons.onedrivebusiness.tests.factories import (
     OneDriveBusinessAccountFactory
 )
 from framework.auth import Auth
-from osf_tests.factories import ProjectFactory, DraftRegistrationFactory
+from osf_tests.factories import ProjectFactory, DraftRegistrationFactory, InstitutionFactory, RegionFactory
 from tests.base import get_default_metaschema
 
 pytestmark = pytest.mark.django_db
@@ -31,6 +31,9 @@ class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
     full_name = FULL_NAME
     ExternalAccountFactory = OneDriveBusinessAccountFactory
 
+    ## Overrides ##
+    def test_merge_user_settings(self):
+        pass
 
 class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
 
@@ -40,6 +43,22 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     NodeSettingsFactory = OneDriveBusinessNodeSettingsFactory
     NodeSettingsClass = NodeSettings
     UserSettingsFactory = OneDriveBusinessUserSettingsFactory
+
+    def setUp(self):
+        super(TestNodeSettings, self).setUp()
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
 
     def test_registration_settings(self):
         registration = ProjectFactory()
@@ -68,6 +87,9 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
 
     ## Overrides ##
     def test_has_auth(self):
+        pass
+
+    def test_set_user_auth(self):
         pass
 
     @mock.patch('addons.onedrivebusiness.models.NodeSettings.oauth_provider')

--- a/addons/onedrivebusiness/tests/test_serializer.py
+++ b/addons/onedrivebusiness/tests/test_serializer.py
@@ -3,7 +3,10 @@
 import mock
 import pytest
 
+from osf_tests.factories import InstitutionFactory, RegionFactory
+
 from addons.base.tests.serializers import StorageAddonSerializerTestSuiteMixin
+from addons.onedrivebusiness import SHORT_NAME
 from addons.onedrivebusiness.tests.factories import OneDriveBusinessAccountFactory
 from addons.onedrivebusiness.serializer import OneDriveBusinessSerializer
 
@@ -43,6 +46,19 @@ class TestOneDriveBusinessSerializer(StorageAddonSerializerTestSuiteMixin, OsfTe
         self.mock_node_settings_oauth_provider_fetch_access_token.start()
         self.mock_node_settings_ensure_team_folder.start()
         super(TestOneDriveBusinessSerializer, self).setUp()
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
 
     def tearDown(self):
         self.mock_node_settings_ensure_team_folder.stop()

--- a/addons/onedrivebusiness/tests/test_view.py
+++ b/addons/onedrivebusiness/tests/test_view.py
@@ -9,11 +9,12 @@ import pytest
 
 from framework.auth import Auth
 from tests.base import OsfTestCase, get_default_metaschema
-from osf_tests.factories import ProjectFactory, AuthUserFactory, DraftRegistrationFactory, InstitutionFactory
+from osf_tests.factories import ProjectFactory, AuthUserFactory, DraftRegistrationFactory, InstitutionFactory, RegionFactory
 
 from addons.base.tests.views import (
     OAuthAddonConfigViewsTestCaseMixin
 )
+from addons.onedrivebusiness import SHORT_NAME
 from addons.onedrivebusiness.tests.utils import OneDriveBusinessAddonTestCase
 import addons.onedrivebusiness.settings as onedrivebusiness_settings
 from website.util import api_url_for
@@ -45,6 +46,19 @@ class TestOneDriveBusinessViews(OneDriveBusinessAddonTestCase, OAuthAddonConfigV
         self.mock_node_settings_oauth_provider_fetch_access_token.start()
         self.mock_node_settings_ensure_team_folder.start()
         super(TestOneDriveBusinessViews, self).setUp()
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.project.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
 
     def tearDown(self):
         self.mock_node_settings_ensure_team_folder.stop()

--- a/addons/osfstorage/apps.py
+++ b/addons/osfstorage/apps.py
@@ -11,6 +11,9 @@ def osf_storage_root(addon_config, node_settings, auth, **kwargs):
     """Build HGrid JSON for root node. Note: include node URLs for client-side
     URL creation for uploaded files.
     """
+    # GRDM-37149: Hide osfstorage for institutional provider
+    if not node_settings.has_auth:
+        return None
     node = node_settings.owner
     root = rubeus.build_addon_root(
         node_settings=node_settings,

--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -10,6 +10,8 @@ from django.contrib.contenttypes.models import ContentType
 from psycopg2._psycopg import AsIs
 
 from addons.base.models import BaseNodeSettings, BaseStorageAddon, BaseUserSettings
+# GRDM-37149: Hide osfstorage for institutional provider
+from addons.base.exceptions import AddonError
 from osf.utils.fields import EncryptedJSONField
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.exceptions import InvalidTagError, NodeStateError, TagNotFoundError
@@ -517,8 +519,20 @@ class UserSettings(BaseUserSettings):
 
 class NodeSettings(BaseNodeSettings, BaseStorageAddon):
     # Required overrides
-    complete = True
-    has_auth = True
+    @property
+    def complete(self):
+        # GRDM-37149: Hide osfstorage for institutional provider
+        return self.has_auth
+
+    @property
+    def has_auth(self):
+        # GRDM-37149: Hide osfstorage for institutional provider
+        from addons.base import institutions_utils
+        region_disabled, _ = institutions_utils.get_region_provider(self.owner)
+        if region_disabled:
+            # hide osfstorage
+            return False
+        return True
 
     root_node = models.ForeignKey(OsfStorageFolder, null=True, blank=True, on_delete=models.CASCADE)
 
@@ -579,6 +593,10 @@ class NodeSettings(BaseNodeSettings, BaseStorageAddon):
         return clone, None
 
     def serialize_waterbutler_settings(self):
+        # GRDM-37149: Hide osfstorage for institutional provider
+        if not self.has_auth:
+            raise AddonError('{} is not configured'.format(
+                self.config.short_name))
         return dict(Region.objects.get(id=self.region_id).waterbutler_settings, **{
             'nid': self.owner._id,
             'rootId': self.root_node._id,
@@ -591,6 +609,10 @@ class NodeSettings(BaseNodeSettings, BaseStorageAddon):
         })
 
     def serialize_waterbutler_credentials(self):
+        # GRDM-37149: Hide osfstorage for institutional provider
+        if not self.has_auth:
+            raise AddonError('{} is not configured'.format(
+                self.config.short_name))
         return Region.objects.get(id=self.region_id).waterbutler_credentials
 
     def create_waterbutler_log(self, auth, action, metadata):

--- a/addons/osfstorage/tests/test_institutions.py
+++ b/addons/osfstorage/tests/test_institutions.py
@@ -1,0 +1,50 @@
+import pytest
+from framework.auth import Auth
+from osf_tests.factories import ProjectFactory, InstitutionFactory, RegionFactory
+
+from addons.osfstorage.apps import osf_storage_root
+from addons.osfstorage.tests import factories
+from addons.osfstorage.tests.utils import StorageTestCase
+
+@pytest.mark.django_db
+class TestNonInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+
+    def test_fields(self):
+        assert self.osfstorage._id
+        assert self.osfstorage.has_auth is True
+        assert self.osfstorage.complete is True
+
+    def test_root(self):
+        auth = Auth(user=self.user)
+        assert osf_storage_root(None, self.osfstorage, auth) is not None
+
+@pytest.mark.django_db
+class TestInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={'disabled': True}
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+
+    def test_fields(self):
+        assert self.osfstorage._id
+        assert self.osfstorage.has_auth is False
+        assert self.osfstorage.complete is False
+
+    def test_root(self):
+        auth = Auth(user=self.user)
+        assert osf_storage_root(None, self.osfstorage, auth) is None

--- a/addons/s3compatinstitutions/apps.py
+++ b/addons/s3compatinstitutions/apps.py
@@ -17,7 +17,9 @@ TEMPLATE_PATH = os.path.join(
 
 def s3compatinstitutions_root(addon_config, node_settings, auth, **kwargs):
     from addons.osfstorage.models import Region
-
+    # GRDM-37149: Hide deactivated institutional storage
+    if not node_settings.complete:
+        return None
     node = node_settings.owner
     institution = node_settings.addon_option.institution
     if Region.objects.filter(_id=institution._id).exists():

--- a/addons/s3compatinstitutions/tests/test_automount.py
+++ b/addons/s3compatinstitutions/tests/test_automount.py
@@ -14,8 +14,10 @@ from osf_tests.factories import (
     InstitutionFactory,
     ExternalAccountFactory,
     UserFactory,
-    ProjectFactory
+    ProjectFactory,
+    RegionFactory,
 )
+from addons.s3compatinstitutions.apps import SHORT_NAME
 from addons.s3compatinstitutions.models import NodeSettings
 from admin_tests.rdm_addons import factories as rdm_addon_factories
 
@@ -69,6 +71,18 @@ class TestS3Compatinstitutions(unittest.TestCase):
                 self.project = ProjectFactory(creator=self.user)
         else:
             self.project = ProjectFactory(creator=self.user)
+        self.osfstorage = self.project.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
 
     def _allow(self, save=True):
         self.option.is_allowed = True

--- a/addons/s3compatinstitutions/tests/test_institutions.py
+++ b/addons/s3compatinstitutions/tests/test_institutions.py
@@ -1,0 +1,88 @@
+import pytest
+from framework.auth import Auth
+from osf_tests.factories import ProjectFactory, InstitutionFactory, RegionFactory
+from admin_tests.rdm_addons.factories import RdmAddonOptionFactory
+
+from osf.models.rdm_addons import RdmAddonOption
+from addons.osfstorage.tests import factories
+from addons.osfstorage.tests.utils import StorageTestCase
+from addons.s3compatinstitutions.apps import SHORT_NAME
+
+@pytest.mark.django_db
+class TestNonInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False
+
+@pytest.mark.django_db
+class TestTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage',
+            waterbutler_settings={
+                'storage': {
+                    'provider': SHORT_NAME,
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is not False
+
+@pytest.mark.django_db
+class TestNonTargetInstitutionalNodeSettings(StorageTestCase):
+    def setUp(self):
+        super(TestNonTargetInstitutionalNodeSettings, self).setUp()
+        self.user = factories.AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.institution = InstitutionFactory()
+        self.osfstorage = self.node.get_addon('osfstorage')
+        new_region = RegionFactory(
+            _id=self.institution._id,
+            name='Institutional Storage for Another Addon',
+            waterbutler_settings={
+                'storage': {
+                    'provider': 'another_provider',
+                },
+            }
+        )
+        self.osfstorage.region = new_region
+        self.osfstorage.save()
+        self.node.add_addon(SHORT_NAME, auth=Auth(user=self.user))
+        self.node_settings = self.node.get_addon(SHORT_NAME)
+        self.node_settings.folder_id = 'some_folder'
+        self.node_settings.addon_option = RdmAddonOptionFactory()
+        self.node_settings.save()
+
+    def test_fields(self):
+        assert self.node_settings._id
+        assert self.node_settings.has_auth is not False
+        assert self.node_settings.complete is False

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -184,6 +184,9 @@ class BaseFileSerializer(JSONAPISerializer):
     current_version = ser.IntegerField(help_text='Latest file version', read_only=True, source='current_version_number')
     delete_allowed = ser.BooleanField(read_only=True, required=False)
 
+    # GRDM-37149: Attribute value indicating whether it is an institutional storage
+    for_institutions = ser.SerializerMethodField(read_only=True, help_text='Whether the addon is institutional storage')
+
     parent_folder = RelationshipField(
         related_view='files:file-detail',
         related_view_kwargs={'file_id': '<parent._id>'},
@@ -291,6 +294,12 @@ class BaseFileSerializer(JSONAPISerializer):
         if obj.provider == 'osfstorage' and obj.is_file:
             extras['downloads'] = obj.get_download_count()
         return extras
+
+    def get_for_institutions(self, obj):
+        # GRDM-37149: Attribute value indicating whether it is an institutional storage
+        if obj.provider not in settings.ADDONS_AVAILABLE_DICT:
+            return False
+        return settings.ADDONS_AVAILABLE_DICT[obj.provider].for_institutions
 
     def get_current_user_can_comment(self, obj):
         user = self.context['request'].user

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -184,9 +184,6 @@ class BaseFileSerializer(JSONAPISerializer):
     current_version = ser.IntegerField(help_text='Latest file version', read_only=True, source='current_version_number')
     delete_allowed = ser.BooleanField(read_only=True, required=False)
 
-    # GRDM-37149: Attribute value indicating whether it is an institutional storage
-    for_institutions = ser.SerializerMethodField(read_only=True, help_text='Whether the addon is institutional storage')
-
     parent_folder = RelationshipField(
         related_view='files:file-detail',
         related_view_kwargs={'file_id': '<parent._id>'},
@@ -294,12 +291,6 @@ class BaseFileSerializer(JSONAPISerializer):
         if obj.provider == 'osfstorage' and obj.is_file:
             extras['downloads'] = obj.get_download_count()
         return extras
-
-    def get_for_institutions(self, obj):
-        # GRDM-37149: Attribute value indicating whether it is an institutional storage
-        if obj.provider not in settings.ADDONS_AVAILABLE_DICT:
-            return False
-        return settings.ADDONS_AVAILABLE_DICT[obj.provider].for_institutions
 
     def get_current_user_can_comment(self, obj):
         user = self.context['request'].user

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -44,6 +44,7 @@ from website.project.model import NodeUpdateError
 from website.util import quota
 from osf.utils import permissions as osf_permissions
 from api.base import settings as api_settings
+from website import settings as website_settings
 
 
 class RegistrationProviderRelationshipField(RelationshipField):
@@ -1440,9 +1441,9 @@ class NodeStorageProviderSerializer(JSONAPISerializer):
 
     def get_for_institutions(self, obj):
         # GRDM-37149: Attribute value indicating whether it is an institutional storage
-        if obj.provider not in settings.ADDONS_AVAILABLE_DICT:
+        if obj.provider not in website_settings.ADDONS_AVAILABLE_DICT:
             return False
-        return settings.ADDONS_AVAILABLE_DICT[obj.provider].for_institutions
+        return website_settings.ADDONS_AVAILABLE_DICT[obj.provider].for_institutions
 
 class InstitutionRelated(JSONAPIRelationshipSerializer):
     id = ser.CharField(source='_id', required=False, allow_null=True)

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1390,6 +1390,8 @@ class NodeStorageProviderSerializer(JSONAPISerializer):
     name = ser.CharField(read_only=True)
     path = ser.CharField(read_only=True)
     node = ser.CharField(source='node_id', read_only=True)
+    # GRDM-37149: Attribute value indicating whether it is an institutional storage
+    for_institutions = ser.SerializerMethodField(read_only=True, help_text='Whether the addon is institutional storage')
     provider = ser.CharField(read_only=True)
     files = NodeFileHyperLinkField(
         related_view='nodes:node-files',
@@ -1435,6 +1437,12 @@ class NodeStorageProviderSerializer(JSONAPISerializer):
                 'filter[categories]': 'storage',
             },
         )
+
+    def get_for_institutions(self, obj):
+        # GRDM-37149: Attribute value indicating whether it is an institutional storage
+        if obj.provider not in settings.ADDONS_AVAILABLE_DICT:
+            return False
+        return settings.ADDONS_AVAILABLE_DICT[obj.provider].for_institutions
 
 class InstitutionRelated(JSONAPIRelationshipSerializer):
     id = ser.CharField(source='_id', required=False, allow_null=True)

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -249,26 +249,8 @@ class NodeFileCollector(object):
 
     def _collect_addons(self, node):
         rv = []
-        region_disabled = False
-        region_provider = None
-        osfstorage = node.get_addon('osfstorage')
-        if osfstorage:
-            region = osfstorage.region
-            if region and region.waterbutler_settings:
-                region_disabled = region.waterbutler_settings.get(
-                    'disabled', False)
-                storage = region.waterbutler_settings.get('storage', None)
-                if storage:
-                    region_provider = storage.get('provider', None)
-
         for addon in node.get_addons():
             if addon.config.has_hgrid_files:
-                if addon == osfstorage and region_disabled:
-                    continue  # skip (hide osfstorage)
-                if addon.config.for_institutions:
-                    if region_provider != addon.config.short_name:
-                        continue  # skip (hide this *institutions)
-
                 # WARNING: get_hgrid_data can return None if the addon is added but has no credentials.
                 try:
                     temp = addon.config.get_hgrid_data(addon, self.auth, **self.extra)


### PR DESCRIPTION
あわせてember の https://github.com/RCOSDP/RDM-ember-osf-web/pull/89 の Merge もお願いします。


## Purpose

「拡張ストレージマウント方式」機関ストレージにおいてWeb UIとAPIの間で一貫性がない状態を解消するため、Viewでストレージの表示・非表示を制御するのではなく、Modelで表示・非表示を制御するようにしました。

## Changes

修正方針については GRDM-37149 のPowerPointファイルをご覧ください。

## QA Notes

変更した各Storageに関して、ユニットテスト追加済みです。
統合テストは以下の3つのストレージにおいて、BinderHubアドオンとの連携が正常に動作するかという観点で実施しております。

- デフォルトストレージ
- 機関ストレージ(一括マウント方式): 例としてAmazon S3
- 機関ストレージ(アドオン方式): 例としてOneDrive for Office365

## Documentation

GRDM-37149 のPowerPointファイルをご覧ください。

## Side Effects

OSS部分コードに対する変更は、マージ時に識別しやすくするため、できるだけインラインコメントを入れております。

## Ticket

GRDM-37149