### PR TITLE
Feature/202210 institutional storage control/fixedbug/39569

### DIFF
--- a/admin/rdm_custom_storage_location/export_data/views/export.py
+++ b/admin/rdm_custom_storage_location/export_data/views/export.py
@@ -248,7 +248,8 @@ def export_data_process(task, cookies, export_data_id, **kwargs):
                 continue
 
         # Separate the failed file list from the file_info_json
-        files_not_found, sub_size, sub_files_numb = separate_failed_files(file_info_json, files_versions_not_found)
+        files = file_info_json.get('files', [])
+        files_not_found, sub_size, sub_files_numb = separate_failed_files(files, files_versions_not_found)
         export_data_json['size'] -= sub_size
         export_data_json['files_numb'] -= sub_files_numb
         logger.debug(f'uploaded file versions')
@@ -339,8 +340,7 @@ def export_data_process(task, cookies, export_data_id, **kwargs):
         raise Ignore(str(e))
 
 
-def separate_failed_files(file_info_json, files_versions_not_found):
-    files = file_info_json.get('files', [])
+def separate_failed_files(files, files_versions_not_found):
     files_not_found = []
     for file_id, ver_ids in files_versions_not_found.items():
         # empty ver_ids

--- a/admin/rdm_custom_storage_location/export_data/views/restore.py
+++ b/admin/rdm_custom_storage_location/export_data/views/restore.py
@@ -660,9 +660,9 @@ def copy_files_from_export_data_to_destination(task, current_process_step, expor
                     cookies, base_url=destination_base_url, **kwargs)
                 if response_body is None:
                     if file_id not in files_versions_restore_fail:
-                        files_versions_restore_fail[file_id] = [version]
+                        files_versions_restore_fail[file_id] = [version_id]
                     else:
-                        files_versions_restore_fail[file_id].append(version)
+                        files_versions_restore_fail[file_id].append(version_id)
                     continue
 
                 response_id = response_body.get('data', {}).get('id')

--- a/admin/static/js/rdm_custom_storage_location/rdm-institutional-storage-page.js
+++ b/admin/static/js/rdm_custom_storage_location/rdm-institutional-storage-page.js
@@ -1123,18 +1123,25 @@ function showExportFilesNotFound(data) {
             'file_path', 'file_name', 'versions', 'size', 'stamper']];
         data_res.forEach(function (file) {
             file.version.forEach(function (version) {
-                list_file_info_export_fail.push([file.project.id, file.project.name, version.contributor,
-                    file.id, file.materialized_path, file.name, version.identifier,
-                    file.size, file.timestamp.verify_user]);
-                text_show_file += "<tr><td>" + file.project.id + "</td><td>" + file.project.name + "</td><td>"
-                    + version.contributor + "</td><td>" + file.id + "</td><td>"
-                    + file.materialized_path + "</td><td>" + file.name + "</td><td>"
-                    + version.identifier + "</td><td>" + file.size + " Bytes</td><td>"
-                    + file.timestamp.verify_user + "</td></tr>";
+                list_file_info_export_fail.push([
+                    file.project.id, file.project.name,
+                    version.contributor, file.id,
+                    file.materialized_path, file.name,
+                    version.identifier, version.size,
+                    file.timestamp.verify_user
+                ]);
+                text_show_file += "<tr>" +
+                    "<td>" + file.project.id + "</td><td>" + file.project.name + "</td>" +
+                    "<td>" + version.contributor + "</td><td>" + file.id + "</td>" +
+                    "<td>" + file.materialized_path + "</td><td>" + file.name + "</td>" +
+                    "<td>" + version.identifier + "</td><td>" + version.size + " Bytes</td>" +
+                    "<td>" + file.timestamp.verify_user + "</td>" +
+                    "</tr>";
             });
         });
-        $('.table-ng-file-export-not-exist').html(text_show_file);
-        $('.table-ng-file-export-not-exist').css('word-break', 'break-word');
+        var $table_ng_file_export_not_exist = $('.table-ng-file-export-not-exist');
+        $table_ng_file_export_not_exist.html(text_show_file);
+        $table_ng_file_export_not_exist.css('word-break', 'break-word');
     }
 }
 
@@ -1666,18 +1673,25 @@ function checkTaskStatus(task_id, task_type) {
                     var data_res_unique = Object.values(data_res_map);
                     data_res_unique.forEach(function (file) {
                         file.version.forEach(function(version) {
-                            list_file_info_restore_fail.push([file.project.id, file.project.name, version.contributor,
-                                                file.id, file.materialized_path, file.name, version.identifier,
-                                                file.size, file.timestamp.verify_user]);
-                            text_show_file += "<tr><td>" + file.project.id + "</td><td>" + file.project.name + "</td><td>"
-                                                + version.contributor + "</td><td>"+ file.id + "</td><td>"
-                                                + file.materialized_path + "</td><td>" + file.name + "</td><td>"
-                                                + version.identifier + "</td><td>" + file.size + " Bytes</td><td>"
-                                                + file.timestamp.verify_user + "</td></tr>";
+                            list_file_info_restore_fail.push([
+                                file.project.id, file.project.name,
+                                version.contributor, file.id,
+                                file.materialized_path, file.name,
+                                version.identifier, file.size,
+                                file.timestamp.verify_user
+                            ]);
+                            text_show_file += "<tr>" +
+                                "<td>" + file.project.id + "</td><td>" + file.project.name + "</td>" +
+                                "<td>" + version.contributor + "</td><td>"+ file.id + "</td>" +
+                                "<td>" + file.materialized_path + "</td><td>" + file.name + "</td>" +
+                                "<td>" + version.identifier + "</td><td>" + version.size + " Bytes</td>" +
+                                "<td>" + file.timestamp.verify_user + "</td>" +
+                                "</tr>";
                         });
                     });
-                    $('.table-ng-file-restore-not-exist').html(text_show_file);
-                    $('.table-ng-file-restore-not-exist').css('word-break', 'break-word');
+                    var $table_ng_file_restore_not_exist = $('.table-ng-file-restore-not-exist');
+                    $table_ng_file_restore_not_exist.html(text_show_file);
+                    $table_ng_file_restore_not_exist.css('word-break', 'break-word');
                 }
             } else if (result_task_type === 'Stop Restore') {
                 // Done stopping restore export data

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
@@ -71,14 +71,7 @@ class TestGetTaskResult(unittest.TestCase):
 
 class TestSeparateFailedFiles(unittest.TestCase):
     def setUp(self):
-        self.file_info_json = {
-            'institution': {
-                'id': 2,
-                'guid': 'inst002',
-                'name': 'inst002',
-            },
-            'folders': [],
-            'files': [
+        self.files = [
                 {
                     'id': 3000,
                     'path': '/24chars24chars24chars24c',
@@ -283,8 +276,7 @@ class TestSeparateFailedFiles(unittest.TestCase):
                     'timestamp': {},
                     'checkout_id': None
                 },
-            ],
-        }
+            ]
 
     def test_separate_failed_files__c1_empty_version_ids(self):
         files_versions_not_found = {
@@ -294,7 +286,7 @@ class TestSeparateFailedFiles(unittest.TestCase):
         expected_sub_files_numb = 0
 
         _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
-            self.file_info_json,
+            self.files,
             files_versions_not_found
         )
 
@@ -310,7 +302,7 @@ class TestSeparateFailedFiles(unittest.TestCase):
         expected_sub_files_numb = 0
 
         _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
-            self.file_info_json,
+            self.files,
             files_versions_not_found
         )
 
@@ -327,13 +319,12 @@ class TestSeparateFailedFiles(unittest.TestCase):
         expected_sub_files_numb = 0
 
         _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
-            self.file_info_json,
+            self.files,
             files_versions_not_found
         )
 
-        files = self.file_info_json.get('files', [])
         file = next(
-            (_file for idx, _file in enumerate(files) if file_id == _file['id']),
+            (_file for idx, _file in enumerate(self.files) if file_id == _file['id']),
             None  # default
         )
         self.assertEqual(file, None)
@@ -352,13 +343,12 @@ class TestSeparateFailedFiles(unittest.TestCase):
         file_id = 4000
 
         _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
-            self.file_info_json,
+            self.files,
             files_versions_not_found
         )
 
-        files = self.file_info_json.get('files', [])
         file = next(
-            (_file for idx, _file in enumerate(files) if file_id == _file['id']),
+            (_file for idx, _file in enumerate(self.files) if file_id == _file['id']),
             None  # default
         )
         self.assertEqual(file, None)
@@ -381,13 +371,12 @@ class TestSeparateFailedFiles(unittest.TestCase):
         expected_sub_files_numb = 0
 
         _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
-            self.file_info_json,
+            self.files,
             files_versions_not_found
         )
 
-        files = self.file_info_json.get('files', [])
         file = next(
-            (_file for idx, _file in enumerate(files) if file_id == _file['id']),
+            (_file for idx, _file in enumerate(self.files) if file_id == _file['id']),
             None  # default
         )
         self.assertEqual(file['id'], file_id)
@@ -402,13 +391,12 @@ class TestSeparateFailedFiles(unittest.TestCase):
         file_id = 6000
 
         _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
-            self.file_info_json,
+            self.files,
             files_versions_not_found
         )
 
-        files = self.file_info_json.get('files', [])
         file = next(
-            (_file for idx, _file in enumerate(files) if file_id == _file['id']),
+            (_file for idx, _file in enumerate(self.files) if file_id == _file['id']),
             None  # default
         )
         self.assertEqual(file['id'], file_id)

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
@@ -72,216 +72,216 @@ class TestGetTaskResult(unittest.TestCase):
 class TestSeparateFailedFiles(unittest.TestCase):
     def setUp(self):
         self.file_info_json = {
-            "institution": {
-                "id": 2,
-                "guid": "inst002",
-                "name": "inst002",
+            'institution': {
+                'id': 2,
+                'guid': 'inst002',
+                'name': 'inst002',
             },
-            "folders": [],
-            "files": [
+            'folders': [],
+            'files': [
                 {
-                    "id": 3000,
-                    "path": "/24chars24chars24chars24c",
-                    "materialized_path": "/folder_path/file_name.ext",
-                    "name": "file_name.ext",
-                    "provider": "osfstorage",
-                    "project": {
-                        "id": "prjid",
-                        "name": "PRJ 20231005 001"
+                    'id': 3000,
+                    'path': '/24chars24chars24chars24c',
+                    'materialized_path': '/folder_path/file_name.ext',
+                    'name': 'file_name.ext',
+                    'provider': 'osfstorage',
+                    'project': {
+                        'id': 'prjid',
+                        'name': 'PRJ 20231005 001'
                     },
-                    "tags": [],
-                    "version": [
+                    'tags': [],
+                    'version': [
                     ],
-                    "size": 3000,
-                    "location": {
-                        "object": "64chars64chars64chars64chars64chars64chars64chars64chars64chars6",
-                        "provider": "s3compat"
+                    'size': 3000,
+                    'location': {
+                        'object': '64chars64chars64chars64chars64chars64chars64chars64chars64chars6',
+                        'provider': 's3compat'
                     },
-                    "timestamp": {},
-                    "checkout_id": None
+                    'timestamp': {},
+                    'checkout_id': None
                 },
                 {
-                    "id": 4000,
-                    "path": "/24chars24chars24chars24c",
-                    "materialized_path": "/folder_path/file_name.ext",
-                    "name": "file_name.ext",
-                    "provider": "osfstorage",
-                    "project": {
-                        "id": "prjid",
-                        "name": "PRJ 20231005 001"
+                    'id': 4000,
+                    'path': '/24chars24chars24chars24c',
+                    'materialized_path': '/folder_path/file_name.ext',
+                    'name': 'file_name.ext',
+                    'provider': 'osfstorage',
+                    'project': {
+                        'id': 'prjid',
+                        'name': 'PRJ 20231005 001'
                     },
-                    "tags": [],
-                    "version": [
+                    'tags': [],
+                    'version': [
                         {
-                            "identifier": "2",
-                            "size": 4001,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '2',
+                            'size': 4001,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion264charsversion264charsversion264charsversion264ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                                'provider': 's3compat'
                             }
                         },
                         {
-                            "identifier": "1",
-                            "size": 4000,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '1',
+                            'size': 4000,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion164charsversion164charsversion164charsversion164ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion164charsversion164charsversion164charsversion164ch',
+                                'provider': 's3compat'
                             }
                         }
                     ],
-                    "size": 4001,
-                    "location": {
-                        "object": "64charsversion264charsversion264charsversion264charsversion264ch",
-                        "provider": "s3compat"
+                    'size': 4001,
+                    'location': {
+                        'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                        'provider': 's3compat'
                     },
-                    "timestamp": {},
-                    "checkout_id": None
+                    'timestamp': {},
+                    'checkout_id': None
                 },
                 {
-                    "id": 5000,
-                    "path": "/24chars24chars24chars24c",
-                    "materialized_path": "/folder_path/file_name.ext",
-                    "name": "file_name.ext",
-                    "provider": "osfstorage",
-                    "project": {
-                        "id": "prjid",
-                        "name": "PRJ 20231005 001"
+                    'id': 5000,
+                    'path': '/24chars24chars24chars24c',
+                    'materialized_path': '/folder_path/file_name.ext',
+                    'name': 'file_name.ext',
+                    'provider': 'osfstorage',
+                    'project': {
+                        'id': 'prjid',
+                        'name': 'PRJ 20231005 001'
                     },
-                    "tags": [],
-                    "version": [
+                    'tags': [],
+                    'version': [
                         {
-                            "identifier": "2",
-                            "size": 5001,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '2',
+                            'size': 5001,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion264charsversion264charsversion264charsversion264ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                                'provider': 's3compat'
                             }
                         },
                         {
-                            "identifier": "1",
-                            "size": 5000,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '1',
+                            'size': 5000,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion164charsversion164charsversion164charsversion164ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion164charsversion164charsversion164charsversion164ch',
+                                'provider': 's3compat'
                             }
                         }
                     ],
-                    "size": 5001,
-                    "location": {
-                        "object": "64charsversion264charsversion264charsversion264charsversion264ch",
-                        "provider": "s3compat"
+                    'size': 5001,
+                    'location': {
+                        'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                        'provider': 's3compat'
                     },
-                    "timestamp": {},
-                    "checkout_id": None
+                    'timestamp': {},
+                    'checkout_id': None
                 },
                 {
-                    "id": 6000,
-                    "path": "/24chars24chars24chars24c",
-                    "materialized_path": "/folder_path/file_name.ext",
-                    "name": "file_name.ext",
-                    "provider": "osfstorage",
-                    "project": {
-                        "id": "prjid",
-                        "name": "PRJ 20231005 001"
+                    'id': 6000,
+                    'path': '/24chars24chars24chars24c',
+                    'materialized_path': '/folder_path/file_name.ext',
+                    'name': 'file_name.ext',
+                    'provider': 'osfstorage',
+                    'project': {
+                        'id': 'prjid',
+                        'name': 'PRJ 20231005 001'
                     },
-                    "tags": [],
-                    "version": [
+                    'tags': [],
+                    'version': [
                         {
-                            "identifier": "6",
-                            "size": 6005,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '6',
+                            'size': 6005,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion664charsversion664charsversion664charsversion664ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion664charsversion664charsversion664charsversion664ch',
+                                'provider': 's3compat'
                             }
                         },
                         {
-                            "identifier": "5",
-                            "size": 6004,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '5',
+                            'size': 6004,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion564charsversion564charsversion564charsversion564ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion564charsversion564charsversion564charsversion564ch',
+                                'provider': 's3compat'
                             }
                         },
                         {
-                            "identifier": "4",
-                            "size": 6003,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '4',
+                            'size': 6003,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion464charsversion464charsversion464charsversion464ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion464charsversion464charsversion464charsversion464ch',
+                                'provider': 's3compat'
                             }
                         },
                         {
-                            "identifier": "3",
-                            "size": 6002,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '3',
+                            'size': 6002,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion364charsversion364charsversion364charsversion364ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion364charsversion364charsversion364charsversion364ch',
+                                'provider': 's3compat'
                             }
                         },
                         {
-                            "identifier": "2",
-                            "size": 6001,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '2',
+                            'size': 6001,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion264charsversion264charsversion264charsversion264ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                                'provider': 's3compat'
                             }
                         },
                         {
-                            "identifier": "1",
-                            "size": 6000,
-                            "version_name": "file_name.ext",
-                            "metadata": {
-                                "kind": "file",
+                            'identifier': '1',
+                            'size': 6000,
+                            'version_name': 'file_name.ext',
+                            'metadata': {
+                                'kind': 'file',
                             },
-                            "location": {
-                                "object": "64charsversion164charsversion164charsversion164charsversion164ch",
-                                "provider": "s3compat"
+                            'location': {
+                                'object': '64charsversion164charsversion164charsversion164charsversion164ch',
+                                'provider': 's3compat'
                             }
                         }
                     ],
-                    "size": 6005,
-                    "location": {
-                        "object": "64charsversion664charsversion664charsversion664charsversion664ch",
-                        "provider": "s3compat"
+                    'size': 6005,
+                    'location': {
+                        'object': '64charsversion664charsversion664charsversion664charsversion664ch',
+                        'provider': 's3compat'
                     },
-                    "timestamp": {},
-                    "checkout_id": None
+                    'timestamp': {},
+                    'checkout_id': None
                 },
             ],
         }

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
@@ -72,211 +72,211 @@ class TestGetTaskResult(unittest.TestCase):
 class TestSeparateFailedFiles(unittest.TestCase):
     def setUp(self):
         self.files = [
-                {
-                    'id': 3000,
-                    'path': '/24chars24chars24chars24c',
-                    'materialized_path': '/folder_path/file_name.ext',
-                    'name': 'file_name.ext',
-                    'provider': 'osfstorage',
-                    'project': {
-                        'id': 'prjid',
-                        'name': 'PRJ 20231005 001'
-                    },
-                    'tags': [],
-                    'version': [
-                    ],
-                    'size': 3000,
-                    'location': {
-                        'object': '64chars64chars64chars64chars64chars64chars64chars64chars64chars6',
-                        'provider': 's3compat'
-                    },
-                    'timestamp': {},
-                    'checkout_id': None
+            {
+                'id': 3000,
+                'path': '/24chars24chars24chars24c',
+                'materialized_path': '/folder_path/file_name.ext',
+                'name': 'file_name.ext',
+                'provider': 'osfstorage',
+                'project': {
+                    'id': 'prjid',
+                    'name': 'PRJ 20231005 001'
                 },
-                {
-                    'id': 4000,
-                    'path': '/24chars24chars24chars24c',
-                    'materialized_path': '/folder_path/file_name.ext',
-                    'name': 'file_name.ext',
-                    'provider': 'osfstorage',
-                    'project': {
-                        'id': 'prjid',
-                        'name': 'PRJ 20231005 001'
-                    },
-                    'tags': [],
-                    'version': [
-                        {
-                            'identifier': '2',
-                            'size': 4001,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion264charsversion264charsversion264charsversion264ch',
-                                'provider': 's3compat'
-                            }
+                'tags': [],
+                'version': [
+                ],
+                'size': 3000,
+                'location': {
+                    'object': '64chars64chars64chars64chars64chars64chars64chars64chars64chars6',
+                    'provider': 's3compat'
+                },
+                'timestamp': {},
+                'checkout_id': None
+            },
+            {
+                'id': 4000,
+                'path': '/24chars24chars24chars24c',
+                'materialized_path': '/folder_path/file_name.ext',
+                'name': 'file_name.ext',
+                'provider': 'osfstorage',
+                'project': {
+                    'id': 'prjid',
+                    'name': 'PRJ 20231005 001'
+                },
+                'tags': [],
+                'version': [
+                    {
+                        'identifier': '2',
+                        'size': 4001,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
                         },
-                        {
-                            'identifier': '1',
-                            'size': 4000,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion164charsversion164charsversion164charsversion164ch',
-                                'provider': 's3compat'
-                            }
+                        'location': {
+                            'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                            'provider': 's3compat'
                         }
-                    ],
-                    'size': 4001,
-                    'location': {
-                        'object': '64charsversion264charsversion264charsversion264charsversion264ch',
-                        'provider': 's3compat'
                     },
-                    'timestamp': {},
-                    'checkout_id': None
-                },
-                {
-                    'id': 5000,
-                    'path': '/24chars24chars24chars24c',
-                    'materialized_path': '/folder_path/file_name.ext',
-                    'name': 'file_name.ext',
-                    'provider': 'osfstorage',
-                    'project': {
-                        'id': 'prjid',
-                        'name': 'PRJ 20231005 001'
-                    },
-                    'tags': [],
-                    'version': [
-                        {
-                            'identifier': '2',
-                            'size': 5001,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion264charsversion264charsversion264charsversion264ch',
-                                'provider': 's3compat'
-                            }
+                    {
+                        'identifier': '1',
+                        'size': 4000,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
                         },
-                        {
-                            'identifier': '1',
-                            'size': 5000,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion164charsversion164charsversion164charsversion164ch',
-                                'provider': 's3compat'
-                            }
+                        'location': {
+                            'object': '64charsversion164charsversion164charsversion164charsversion164ch',
+                            'provider': 's3compat'
                         }
-                    ],
-                    'size': 5001,
-                    'location': {
-                        'object': '64charsversion264charsversion264charsversion264charsversion264ch',
-                        'provider': 's3compat'
-                    },
-                    'timestamp': {},
-                    'checkout_id': None
+                    }
+                ],
+                'size': 4001,
+                'location': {
+                    'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                    'provider': 's3compat'
                 },
-                {
-                    'id': 6000,
-                    'path': '/24chars24chars24chars24c',
-                    'materialized_path': '/folder_path/file_name.ext',
-                    'name': 'file_name.ext',
-                    'provider': 'osfstorage',
-                    'project': {
-                        'id': 'prjid',
-                        'name': 'PRJ 20231005 001'
-                    },
-                    'tags': [],
-                    'version': [
-                        {
-                            'identifier': '6',
-                            'size': 6005,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion664charsversion664charsversion664charsversion664ch',
-                                'provider': 's3compat'
-                            }
+                'timestamp': {},
+                'checkout_id': None
+            },
+            {
+                'id': 5000,
+                'path': '/24chars24chars24chars24c',
+                'materialized_path': '/folder_path/file_name.ext',
+                'name': 'file_name.ext',
+                'provider': 'osfstorage',
+                'project': {
+                    'id': 'prjid',
+                    'name': 'PRJ 20231005 001'
+                },
+                'tags': [],
+                'version': [
+                    {
+                        'identifier': '2',
+                        'size': 5001,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
                         },
-                        {
-                            'identifier': '5',
-                            'size': 6004,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion564charsversion564charsversion564charsversion564ch',
-                                'provider': 's3compat'
-                            }
-                        },
-                        {
-                            'identifier': '4',
-                            'size': 6003,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion464charsversion464charsversion464charsversion464ch',
-                                'provider': 's3compat'
-                            }
-                        },
-                        {
-                            'identifier': '3',
-                            'size': 6002,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion364charsversion364charsversion364charsversion364ch',
-                                'provider': 's3compat'
-                            }
-                        },
-                        {
-                            'identifier': '2',
-                            'size': 6001,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion264charsversion264charsversion264charsversion264ch',
-                                'provider': 's3compat'
-                            }
-                        },
-                        {
-                            'identifier': '1',
-                            'size': 6000,
-                            'version_name': 'file_name.ext',
-                            'metadata': {
-                                'kind': 'file',
-                            },
-                            'location': {
-                                'object': '64charsversion164charsversion164charsversion164charsversion164ch',
-                                'provider': 's3compat'
-                            }
+                        'location': {
+                            'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                            'provider': 's3compat'
                         }
-                    ],
-                    'size': 6005,
-                    'location': {
-                        'object': '64charsversion664charsversion664charsversion664charsversion664ch',
-                        'provider': 's3compat'
                     },
-                    'timestamp': {},
-                    'checkout_id': None
+                    {
+                        'identifier': '1',
+                        'size': 5000,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
+                        },
+                        'location': {
+                            'object': '64charsversion164charsversion164charsversion164charsversion164ch',
+                            'provider': 's3compat'
+                        }
+                    }
+                ],
+                'size': 5001,
+                'location': {
+                    'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                    'provider': 's3compat'
                 },
-            ]
+                'timestamp': {},
+                'checkout_id': None
+            },
+            {
+                'id': 6000,
+                'path': '/24chars24chars24chars24c',
+                'materialized_path': '/folder_path/file_name.ext',
+                'name': 'file_name.ext',
+                'provider': 'osfstorage',
+                'project': {
+                    'id': 'prjid',
+                    'name': 'PRJ 20231005 001'
+                },
+                'tags': [],
+                'version': [
+                    {
+                        'identifier': '6',
+                        'size': 6005,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
+                        },
+                        'location': {
+                            'object': '64charsversion664charsversion664charsversion664charsversion664ch',
+                            'provider': 's3compat'
+                        }
+                    },
+                    {
+                        'identifier': '5',
+                        'size': 6004,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
+                        },
+                        'location': {
+                            'object': '64charsversion564charsversion564charsversion564charsversion564ch',
+                            'provider': 's3compat'
+                        }
+                    },
+                    {
+                        'identifier': '4',
+                        'size': 6003,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
+                        },
+                        'location': {
+                            'object': '64charsversion464charsversion464charsversion464charsversion464ch',
+                            'provider': 's3compat'
+                        }
+                    },
+                    {
+                        'identifier': '3',
+                        'size': 6002,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
+                        },
+                        'location': {
+                            'object': '64charsversion364charsversion364charsversion364charsversion364ch',
+                            'provider': 's3compat'
+                        }
+                    },
+                    {
+                        'identifier': '2',
+                        'size': 6001,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
+                        },
+                        'location': {
+                            'object': '64charsversion264charsversion264charsversion264charsversion264ch',
+                            'provider': 's3compat'
+                        }
+                    },
+                    {
+                        'identifier': '1',
+                        'size': 6000,
+                        'version_name': 'file_name.ext',
+                        'metadata': {
+                            'kind': 'file',
+                        },
+                        'location': {
+                            'object': '64charsversion164charsversion164charsversion164charsversion164ch',
+                            'provider': 's3compat'
+                        }
+                    }
+                ],
+                'size': 6005,
+                'location': {
+                    'object': '64charsversion664charsversion664charsversion664charsversion664ch',
+                    'provider': 's3compat'
+                },
+                'timestamp': {},
+                'checkout_id': None
+            },
+        ]
 
     def test_separate_failed_files__c1_empty_version_ids(self):
         files_versions_not_found = {

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
@@ -69,6 +69,363 @@ class TestGetTaskResult(unittest.TestCase):
         self.assertEqual(export.get_task_result(result), expected_result)
 
 
+class TestSeparateFailedFiles(unittest.TestCase):
+    def setUp(self):
+        self.file_info_json = {
+            "institution": {
+                "id": 2,
+                "guid": "inst002",
+                "name": "inst002",
+            },
+            "folders": [],
+            "files": [
+                {
+                    "id": 3000,
+                    "path": "/24chars24chars24chars24c",
+                    "materialized_path": "/folder_path/file_name.ext",
+                    "name": "file_name.ext",
+                    "provider": "osfstorage",
+                    "project": {
+                        "id": "prjid",
+                        "name": "PRJ 20231005 001"
+                    },
+                    "tags": [],
+                    "version": [
+                    ],
+                    "size": 3000,
+                    "location": {
+                        "object": "64chars64chars64chars64chars64chars64chars64chars64chars64chars6",
+                        "provider": "s3compat"
+                    },
+                    "timestamp": {},
+                    "checkout_id": None
+                },
+                {
+                    "id": 4000,
+                    "path": "/24chars24chars24chars24c",
+                    "materialized_path": "/folder_path/file_name.ext",
+                    "name": "file_name.ext",
+                    "provider": "osfstorage",
+                    "project": {
+                        "id": "prjid",
+                        "name": "PRJ 20231005 001"
+                    },
+                    "tags": [],
+                    "version": [
+                        {
+                            "identifier": "2",
+                            "size": 4001,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion264charsversion264charsversion264charsversion264ch",
+                                "provider": "s3compat"
+                            }
+                        },
+                        {
+                            "identifier": "1",
+                            "size": 4000,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion164charsversion164charsversion164charsversion164ch",
+                                "provider": "s3compat"
+                            }
+                        }
+                    ],
+                    "size": 4001,
+                    "location": {
+                        "object": "64charsversion264charsversion264charsversion264charsversion264ch",
+                        "provider": "s3compat"
+                    },
+                    "timestamp": {},
+                    "checkout_id": None
+                },
+                {
+                    "id": 5000,
+                    "path": "/24chars24chars24chars24c",
+                    "materialized_path": "/folder_path/file_name.ext",
+                    "name": "file_name.ext",
+                    "provider": "osfstorage",
+                    "project": {
+                        "id": "prjid",
+                        "name": "PRJ 20231005 001"
+                    },
+                    "tags": [],
+                    "version": [
+                        {
+                            "identifier": "2",
+                            "size": 5001,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion264charsversion264charsversion264charsversion264ch",
+                                "provider": "s3compat"
+                            }
+                        },
+                        {
+                            "identifier": "1",
+                            "size": 5000,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion164charsversion164charsversion164charsversion164ch",
+                                "provider": "s3compat"
+                            }
+                        }
+                    ],
+                    "size": 5001,
+                    "location": {
+                        "object": "64charsversion264charsversion264charsversion264charsversion264ch",
+                        "provider": "s3compat"
+                    },
+                    "timestamp": {},
+                    "checkout_id": None
+                },
+                {
+                    "id": 6000,
+                    "path": "/24chars24chars24chars24c",
+                    "materialized_path": "/folder_path/file_name.ext",
+                    "name": "file_name.ext",
+                    "provider": "osfstorage",
+                    "project": {
+                        "id": "prjid",
+                        "name": "PRJ 20231005 001"
+                    },
+                    "tags": [],
+                    "version": [
+                        {
+                            "identifier": "6",
+                            "size": 6005,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion664charsversion664charsversion664charsversion664ch",
+                                "provider": "s3compat"
+                            }
+                        },
+                        {
+                            "identifier": "5",
+                            "size": 6004,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion564charsversion564charsversion564charsversion564ch",
+                                "provider": "s3compat"
+                            }
+                        },
+                        {
+                            "identifier": "4",
+                            "size": 6003,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion464charsversion464charsversion464charsversion464ch",
+                                "provider": "s3compat"
+                            }
+                        },
+                        {
+                            "identifier": "3",
+                            "size": 6002,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion364charsversion364charsversion364charsversion364ch",
+                                "provider": "s3compat"
+                            }
+                        },
+                        {
+                            "identifier": "2",
+                            "size": 6001,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion264charsversion264charsversion264charsversion264ch",
+                                "provider": "s3compat"
+                            }
+                        },
+                        {
+                            "identifier": "1",
+                            "size": 6000,
+                            "version_name": "file_name.ext",
+                            "metadata": {
+                                "kind": "file",
+                            },
+                            "location": {
+                                "object": "64charsversion164charsversion164charsversion164charsversion164ch",
+                                "provider": "s3compat"
+                            }
+                        }
+                    ],
+                    "size": 6005,
+                    "location": {
+                        "object": "64charsversion664charsversion664charsversion664charsversion664ch",
+                        "provider": "s3compat"
+                    },
+                    "timestamp": {},
+                    "checkout_id": None
+                },
+            ],
+        }
+
+    def test_separate_failed_files__c1_empty_version_ids(self):
+        files_versions_not_found = {
+            1000: [],
+        }
+        expected_sub_size = 0
+        expected_sub_files_numb = 0
+
+        _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
+            self.file_info_json,
+            files_versions_not_found
+        )
+
+        self.assertEqual(_files_not_found, [])
+        self.assertEqual(_sub_size, expected_sub_size)
+        self.assertEqual(_sub_files_numb, expected_sub_files_numb)
+
+    def test_separate_failed_files__c2_not_found_in_files(self):
+        files_versions_not_found = {
+            2000: ['1'],
+        }
+        expected_sub_size = 0
+        expected_sub_files_numb = 0
+
+        _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
+            self.file_info_json,
+            files_versions_not_found
+        )
+
+        self.assertEqual(_files_not_found, [])
+        self.assertEqual(_sub_size, expected_sub_size)
+        self.assertEqual(_sub_files_numb, expected_sub_files_numb)
+
+    def test_separate_failed_files__c3_file_no_versions(self):
+        files_versions_not_found = {
+            3000: ['1'],
+        }
+        file_id = 3000
+        expected_sub_size = 0
+        expected_sub_files_numb = 0
+
+        _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
+            self.file_info_json,
+            files_versions_not_found
+        )
+
+        files = self.file_info_json.get('files', [])
+        file = next(
+            (_file for idx, _file in enumerate(files) if file_id == _file['id']),
+            None  # default
+        )
+        self.assertEqual(file, None)
+        self.assertEqual(len(_files_not_found), 1)
+        file = _files_not_found[0]
+        versions = file.get('version', [])
+        self.assertEqual(file['id'], file_id)
+        self.assertEqual(versions, [])
+        self.assertEqual(_sub_size, expected_sub_size)
+        self.assertEqual(_sub_files_numb, expected_sub_files_numb)
+
+    def test_separate_failed_files__c4_match_all_versions(self):
+        files_versions_not_found = {
+            4000: ['1', '2'],
+        }
+        file_id = 4000
+
+        _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
+            self.file_info_json,
+            files_versions_not_found
+        )
+
+        files = self.file_info_json.get('files', [])
+        file = next(
+            (_file for idx, _file in enumerate(files) if file_id == _file['id']),
+            None  # default
+        )
+        self.assertEqual(file, None)
+        self.assertEqual(len(_files_not_found), 1)
+        file = _files_not_found[0]
+        self.assertEqual(file['id'], file_id)
+        versions = file.get('version', [])
+        not_found_ver_ids_set = set(files_versions_not_found[file_id])
+        found_ver_ids_set = set([_ver['identifier'] for _ver in versions])
+        self.assertEqual(found_ver_ids_set, not_found_ver_ids_set)
+        self.assertEqual(_sub_size, sum([ver.get('size') for ver in versions]))
+        self.assertEqual(_sub_files_numb, len(versions))
+
+    def test_separate_failed_files__c5_match_no_versions(self):
+        files_versions_not_found = {
+            5000: ['10'],
+        }
+        file_id = 5000
+        expected_sub_size = 0
+        expected_sub_files_numb = 0
+
+        _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
+            self.file_info_json,
+            files_versions_not_found
+        )
+
+        files = self.file_info_json.get('files', [])
+        file = next(
+            (_file for idx, _file in enumerate(files) if file_id == _file['id']),
+            None  # default
+        )
+        self.assertEqual(file['id'], file_id)
+        self.assertEqual(len(_files_not_found), 0)
+        self.assertEqual(_sub_size, expected_sub_size)
+        self.assertEqual(_sub_files_numb, expected_sub_files_numb)
+
+    def test_separate_failed_files__c6_match_some_versions(self):
+        files_versions_not_found = {
+            6000: ['3', '5'],
+        }
+        file_id = 6000
+
+        _files_not_found, _sub_size, _sub_files_numb = export.separate_failed_files(
+            self.file_info_json,
+            files_versions_not_found
+        )
+
+        files = self.file_info_json.get('files', [])
+        file = next(
+            (_file for idx, _file in enumerate(files) if file_id == _file['id']),
+            None  # default
+        )
+        self.assertEqual(file['id'], file_id)
+        versions = file.get('version', [])
+        found_ver_ids_set = set([_ver['identifier'] for _ver in versions])
+        self.assertEqual(len(_files_not_found), 1)
+        file = _files_not_found[0]
+        self.assertEqual(file['id'], file_id)
+        versions = file.get('version', [])
+        _not_found_ver_ids_set = set(files_versions_not_found[file_id])
+        not_found_ver_ids_set = set([_ver['identifier'] for _ver in versions])
+        self.assertEqual(not_found_ver_ids_set, _not_found_ver_ids_set)
+        self.assertEqual(not_found_ver_ids_set - found_ver_ids_set, _not_found_ver_ids_set)
+        self.assertEqual(_sub_size, sum([ver.get('size') for ver in versions]))
+        self.assertEqual(_sub_files_numb, len(versions))
+
+
 class TestExportDataProcess(unittest.TestCase):
     def setUp(self):
         celery_app.conf.update({

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_restore.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_restore.py
@@ -232,39 +232,44 @@ class TestRestoreDataFunction(AdminTestCase):
         self.region = RegionFactory()
         self.project_id = 'project_id'
         self.view = restore
-        self.test_export_data_files = \
-            [
-                {
-                    'id': 995,
-                    'path': '/630de9f5b71d8f06d918fbd7',
-                    'materialized_path': '/@ember-decorators/utils/collapse-proto.d.ts',
-                    'name': 'collapse-proto.d.ts',
-                    'provider': 'osfstorage',
-                    'created_at': '2023-04-18 04:40:25',
-                    'modified_at': '2023-04-18 04:40:25',
-                    'project': {
-                        'id': 'pmockt',
-                        'name': 'Project Mock'
-                    },
-                    'tags': ['hello', 'world'],
-                    'version': [
-                        {
-                            'identifier': '1',
-                            'created_at': '2023-04-18 04:40:25',
-                            'modified_at': '2023-04-18 04:40:25',
-                            'metadata': {
-                                'md5': '8c42361841f16989e0bf62a3ae408f1c',
-                                'kind': 'file',
-                                'sha256': 'ea070092664567d32e4524c6034214a293e75d0a53cfe9118f41e4752e97987c',
-                            },
-                            'location': {},
-                            'contributor': 'fake_user',
-                        }
-                    ],
-                    'location': {},
-                    'timestamp': {}
+        self.test_export_data_files = [
+            {
+                'id': 995,
+                'path': '/630de9f5b71d8f06d918fbd7',
+                'materialized_path': '/@ember-decorators/utils/collapse-proto.d.ts',
+                'name': 'collapse-proto.d.ts',
+                'provider': 'osfstorage',
+                'created_at': '2023-04-18 04:40:25',
+                'modified_at': '2023-04-18 04:40:25',
+                'project': {
+                    'id': 'pmockt',
+                    'name': 'Project Mock'
                 },
-            ]
+                'tags': ['hello', 'world'],
+                'version': [
+                    {
+                        'identifier': '1',
+                        'created_at': '2023-04-18 04:40:25',
+                        'modified_at': '2023-04-18 04:40:25',
+                        'size': 6000,
+                        'version_name': 'collapse-proto.d.ts',
+                        'metadata': {
+                            'md5': '8c42361841f16989e0bf62a3ae408f1c',
+                            'kind': 'file',
+                            'sha256': 'ea070092664567d32e4524c6034214a293e75d0a53cfe9118f41e4752e97987c',
+                        },
+                        'location': {
+                            'object': '64charsversion164charsversion164charsversion164charsversion164ch',
+                            'provider': 's3compat'
+                        },
+                        'contributor': 'fake_user',
+                    }
+                ],
+                'location': {},
+                'timestamp': {},
+                'checkout_id': None
+            },
+        ]
         addon_region = RegionFactory(waterbutler_settings=addon_waterbutler_settings)
         self.addon_data_restore = ExportDataRestoreFactory.create(destination=addon_region)
 

--- a/osf/models/export_data.py
+++ b/osf/models/export_data.py
@@ -268,8 +268,8 @@ class ExportData(base.BaseModel):
                 total_size += version.size
 
             file_info['version'] = file_versions_info
-            file_info['size'] = file_versions_info[-1]['size']
-            file_info['location'] = file_versions_info[-1]['location']
+            file_info['size'] = file_versions_info[0]['size']
+            file_info['location'] = file_versions_info[0]['location']
             files.append(file_info)
 
         file_info_json['folders'] = folders

--- a/osf/models/export_data.py
+++ b/osf/models/export_data.py
@@ -141,13 +141,10 @@ class ExportData(base.BaseModel):
         # If source institutional storage is the same as default storage, also get default storage for export
         if self.source.has_same_settings_as_default_region and self.source.id != 1:
             # get list FileVersion linked to source storage, default storage
-            # but the creator must be affiliated with current institution
-            file_versions = FileVersion.objects.filter(region_id__in=[1, self.source.id], creator__affiliated_institutions___id=source_storage_guid)
+            file_versions = FileVersion.objects.filter(region_id__in=[1, self.source.id])
         else:
             # get list FileVersion linked to source storage
             file_versions = self.source.fileversion_set.all()
-            # but the creator must be affiliated with current institution
-            file_versions = file_versions.filter(creator__affiliated_institutions___id=source_storage_guid)
 
         # get base_file_nodes__ids by file_versions__ids above via the BaseFileVersionsThrough model
         base_file_versions_set = BaseFileVersionsThrough.objects.filter(fileversion__in=file_versions)

--- a/osf/models/export_data_restore.py
+++ b/osf/models/export_data_restore.py
@@ -80,8 +80,6 @@ class ExportDataRestore(base.BaseModel):
 
         # get list FileVersion linked to destination storage
         file_versions = self.destination.fileversion_set.all()
-        # but the creator must be affiliated with current institution
-        file_versions = file_versions.filter(creator__affiliated_institutions___id=destination_storage_guid)
 
         # get base_file_nodes__ids by file_versions__ids above via the BaseFileVersionsThrough model
         base_file_versions_set = BaseFileVersionsThrough.objects.filter(fileversion__in=file_versions)

--- a/osf/models/export_data_restore.py
+++ b/osf/models/export_data_restore.py
@@ -177,8 +177,8 @@ class ExportDataRestore(base.BaseModel):
                 total_size += version.size
 
             file_info['version'] = file_versions_info
-            file_info['size'] = file_versions_info[-1]['size']
-            file_info['location'] = file_versions_info[-1]['location']
+            file_info['size'] = file_versions_info[0]['size']
+            file_info['location'] = file_versions_info[0]['location']
             files.append(file_info)
 
         file_info_json['files'] = files

--- a/osf_tests/test_export_data.py
+++ b/osf_tests/test_export_data.py
@@ -131,7 +131,6 @@ class TestExportData(TestCase):
         target = AbstractNode(id=object_id)
         node = OsfStorageFileFactory.create(target_object_id=object_id, target=target)
         file_version = FileVersionFactory(region=cls.export_data.source)
-        file_version.creator.affiliated_institutions.set([cls.institution])
 
         file_versions_through = BaseFileVersionsThroughFactory.create(version_name='file.txt', basefilenode=node,
                                                                       fileversion=file_version)
@@ -263,7 +262,6 @@ class TestExportData(TestCase):
         institution.nodes.set([project])
         default_region = Region.objects.get(_id=DEFAULT_REGION_ID)
         file_version = FileVersionFactory(region=default_region)
-        file_version.creator.affiliated_institutions.set([institution])
         object_id = project.id
         target = AbstractNode(id=object_id)
         node = OsfStorageFileFactory.create(name='file2.txt', created=datetime.now(), target_content_type=self.file.target_content_type,

--- a/osf_tests/test_export_data_restore.py
+++ b/osf_tests/test_export_data_restore.py
@@ -56,7 +56,6 @@ class TestExportDataRestore(TestCase):
         target = AbstractNode(id=object_id)
         node = OsfStorageFileFactory.create(target_object_id=object_id, target=target)
         file_version = FileVersionFactory(region=cls.data_restore.destination)
-        file_version.creator.affiliated_institutions.set([cls.institution])
 
         file_versions_through = BaseFileVersionsThroughFactory.create(version_name='file.txt', basefilenode=node,
                                                                       fileversion=file_version)


### PR DESCRIPTION
## Purpose

Relate to the following issue:
NII Redmine#39569
エクスポート対象のファイルとして存在しているが、エクスポートに失敗したファイルリストに記録される

## Changes

* No DB changes
* ③エクスポート対象のファイルが複数バージョン存在する場合、いずれかのバージョンでエラーを検知すると、全バージョンエラーとなる
  * Correct the list of failed files which includes only the specific version of files in the Export/Restore process.
  * Correct size value, and location value by the latest version of files when extracting file info from institutional storage.
  * Correct the size value of the file version in the downloadable CSV file and in the modal view
* ④エクスポート対象として適切にファイルが抽出出来ていない
  * Remove the file version's creator filter condition when extracting file info from institutional storage in the Export/Restore process.

## QA Notes

## Documentation

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
