### PR TITLE
hotfix 39082 (temporary)

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -338,14 +338,14 @@
           {% if not user.is_superuser and user.is_staff %}
             <li><a href="{% url 'custom_storage_location:institutional_storage' %}"><i class='fa fa-link'></i> <span>{% trans "Institutional Storage" %}</span></a></li>
           {% endif %}
-          {% if user.is_superuser %}
+          {% if False and user.is_superuser %}
             <li class="{% if request.resolver_match.url_name == 'export_data_institutions' or request.resolver_match.url_name == 'export_data_institutional_storage' %}active{% endif %}">
                 <a href="{% url 'custom_storage_location:export_data:export_data_institutions' %}">
                     <i class="fa fa-link"></i> <span>{% trans "Institutional Storages Control" %}</span>
                 </a>
             </li>
           {% endif %}
-          {% if not user.is_superuser and user.is_institutional_admin %}
+          {% if False and not user.is_superuser and user.is_institutional_admin %}
             <li class="{% if request.resolver_match.url_name == 'export_data_institutional_storage' %}active{% endif %}">
                 <a href="{% url 'custom_storage_location:export_data:export_data_institutional_storage' institution_id=user.representative_affiliated_institution.id %}">
                     <i class="fa fa-link"></i> <span>{% trans "Institutional Storages Control" %}</span>
@@ -358,7 +358,7 @@
           {% if user.is_superuser or user.is_staff %}
             <li><a href="{% url 'institutional_storage_quota_control:list_institution_storage' %}"><i class='fa fa-link'></i> <span>{% trans "Inst. Storage Quota Control" %}</span></a></li>
           {% endif %}
-          {% if user.is_superuser or user.is_institutional_admin %}
+          {% if False and user.is_superuser or False and user.is_institutional_admin %}
             <li class="{% if request.resolver_match.url_name == 'export_data_storage_location'  %}active{% endif %}">
                 <a href="{% url 'custom_storage_location:export_data:export_data_storage_location' %}">
                     <i class="fa fa-link"></i> <span>{% trans "Export data storage location" %}</span>

--- a/admin/templates/rdm_custom_storage_location/export_data_institutional_storages.html
+++ b/admin/templates/rdm_custom_storage_location/export_data_institutional_storages.html
@@ -13,6 +13,7 @@
 {% endblock title %}
 
 {% block content %}
+    <h2><small style="color: red;">本画面内の機能はベータ版であり、不用な操作はお控え頂きたく存じます。操作される方は <a href="mailto:rdm_support@nii.ac.jp">rdm_support@nii.ac.jp</a> への連絡をお願い致します。</small></h2>
     <h2>{% trans "List of Institutional Storages" %}<br/><small>(for {{ institution.name }})</small></h2>
 
     {% include "util/pagination.html" with items=page status=status %}

--- a/admin/templates/rdm_custom_storage_location/export_data_institutions.html
+++ b/admin/templates/rdm_custom_storage_location/export_data_institutions.html
@@ -13,6 +13,7 @@
 {% endblock title %}
 
 {% block content %}
+    <h2><small style="color: red;">本画面内の機能はベータ版であり、不用な操作はお控え頂きたく存じます。操作される方は <a href="mailto:rdm_support@nii.ac.jp">rdm_support@nii.ac.jp</a> への連絡をお願い致します。</small></h2>
     <h2>{% trans "List of Institutions" %}</h2>
 
     {% include "util/pagination.html" with items=page status=status %}

--- a/admin/templates/rdm_custom_storage_location/export_data_list.html
+++ b/admin/templates/rdm_custom_storage_location/export_data_list.html
@@ -13,6 +13,7 @@
 {% endblock title %}
 
 {% block content %}
+    <h2><small style="color: red;">本画面内の機能はベータ版であり、不用な操作はお控え頂きたく存じます。操作される方は <a href="mailto:rdm_support@nii.ac.jp">rdm_support@nii.ac.jp</a> への連絡をお願い致します。</small></h2>
     <h2>{% trans "Export Data List" %}<br/><small>(for {{ institution.name }})</small></h2>
 
     <form method="get"

--- a/admin/templates/rdm_custom_storage_location/export_data_list_institutions.html
+++ b/admin/templates/rdm_custom_storage_location/export_data_list_institutions.html
@@ -13,6 +13,7 @@
 {% endblock title %}
 
 {% block content %}
+    <h2><small style="color: red;">本画面内の機能はベータ版であり、不用な操作はお控え頂きたく存じます。操作される方は <a href="mailto:rdm_support@nii.ac.jp">rdm_support@nii.ac.jp</a> への連絡をお願い致します。</small></h2>
     <h2>{% trans "List of Institutions" %}</h2>
 
     {% include "util/pagination.html" with items=page status=status %}

--- a/admin/templates/rdm_custom_storage_location/export_data_storage_location.html
+++ b/admin/templates/rdm_custom_storage_location/export_data_storage_location.html
@@ -15,6 +15,7 @@
 {% endblock title %}
 
 {% block content %}
+    <h2><small style="color: red;">本画面内の機能はベータ版であり、不用な操作はお控え頂きたく存じます。操作される方は <a href="mailto:rdm_support@nii.ac.jp">rdm_support@nii.ac.jp</a> への連絡をお願い致します。</small></h2>
     <h2>{% trans "Export data storage location" %}{% if user.is_institutional_admin %}<small>({{ institution.name }})</small>{% endif %}</h2>
 
     <div id="content-main">


### PR DESCRIPTION
## Purpose

redmine 39082 対応
エクスポートリストア関連のメニューを非表示にする。
一時的な対処であり、将来においてrevertされる予定。

## Changes

エクスポートリストア関連のメニューを非表示にした。
各機能のURLを直接アクセスすることは可能だが、各画面には警告メッセージを追加した。


## Side Effects

なし

## Ticket

redmine 39082 対応
