### PR TITLE
[GRDM-39994] 同じパスのファイルメタデータが複数作られる不具合の修正

### DIFF
--- a/addons/metadata/migrations/0008_add_unique_file_metadata.py
+++ b/addons/metadata/migrations/0008_add_unique_file_metadata.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+
+from django.db import connection, migrations
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_unique_project_id_path(*args):
+    from addons.metadata.models import FileMetadata
+    # Deletes the newest from each set of FileMetadata
+    sql = """
+    SELECT f.id
+    FROM addons_metadata_filemetadata f
+    INNER JOIN (
+      SELECT path, MAX(modified) as max_modified
+      FROM addons_metadata_filemetadata
+      GROUP BY path
+    ) AS max_dates ON f.path = max_dates.path
+    WHERE f.modified < max_dates.max_modified;
+    """
+    # It is possible that new duplicate data will be created during migration in the old service instance,
+    # in which case migration should fail, so have the migration run again.
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+        ids = list(sum(cursor.fetchall(), ()))
+        logger.info('Deleting duplicate FileMetadata with `id`s {}'.format(ids))
+        FileMetadata.objects.filter(id__in=ids).delete()
+        logger.info('Deleted.')
+
+
+def noop(*args):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('addons_metadata', '0007_user_to_file_metadata'),
+    ]
+
+    operations = [
+        migrations.RunPython(ensure_unique_project_id_path, noop),
+        migrations.AlterUniqueTogether(
+            name='filemetadata',
+            unique_together=set([('project_id', 'path')]),
+        ),
+    ]


### PR DESCRIPTION
## Purpose

同じパスのファイルメタデータが複数作られることで、ElasticSearch のデータの更新に失敗する不具合を修正しました。

## Changes

- FileMetadata の (project_id, path) で unique key を作成しました
- FileMetadata の作成時にトランザクション処理を追加し、同じ path のデータが同時に作成されることのないよう修正しました。

## QA Notes
None

## Documentation
None

## Side Effects
None

## Ticket
GRDM-39994
