### PR TITLE
Feature/202210 institutional storage control/fixedbug/40128

### DIFF
--- a/admin/institutional_storage_quota_control/urls.py
+++ b/admin/institutional_storage_quota_control/urls.py
@@ -6,5 +6,5 @@ app_name = 'admin'
 urlpatterns = [
     url(r'^$', views.InstitutionStorageList.as_view(), name='list_institution_storage'),
     url(r'^(?P<institution_id>[0-9]+)/update_quota/$', views.UpdateQuotaUserListByInstitutionStorageID.as_view(), name='update_quota_institution_user_list'),
-    url(r'^user_list_by_institution_id/(?P<institution_id>.*)/$', views.UserListByInstitutionStorageID.as_view(), name='institution_user_list'),
+    url(r'^user_list_by_institution_id/(?P<institution_id>[0-9]+)/$', views.UserListByInstitutionStorageID.as_view(), name='institution_user_list'),
 ]

--- a/admin/institutional_storage_quota_control/urls.py
+++ b/admin/institutional_storage_quota_control/urls.py
@@ -6,5 +6,5 @@ app_name = 'admin'
 urlpatterns = [
     url(r'^$', views.InstitutionStorageList.as_view(), name='list_institution_storage'),
     url(r'^(?P<institution_id>[0-9]+)/update_quota/$', views.UpdateQuotaUserListByInstitutionStorageID.as_view(), name='update_quota_institution_user_list'),
-    url(r'^user_list_by_institution_id/(?P<institution_id>[0-9]+)/$', views.UserListByInstitutionStorageID.as_view(), name='institution_user_list'),
+    url(r'^user_list_by_institution_id/(?P<institution_id>.*)/$', views.UserListByInstitutionStorageID.as_view(), name='institution_user_list'),
 ]

--- a/admin/institutional_storage_quota_control/views.py
+++ b/admin/institutional_storage_quota_control/views.py
@@ -2,7 +2,6 @@ import logging
 import inspect  # noqa
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import connection
-from django.http import Http404
 
 from admin.institutions.views import QuotaUserList
 from osf.models import Institution, OSFUser, UserQuota
@@ -20,8 +19,7 @@ logger = logging.getLogger(__name__)
 
 class InstitutionStorageList(RdmPermissionMixin, UserPassesTestMixin, ListView):
     paginate_by = 25
-    template_name = 'institutional_storage_quota_control/' \
-                    'list_institution_storage.html'
+    template_name = 'institutional_storage_quota_control/list_institution_storage.html'
     ordering = 'name'
     raise_exception = True
     model = Institution
@@ -47,8 +45,8 @@ class InstitutionStorageList(RdmPermissionMixin, UserPassesTestMixin, ListView):
         self.object_list = query_set
 
         for item in query_set:
-            if item.institution_id:
-                institution_id = item.institution_id
+            if item.institution.id:
+                institution_id = item.institution.id
                 count += 1
             else:
                 self.object_list = self.object_list.exclude(id=item.id)
@@ -60,53 +58,31 @@ class InstitutionStorageList(RdmPermissionMixin, UserPassesTestMixin, ListView):
         elif self.is_admin:
             if count == 1:
                 return redirect(reverse(
-                    'institutional_storage_quota_control:'
-                    'institution_user_list',
+                    'institutional_storage_quota_control:institution_user_list',
                     kwargs={'institution_id': institution_id}
                 ))
             return self.render_to_response(ctx)
 
     def get_queryset(self):
         if self.is_super_admin:
-            query = 'select {} ' \
-                    'from osf_institution ' \
-                    'where addons_osfstorage_region._id = osf_institution._id'
             return Region.objects.filter(
-                ~Q(waterbutler_settings__storage__provider='filesystem'))\
-                .extra(select={'institution_id': query.format('id'),
-                               'institution_name': query.format('name'),
-                               'institution_logo_name': query.format(
-                                   'logo_name'),
-                               }).order_by('institution_name', self.ordering)
+                ~Q(waterbutler_settings__storage__provider='filesystem')
+            ).order_by('_id', self.ordering)
 
         elif self.is_admin:
             user_id = self.request.user.id
-            query = 'select {} ' \
-                    'from osf_institution ' \
-                    'where addons_osfstorage_region._id = _id ' \
-                    'and id in (' \
-                    '    select institution_id ' \
-                    '    from osf_osfuser_affiliated_institutions ' \
-                    '    where osfuser_id = {}' \
-                    ')'
+            osf_user = OSFUser.objects.get(pk=user_id)
+            institutions = osf_user.affiliated_institutions.all()
+            institution_guids = institutions.values_list('_id')
             return Region.objects.filter(
-                ~Q(waterbutler_settings__storage__provider='filesystem'))\
-                .extra(select={'institution_id': query.format('id', user_id),
-                               'institution_name': query.format(
-                                   'name',
-                                   user_id),
-                               'institution_logo_name': query.format(
-                                   'logo_name',
-                                   user_id),
-                               })
+                ~Q(waterbutler_settings__storage__provider='filesystem'),
+                Q(_id__in=institution_guids)
+            ).order_by('_id', self.ordering)
 
     def get_context_data(self, **kwargs):
         query_set = kwargs.pop('object_list', self.object_list)
         page_size = self.get_paginate_by(query_set)
-        paginator, page, query_set, is_paginated = self.paginate_queryset(
-            query_set,
-            page_size
-        )
+        paginator, page, query_set, is_paginated = self.paginate_queryset(query_set, page_size)
         kwargs.setdefault('institutions', query_set)
         kwargs.setdefault('page', page)
         kwargs.setdefault('logohost', settings.OSF_URL)
@@ -123,7 +99,7 @@ class UserListByInstitutionStorageID(RdmPermissionMixin, UserPassesTestMixin, Qu
         institution_id = int(self.kwargs.get('institution_id'))
         return self.has_auth(institution_id)
 
-    def get_userlist(self):
+    def get_user_list(self):
         user_list = []
         for user in OSFUser.objects.filter(
                 affiliated_institutions=self.kwargs['institution_id']):
@@ -136,17 +112,14 @@ class UserListByInstitutionStorageID(RdmPermissionMixin, UserPassesTestMixin, Qu
         query = 'select name '\
                 'from addons_osfstorage_region '\
                 'where addons_osfstorage_region._id = osf_institution._id'
-        institutions = Institution.objects.filter(
+        institution = Institution.objects.filter(
             id=self.kwargs['institution_id']
         ).extra(
             select={
                 'storage_name': query,
             }
         )
-        institution = institutions.first()
-        if institution is None:
-            raise Http404('Institution is not found.')
-        return institution
+        return institution.first()
 
 
 class UpdateQuotaUserListByInstitutionStorageID(RdmPermissionMixin, UserPassesTestMixin, View):
@@ -161,8 +134,7 @@ class UpdateQuotaUserListByInstitutionStorageID(RdmPermissionMixin, UserPassesTe
         institution_id = self.kwargs['institution_id']
         min_value, max_value = connection.ops.integer_field_range('IntegerField')
         max_quota = min(int(self.request.POST.get('maxQuota')), max_value)
-        for user in OSFUser.objects.filter(
-                affiliated_institutions=institution_id):
+        for user in OSFUser.objects.filter(affiliated_institutions=institution_id):
             UserQuota.objects.update_or_create(
                 user=user,
                 storage_type=UserQuota.CUSTOM_STORAGE,

--- a/admin/institutional_storage_quota_control/views.py
+++ b/admin/institutional_storage_quota_control/views.py
@@ -1,5 +1,3 @@
-import logging
-import inspect  # noqa
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import connection
 
@@ -12,9 +10,6 @@ from django.shortcuts import redirect
 from admin.rdm.utils import RdmPermissionMixin
 from django.core.urlresolvers import reverse
 from django.db.models import Q
-from website.util import inspect_info  # noqa
-
-logger = logging.getLogger(__name__)
 
 
 class InstitutionStorageList(RdmPermissionMixin, UserPassesTestMixin, ListView):

--- a/admin_tests/institutional_storage_quota_control/test_views.py
+++ b/admin_tests/institutional_storage_quota_control/test_views.py
@@ -1,7 +1,6 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
-from django.http import Http404
 
 from addons.osfstorage.models import Region
 from admin.institutional_storage_quota_control import views

--- a/admin_tests/institutional_storage_quota_control/test_views.py
+++ b/admin_tests/institutional_storage_quota_control/test_views.py
@@ -333,7 +333,7 @@ class TestAccessInstitutionStorageList(AdminTestCase):
         request = RequestFactory().get(reverse(self.view_name))
         request.user = self.institution01_admin
         response = self.view(request, institution_id=self.institution01.id)
-        nt.assert_equal(response.status_code, 320)
+        nt.assert_equal(response.status_code, 302)
 
 
 class TestInstitutionStorageListByAdmin(AdminTestCase):

--- a/admin_tests/institutional_storage_quota_control/test_views.py
+++ b/admin_tests/institutional_storage_quota_control/test_views.py
@@ -221,7 +221,7 @@ class TestUserListByInstitutionStorageID(AdminTestCase):
         with self.assertRaises(PermissionDenied):
             self.view(request, institution_id=self.institution02.id)
 
-    def test_get_user_list(self):
+    def test_get_userlist(self):
         request = RequestFactory().get(
             reverse(
                 self.view_name,
@@ -232,7 +232,7 @@ class TestUserListByInstitutionStorageID(AdminTestCase):
 
         view = setup_view(self.view_instance, request,
                           institution_id=self.institution01.id)
-        user_list = view.get_user_list()
+        user_list = view.get_userlist()
 
         nt.assert_equal(len(user_list), 1)
         nt.assert_equal(user_list[0]['fullname'], self.institution01_admin.fullname)

--- a/admin_tests/institutional_storage_quota_control/test_views.py
+++ b/admin_tests/institutional_storage_quota_control/test_views.py
@@ -253,20 +253,6 @@ class TestUserListByInstitutionStorageID(AdminTestCase):
 
         nt.assert_equal(institution.storage_name, self.region01.name)
 
-    def test_get_institution__none(self):
-        request = RequestFactory().get(
-            reverse(
-                self.view_name,
-                kwargs={'institution_id': 9999}
-            )
-        )
-        request.user = self.institution01_admin
-
-        view = setup_view(self.view_instance, request,
-                          institution_id=9999)
-        with self.assertRaises(Http404):
-            view.get_institution()
-
     def test_get_context_data_has_storage_name(self):
         request = RequestFactory().get(
             reverse(

--- a/admin_tests/institutional_storage_quota_control/test_views.py
+++ b/admin_tests/institutional_storage_quota_control/test_views.py
@@ -1,4 +1,8 @@
 import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+
 from addons.osfstorage.models import Region
 from admin.institutional_storage_quota_control import views
 from django.test import RequestFactory
@@ -20,142 +24,327 @@ pytestmark = pytest.mark.django_db
 class TestUpdateQuotaUserListByInstitutionStorageID(AdminTestCase):
     def setUp(self):
         super(TestUpdateQuotaUserListByInstitutionStorageID, self).setUp()
-        self.user1 = AuthUserFactory(fullname='fullname1')
-        self.institution = InstitutionFactory()
-        self.user1.affiliated_institutions.add(self.institution)
-        self.user1.save()
+        self.institution01 = InstitutionFactory(name='inst01')
+        self.institution02 = InstitutionFactory(name='inst02')
 
+        self.anon = AnonymousUser()
+
+        self.superuser = AuthUserFactory(fullname='superuser')
+        self.superuser.is_staff = True
+        self.superuser.is_superuser = True
+        self.superuser.save()
+
+        self.institution01_admin = AuthUserFactory(fullname='admin001_inst01')
+        self.institution01_admin.is_staff = True
+        self.institution01_admin.affiliated_institutions.add(self.institution01)
+        self.institution01_admin.save()
+
+        self.institution02_admin = AuthUserFactory(fullname='admin001_inst02')
+        self.institution02_admin.is_staff = True
+        self.institution02_admin.affiliated_institutions.add(self.institution02)
+        self.institution02_admin.save()
+
+        self.view_name = 'institutional_storage_quota_control:update_quota_institution_user_list'
         self.view = views.UpdateQuotaUserListByInstitutionStorageID.as_view()
 
-    def test_post_create_quota(self):
+    def test__anonymous(self):
         max_quota = 50
         request = RequestFactory().post(
-            reverse(
-                'institutional_storage_quota_control'
-                ':update_quota_institution_user_list',
-                kwargs={'institution_id': self.institution.id}),
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution01.id}),
             {'maxQuota': max_quota})
-        request.user = self.user1
+        request.user = self.anon
+        with self.assertRaises(PermissionDenied):
+            self.view(request, institution_id=self.institution01.id)
 
-        response = self.view(
-            request,
-            institution_id=self.institution.id
-        )
+    def test__superuser(self):
+        new_max_quota = 50
+        upd_max_quota = 150
 
-        nt.assert_equal(response.status_code, 302)
-        user_quota = UserQuota.objects.filter(
-            user=self.user1, storage_type=UserQuota.CUSTOM_STORAGE
-        ).first()
-        nt.assert_is_not_none(user_quota)
-        nt.assert_equal(user_quota.max_quota, max_quota)
-
-    def test_post_update_quota(self):
-        UserQuota.objects.create(user=self.user1, max_quota=100)
-        max_quota = 150
+        # create user quota of inst01
         request = RequestFactory().post(
-            reverse(
-                'institutional_storage_quota_control:'
-                'update_quota_institution_user_list',
-                kwargs={'institution_id': self.institution.id}),
-            {'maxQuota': max_quota})
-        request.user = self.user1
-
-        response = self.view(
-            request,
-            institution_id=self.institution.id
-        )
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution01.id}),
+            {'maxQuota': new_max_quota})
+        request.user = self.superuser
+        response = self.view(request, institution_id=self.institution01.id)
 
         nt.assert_equal(response.status_code, 302)
-        user_quota = UserQuota.objects.filter(
-            user=self.user1, storage_type=UserQuota.CUSTOM_STORAGE
+        new_user_quota_1 = UserQuota.objects.filter(
+            user=self.institution01_admin, storage_type=UserQuota.CUSTOM_STORAGE
         ).first()
-        nt.assert_is_not_none(user_quota)
-        nt.assert_equal(user_quota.max_quota, max_quota)
+        nt.assert_is_not_none(new_user_quota_1)
+        nt.assert_equal(new_user_quota_1.max_quota, new_max_quota)
+
+        # update user quota of inst01
+        request = RequestFactory().post(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution01.id}),
+            {'maxQuota': upd_max_quota})
+        request.user = self.superuser
+        response = self.view(request, institution_id=self.institution01.id)
+
+        nt.assert_equal(response.status_code, 302)
+        upd_user_quota_1 = UserQuota.objects.filter(
+            user=self.institution01_admin, storage_type=UserQuota.CUSTOM_STORAGE
+        ).first()
+        nt.assert_equal(upd_user_quota_1.max_quota, upd_max_quota)
+        nt.assert_equal(upd_user_quota_1.id, new_user_quota_1.id)
+
+        # create user quota of inst02
+        request = RequestFactory().post(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution02.id}),
+            {'maxQuota': new_max_quota})
+        request.user = self.superuser
+        response = self.view(request, institution_id=self.institution02.id)
+
+        nt.assert_equal(response.status_code, 302)
+        new_user_quota_2 = UserQuota.objects.filter(
+            user=self.institution02_admin, storage_type=UserQuota.CUSTOM_STORAGE
+        ).first()
+        nt.assert_is_not_none(new_user_quota_2)
+        nt.assert_equal(new_user_quota_2.max_quota, new_max_quota)
+
+    def test__institutional_admin(self):
+        new_max_quota = 100
+
+        # create user quota of inst01
+        request = RequestFactory().post(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution01.id}),
+            {'maxQuota': new_max_quota})
+        request.user = self.institution01_admin
+        response = self.view(request, institution_id=self.institution01.id)
+
+        nt.assert_equal(response.status_code, 302)
+        new_user_quota_1 = UserQuota.objects.filter(
+            user=self.institution01_admin, storage_type=UserQuota.CUSTOM_STORAGE
+        ).first()
+        nt.assert_is_not_none(new_user_quota_1)
+        nt.assert_equal(new_user_quota_1.max_quota, new_max_quota)
+
+        # create user quota of inst02
+        request = RequestFactory().post(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution02.id}),
+            {'maxQuota': new_max_quota})
+        request.user = self.institution01_admin
+        with self.assertRaises(PermissionDenied):
+            self.view(request, institution_id=self.institution02.id)
 
 
 class TestUserListByInstitutionStorageID(AdminTestCase):
     def setUp(self):
         super(TestUserListByInstitutionStorageID, self).setUp()
-        self.user = AuthUserFactory(fullname='fullname')
-        self.institution = InstitutionFactory()
-        self.region = RegionFactory(_id=self.institution._id, name='Storage')
-        self.user.affiliated_institutions.add(self.institution)
-        self.user.save()
+        self.institution01 = InstitutionFactory(name='inst01')
+        self.institution02 = InstitutionFactory(name='inst02')
 
-        self.view = views.UserListByInstitutionStorageID()
+        self.region01 = RegionFactory(_id=self.institution01._id, name='Storage 01')
+        self.region02 = RegionFactory(_id=self.institution02._id, name='Storage 02')
+
+        self.anon = AnonymousUser()
+
+        self.superuser = AuthUserFactory(fullname='superuser')
+        self.superuser.is_staff = True
+        self.superuser.is_superuser = True
+        self.superuser.save()
+
+        self.institution01_admin = AuthUserFactory(fullname='admin001_inst01')
+        self.institution01_admin.is_staff = True
+        self.institution01_admin.affiliated_institutions.add(self.institution01)
+        self.institution01_admin.save()
+
+        self.institution02_admin = AuthUserFactory(fullname='admin001_inst02')
+        self.institution02_admin.is_staff = True
+        self.institution02_admin.affiliated_institutions.add(self.institution02)
+        self.institution02_admin.save()
+
+        self.view_name = 'institutional_storage_quota_control:institution_user_list'
+        self.view = views.UserListByInstitutionStorageID.as_view()
+        self.view_instance = views.UserListByInstitutionStorageID()
+
+    def test__anonymous(self):
+        request = RequestFactory().get(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution01.id}),
+            )
+        request.user = self.anon
+        with self.assertRaises(PermissionDenied):
+            self.view(request, institution_id=self.institution01.id)
+
+    def test__superuser(self):
+        # access inst01
+        request = RequestFactory().get(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution01.id}),
+            )
+        request.user = self.superuser
+        response = self.view(request, institution_id=self.institution01.id)
+        nt.assert_equal(response.status_code, 200)
+
+        # access inst02
+        request = RequestFactory().get(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution02.id}),
+            )
+        request.user = self.superuser
+        response = self.view(request, institution_id=self.institution02.id)
+        nt.assert_equal(response.status_code, 200)
+
+    def test__institutional_admin(self):
+        # access inst01
+        request = RequestFactory().get(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution01.id}),
+            )
+        request.user = self.institution01_admin
+        response = self.view(request, institution_id=self.institution01.id)
+        nt.assert_equal(response.status_code, 200)
+
+        # access inst02
+        request = RequestFactory().get(
+            reverse(self.view_name,
+                    kwargs={'institution_id': self.institution02.id}),
+            )
+        request.user = self.institution01_admin
+        with self.assertRaises(PermissionDenied):
+            self.view(request, institution_id=self.institution02.id)
 
     def test_get_user_list(self):
         request = RequestFactory().get(
             reverse(
-                'institutional_storage_quota_control:institution_user_list',
-                kwargs={'institution_id': self.institution.id}
+                self.view_name,
+                kwargs={'institution_id': self.institution01.id}
             )
         )
-        request.user = self.user
+        request.user = self.institution01_admin
 
-        view = setup_view(self.view, request,
-                          institution_id=self.institution.id)
-        user_list = view.get_userlist()
+        view = setup_view(self.view_instance, request,
+                          institution_id=self.institution01.id)
+        user_list = view.get_user_list()
 
         nt.assert_equal(len(user_list), 1)
-        nt.assert_equal(user_list[0]['fullname'], self.user.fullname)
+        nt.assert_equal(user_list[0]['fullname'], self.institution01_admin.fullname)
         nt.assert_equal(user_list[0]['quota'], api_settings.DEFAULT_MAX_QUOTA)
 
     def test_get_institution(self):
         request = RequestFactory().get(
             reverse(
-                'institutional_storage_quota_control:institution_user_list',
-                kwargs={'institution_id': self.institution.id}
+                self.view_name,
+                kwargs={'institution_id': self.institution01.id}
             )
         )
-        request.user = self.user
+        request.user = self.institution01_admin
 
-        view = setup_view(self.view, request,
-                          institution_id=self.institution.id)
+        view = setup_view(self.view_instance, request,
+                          institution_id=self.institution01.id)
         institution = view.get_institution()
 
-        nt.assert_equal(institution.storage_name, self.region.name)
+        nt.assert_equal(institution.storage_name, self.region01.name)
+
+    def test_get_institution__none(self):
+        request = RequestFactory().get(
+            reverse(
+                self.view_name,
+                kwargs={'institution_id': 9999}
+            )
+        )
+        request.user = self.institution01_admin
+
+        view = setup_view(self.view_instance, request,
+                          institution_id=9999)
+        with self.assertRaises(Http404):
+            view.get_institution()
 
     def test_get_context_data_has_storage_name(self):
         request = RequestFactory().get(
             reverse(
-                'institutional_storage_quota_control:institution_user_list',
-                kwargs={'institution_id': self.institution.id}
+                self.view_name,
+                kwargs={'institution_id': self.institution01.id}
             )
         )
 
-        request.user = self.user
+        request.user = self.institution01_admin
 
-        view = setup_view(self.view, request,
-                          institution_id=self.institution.id)
+        view = setup_view(self.view_instance, request,
+                          institution_id=self.institution01.id)
         view.object_list = view.get_queryset()
         res = view.get_context_data()
 
         nt.assert_is_instance(res, dict)
-        nt.assert_equal(res['institution_storage_name'], self.region.name)
+        nt.assert_equal(res['institution_storage_name'], self.region01.name)
+
+
+class TestAccessInstitutionStorageList(AdminTestCase):
+    def setUp(self):
+        super(TestAccessInstitutionStorageList, self).setUp()
+        self.institution01 = InstitutionFactory(name='inst01')
+        self.institution02 = InstitutionFactory(name='inst02')
+
+        self.region01 = RegionFactory(_id=self.institution01._id, name='Storage 01')
+        self.region02 = RegionFactory(_id=self.institution02._id, name='Storage 02')
+
+        self.anon = AnonymousUser()
+
+        self.superuser = AuthUserFactory(fullname='superuser')
+        self.superuser.is_staff = True
+        self.superuser.is_superuser = True
+        self.superuser.save()
+
+        self.institution01_admin = AuthUserFactory(fullname='admin001_inst01')
+        self.institution01_admin.is_staff = True
+        self.institution01_admin.affiliated_institutions.add(self.institution01)
+        self.institution01_admin.save()
+
+        self.institution02_admin = AuthUserFactory(fullname='admin001_inst02')
+        self.institution02_admin.is_staff = True
+        self.institution02_admin.affiliated_institutions.add(self.institution02)
+        self.institution02_admin.save()
+
+        self.view_name = 'institutional_storage_quota_control:list_institution_storage'
+        self.view = views.InstitutionStorageList.as_view()
+        self.view_instance = views.InstitutionStorageList()
+
+    def test__anonymous(self):
+        request = RequestFactory().get(reverse(self.view_name))
+        request.user = self.anon
+        with self.assertRaises(PermissionDenied):
+            self.view(request)
+
+    def test__superuser(self):
+        # access inst01
+        request = RequestFactory().get(reverse(self.view_name))
+        request.user = self.superuser
+        response = self.view(request)
+        nt.assert_equal(response.status_code, 200)
+
+    def test__institutional_admin(self):
+        request = RequestFactory().get(reverse(self.view_name))
+        request.user = self.institution01_admin
+        response = self.view(request, institution_id=self.institution01.id)
+        nt.assert_equal(response.status_code, 320)
 
 
 class TestInstitutionStorageListByAdmin(AdminTestCase):
     def setUp(self):
         super(TestInstitutionStorageListByAdmin, self).setUp()
+        self.institution = InstitutionFactory()
+        self.region = RegionFactory(_id=self.institution._id, name='Storage')
+
         self.user = AuthUserFactory(fullname='fullname')
         self.user.is_registered = True
         self.user.is_active = True
         self.user.is_staff = True
         self.user.is_superuser = False
-        self.institution = InstitutionFactory()
-        self.region = RegionFactory(_id=self.institution._id, name='Storage')
         self.user.affiliated_institutions.add(self.institution)
         self.user.save()
 
+        self.view_name = 'institutional_storage_quota_control:list_institution_storage'
         self.view = views.InstitutionStorageList.as_view()
 
     def test_get_redirect_to_user_list(self):
-        request = RequestFactory().get(
-            reverse(
-                'institutional_storage_quota_control:list_institution_storage'
-            )
-        )
+        request = RequestFactory().get(reverse(self.view_name))
         request.user = self.user
 
         response = self.view(
@@ -178,16 +367,10 @@ class TestInstitutionStorageListByAdmin(AdminTestCase):
         self.user.affiliated_institutions.add(inst1)
         self.user.save()
 
-        request = RequestFactory().get(
-            reverse(
-                'institutional_storage_quota_control:list_institution_storage'
-            )
-        )
+        request = RequestFactory().get(reverse(self.view_name))
         request.user = self.user
 
-        response = self.view(
-            request,
-        )
+        response = self.view(request,)
 
         nt.assert_equal(response.status_code, 200)
         nt.assert_is_not_none(Region.objects.filter(id=region1.id))
@@ -198,11 +381,7 @@ class TestInstitutionStorageListByAdmin(AdminTestCase):
         )
 
     def test_get_query_set(self):
-        request = RequestFactory().get(
-            reverse(
-                'institutional_storage_quota_control:list_institution_storage'
-            )
-        )
+        request = RequestFactory().get(reverse(self.view_name))
         request.user = self.user
         view = views.InstitutionStorageList()
         view = setup_view(view, request)
@@ -212,11 +391,7 @@ class TestInstitutionStorageListByAdmin(AdminTestCase):
         nt.assert_equal(query_set.first().id, self.region.id)
 
     def test_get_context_data(self):
-        request = RequestFactory().get(
-            reverse(
-                'institutional_storage_quota_control:list_institution_storage'
-            )
-        )
+        request = RequestFactory().get(reverse(self.view_name))
         request.user = self.user
         view = views.InstitutionStorageList()
         view = setup_view(view, request)
@@ -231,31 +406,28 @@ class TestInstitutionStorageListByAdmin(AdminTestCase):
 class TestInstitutionStorageListBySuperUser(AdminTestCase):
     def setUp(self):
         super(TestInstitutionStorageListBySuperUser, self).setUp()
+        self.institution = InstitutionFactory()
+        self.institution_1 = InstitutionFactory()
+
+        self.region = RegionFactory(_id=self.institution._id, name='Storage')
+        self.region_1 = RegionFactory(_id=self.institution_1._id, name='Storage_1')
+
         self.user = AuthUserFactory(fullname='fullname')
         self.user.is_registered = True
         self.user.is_active = True
+        self.user.is_staff = True
         self.user.is_superuser = True
-        self.institution = InstitutionFactory()
-        self.institution_1 = InstitutionFactory()
-        self.region = RegionFactory(_id=self.institution._id, name='Storage')
-        self.region_1 = RegionFactory(_id=self.institution_1._id,
-                                      name='Storage_1')
         self.user.affiliated_institutions.add(self.institution)
         self.user.save()
 
+        self.view_name = 'institutional_storage_quota_control:list_institution_storage'
         self.view = views.InstitutionStorageList.as_view()
 
     def test_get_render_response(self):
-        request = RequestFactory().get(
-            reverse(
-                'institutional_storage_quota_control:list_institution_storage'
-            )
-        )
+        request = RequestFactory().get(reverse(self.view_name))
         request.user = self.user
 
-        response = self.view(
-            request,
-        )
+        response = self.view(request,)
 
         nt.assert_equal(response.status_code, 200)
         nt.assert_is_instance(
@@ -264,11 +436,7 @@ class TestInstitutionStorageListBySuperUser(AdminTestCase):
         )
 
     def test_get_query_set(self):
-        request = RequestFactory().get(
-            reverse(
-                'institutional_storage_quota_control:list_institution_storage'
-            )
-        )
+        request = RequestFactory().get(reverse(self.view_name))
         request.user = self.user
         view = views.InstitutionStorageList()
         view = setup_view(view, request)

--- a/admin_tests/institutional_storage_quota_control/test_views.py
+++ b/admin_tests/institutional_storage_quota_control/test_views.py
@@ -166,9 +166,11 @@ class TestUserListByInstitutionStorageID(AdminTestCase):
 
     def test__anonymous(self):
         request = RequestFactory().get(
-            reverse(self.view_name,
-                    kwargs={'institution_id': self.institution01.id}),
+            reverse(
+                self.view_name,
+                kwargs={'institution_id': self.institution01.id}
             )
+        )
         request.user = self.anon
         with self.assertRaises(PermissionDenied):
             self.view(request, institution_id=self.institution01.id)
@@ -176,18 +178,22 @@ class TestUserListByInstitutionStorageID(AdminTestCase):
     def test__superuser(self):
         # access inst01
         request = RequestFactory().get(
-            reverse(self.view_name,
-                    kwargs={'institution_id': self.institution01.id}),
+            reverse(
+                self.view_name,
+                kwargs={'institution_id': self.institution01.id}
             )
+        )
         request.user = self.superuser
         response = self.view(request, institution_id=self.institution01.id)
         nt.assert_equal(response.status_code, 200)
 
         # access inst02
         request = RequestFactory().get(
-            reverse(self.view_name,
-                    kwargs={'institution_id': self.institution02.id}),
+            reverse(
+                self.view_name,
+                kwargs={'institution_id': self.institution02.id}
             )
+        )
         request.user = self.superuser
         response = self.view(request, institution_id=self.institution02.id)
         nt.assert_equal(response.status_code, 200)
@@ -195,18 +201,22 @@ class TestUserListByInstitutionStorageID(AdminTestCase):
     def test__institutional_admin(self):
         # access inst01
         request = RequestFactory().get(
-            reverse(self.view_name,
-                    kwargs={'institution_id': self.institution01.id}),
+            reverse(
+                self.view_name,
+                kwargs={'institution_id': self.institution01.id}
             )
+        )
         request.user = self.institution01_admin
         response = self.view(request, institution_id=self.institution01.id)
         nt.assert_equal(response.status_code, 200)
 
         # access inst02
         request = RequestFactory().get(
-            reverse(self.view_name,
-                    kwargs={'institution_id': self.institution02.id}),
+            reverse(
+                self.view_name,
+                kwargs={'institution_id': self.institution02.id}
             )
+        )
         request.user = self.institution01_admin
         with self.assertRaises(PermissionDenied):
             self.view(request, institution_id=self.institution02.id)
@@ -370,7 +380,7 @@ class TestInstitutionStorageListByAdmin(AdminTestCase):
         request = RequestFactory().get(reverse(self.view_name))
         request.user = self.user
 
-        response = self.view(request,)
+        response = self.view(request)
 
         nt.assert_equal(response.status_code, 200)
         nt.assert_is_not_none(Region.objects.filter(id=region1.id))
@@ -427,7 +437,7 @@ class TestInstitutionStorageListBySuperUser(AdminTestCase):
         request = RequestFactory().get(reverse(self.view_name))
         request.user = self.user
 
-        response = self.view(request,)
+        response = self.view(request)
 
         nt.assert_equal(response.status_code, 200)
         nt.assert_is_instance(


### PR DESCRIPTION
## Purpose

Relate to the following issue:
NII Redmine#40128
「機関ストレージのクォータ制御」画面にログイン無しでアクセス可能な状態になっている

## Changes

* No DB changes
* Add to related Views a function for user permission checking

## QA Notes


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
