### PR TITLE
Feature/202210 institutional storage control/fixedbug/39836

### DIFF
--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -350,3 +350,6 @@ LOCALE_PATHS = (
 
 # The directory to store data temporarily.
 TEMPORARY_PATH = '/tmp/'
+
+# Time out for calling copy API
+EACH_FILE_EXPORT_TIME_OUT = 1800

--- a/admin/rdm_custom_storage_location/tasks.py
+++ b/admin/rdm_custom_storage_location/tasks.py
@@ -16,20 +16,28 @@ __all__ = [
 
 
 @celery_app.task(bind=True, base=AbortableTask, track_started=True)
-def run_export_data_process(self, cookies, export_data_id, **kwargs):
-    return export.export_data_process(self, cookies, export_data_id, **kwargs)
+def run_export_data_process(
+        self, cookies, export_data_id, location_id, source_id, **kwargs):
+    return export.export_data_process(
+        self, cookies, export_data_id, location_id, source_id, **kwargs)
 
 
 @celery_app.task(bind=True, base=AbortableTask, track_started=True)
-def run_export_data_rollback_process(self, cookies, export_data_id, **kwargs):
-    return export.export_data_rollback_process(self, cookies, export_data_id, **kwargs)
+def run_export_data_rollback_process(
+        self, cookies, export_data_id, location_id, source_id, **kwargs):
+    return export.export_data_rollback_process(
+        self, cookies, export_data_id, location_id, source_id, **kwargs)
 
 
 @celery_app.task(bind=True, base=AbortableTask, track_started=True)
-def run_restore_export_data_process(self, cookies, export_id, export_data_restore_id, list_project_id, **kwargs):
-    return restore.restore_export_data_process(self, cookies, export_id, export_data_restore_id, list_project_id, **kwargs)
+def run_restore_export_data_process(
+        self, cookies, export_id, export_data_restore_id, list_project_id, **kwargs):
+    return restore.restore_export_data_process(
+        self, cookies, export_id, export_data_restore_id, list_project_id, **kwargs)
 
 
 @celery_app.task(bind=True, base=AbortableTask, track_started=True)
-def run_restore_export_data_rollback_process(self, cookies, export_id, export_data_restore_id, process_step, **kwargs):
-    return restore.restore_export_data_rollback_process(self, cookies, export_id, export_data_restore_id, process_step, **kwargs)
+def run_restore_export_data_rollback_process(
+        self, cookies, export_id, export_data_restore_id, process_step, **kwargs):
+    return restore.restore_export_data_rollback_process(
+        self, cookies, export_id, export_data_restore_id, process_step, **kwargs)

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
@@ -1775,12 +1775,14 @@ class TestCheckExportDataProcessStatus(AdminTestCase):
 
     def test_check_export_data_process_status__c2_is_forced(self):
         _start_time = time.time()
+        self.task.update_state(state=states.STARTED, meta={})
         _prev_time = export.check_export_data_process_status(
             _start_time, self.task.request.id,
             is_force=True
         )
         self.assertNotEqual(_prev_time, _start_time)
 
+        self.task.update_state(state=states.STARTED, meta={})
         _prev_time = export.check_export_data_process_status(
             _start_time, self.task.request.id,
             location_id=self.location.id,

--- a/admin_tests/rdm_custom_storage_location/test_tasks.py
+++ b/admin_tests/rdm_custom_storage_location/test_tasks.py
@@ -17,7 +17,7 @@ from admin.rdm_custom_storage_location.tasks import (
 @patch('admin.rdm_custom_storage_location.tasks.export.export_data_process')
 def test_run_export_data_process(mock_export_data_process):
     mock_export_data_process.return_value = None
-    process = run_export_data_process.delay(None, 1)
+    process = run_export_data_process.delay(None, 1, 1, 1)
     nt.assert_is_not_none(process.task_id)
     nt.assert_equal(process.state, SUCCESS)
 
@@ -27,7 +27,7 @@ def test_run_export_data_process(mock_export_data_process):
 @patch('admin.rdm_custom_storage_location.tasks.export.export_data_rollback_process')
 def test_run_export_data_rollback_process(mock_export_data_rollback_process):
     mock_export_data_rollback_process.return_value = None
-    process = run_export_data_rollback_process.delay(None, 1)
+    process = run_export_data_rollback_process.delay(None, 1, 1, 1)
     nt.assert_is_not_none(process.task_id)
     nt.assert_equal(process.state, SUCCESS)
 

--- a/osf/models/export_data.py
+++ b/osf/models/export_data.py
@@ -22,6 +22,7 @@ from osf.models import (
 from admin.base import settings as admin_settings
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import EncryptedJSONField
+from admin.base.settings import EACH_FILE_EXPORT_TIME_OUT
 
 logger = logging.getLogger(__name__)
 
@@ -512,7 +513,8 @@ class ExportData(base.BaseModel):
         return requests.post(copy_file_url,
                              headers={'content-type': 'application/json'},
                              cookies=cookies,
-                             json=request_body)
+                             json=request_body,
+                             timeout=EACH_FILE_EXPORT_TIME_OUT)
 
     def get_data_file_file_path(self, file_name):
         """get /export_{source.id}_{process_start_timestamp}/files/{file_name} file path"""


### PR DESCRIPTION
## Purpose

Relate to the following issue:
[NII Redmine#39836]エクスポート開始後、プロセスのステータスが"Pending"となり、エクスポート処理が開始されない
- When deleting the export destination storage during the export process, the osf-worker process will also be stopped.
- When exporting data, set the timeout value for rdm-osf-osf-worker at the time the API copy is called.

## Changes

- No DB changes

## QA Notes

## Documentation

## Side Effects

## Ticket

