### PR TITLE
Feature/202210 institutional storage control/fixedbug/39836_note-18

### DIFF
--- a/admin/rdm_custom_storage_location/export_data/utils.py
+++ b/admin/rdm_custom_storage_location/export_data/utils.py
@@ -425,6 +425,44 @@ def count_files_ng_ok(exported_file_versions, storage_file_versions, exclude_key
     data['list_file_ng'] = list_file_ng if len(list_file_ng) <= 10 else list_file_ng[:10]
     return data
 
+def check_for_file_existent_on_export_location(file_info_json, node_id, provider, file_path, location_id, cookies, cookie):
+    response = get_file_data(node_id, provider, file_path, cookies, base_url=WATERBUTLER_URL, get_file_info=False,
+                             version=None, location_id=location_id, cookie=cookie)
+    # Get list file in export storage location
+    response_body = response.json() if response.status_code == 200 else None
+    file_list = response_body.get('data') if response_body is not None else None
+    if (file_list is None):
+        return None
+    attrs = ['name', 'size']
+    storage_file_list = [{attr: file.get('attributes', {}).get(attr) for attr in attrs} for file in file_list]
+    storage_file_dict = {file.get('name'): file for file in storage_file_list}
+
+    # get file data saved in file info Json
+    file_versions = []
+    for file in file_info_json.get('files', []):
+        versions = file.get('version', [])
+        file_path = file.get('materialized_path')
+        for version in versions:
+            size = version.get('size')
+            metadata = version.get('metadata')
+            # get metadata.get('sha256', metadata.get('md5', metadata.get('sha512', metadata.get('sha1', metadata.get('name')))))
+            file_name = metadata.get('sha256', metadata.get('md5'))
+            version_name = version.get('version_name')
+            version_id = version.get('identifier')
+            file_versions.append({'path': file_path, 'name': file_name, 'version_name': version_name, 'version_id': version_id, 'size': size})
+
+    # compare file_list with file_versions
+    list_file_ng = []
+    for file in file_versions:
+        if not storage_file_dict.get(file['name']):
+            ng_content = {
+                'path': file['path'],
+                'size': file['size'],
+                'version_id': file['version_id'],
+                'reason': 'File does not exist on the Export Storage Location',
+            }
+            list_file_ng.append(ng_content)
+    return list_file_ng
 
 def check_for_any_running_restore_process(destination_id):
     return ExportDataRestore.objects.filter(destination_id=destination_id).exclude(

--- a/admin/rdm_custom_storage_location/export_data/views/export.py
+++ b/admin/rdm_custom_storage_location/export_data/views/export.py
@@ -199,6 +199,20 @@ def export_data_process(task, cookies, export_data_id, **kwargs):
             return export_data_rollback_process(task, cookies, export_data_id, **kwargs)
         logger.debug(f'created export data process folder')
 
+        # temporary file
+        temp_file_path = export_data.export_data_temp_file_path
+
+        if task.is_aborted():  # check before each steps
+            raise ExportDataTaskException(MSG_EXPORT_ABORTED)
+        # create files' information file
+        logger.debug(f'creating files information file')
+        write_json_file(file_info_json, temp_file_path)
+        response = export_data.upload_file_info_full_data_file(cookies, temp_file_path, **kwargs)
+        if not task.is_aborted() and response.status_code != 201:
+            kwargs['is_rollback'] = True
+            return export_data_rollback_process(task, cookies, export_data_id, **kwargs)
+        logger.debug(f'created files information file')
+
         # export target file and accompanying data
         if task.is_aborted():  # check before each steps
             raise ExportDataTaskException(MSG_EXPORT_ABORTED)
@@ -255,7 +269,7 @@ def export_data_process(task, cookies, export_data_id, **kwargs):
         logger.debug(f'uploaded file versions')
 
         # temporary file
-        temp_file_path = export_data.export_data_temp_file_path
+        # temp_file_path = export_data.export_data_temp_file_path
 
         if task.is_aborted():  # check before each steps
             raise ExportDataTaskException(MSG_EXPORT_ABORTED)

--- a/admin/rdm_custom_storage_location/export_data/views/export.py
+++ b/admin/rdm_custom_storage_location/export_data/views/export.py
@@ -258,7 +258,7 @@ def export_data_process(task, cookies, export_data_id, location_id, source_id, *
         logger.debug(f'creating files information file')
         write_json_file(file_info_json, temp_file_path)
         response = export_data.upload_file_info_full_data_file(cookies, temp_file_path, **kwargs)
-        if not task.is_aborted() and response.status_code != 201:
+        if not task.is_aborted() and response.status_code not in [201, 204]:
             raise ExportDataTaskException(MSG_EXPORT_FAILED_UPLOAD_TO_LOCATION)
         logger.debug(f'created files information file')
 
@@ -367,7 +367,7 @@ def export_data_process(task, cookies, export_data_id, location_id, source_id, *
         _step_start_time = time.time()
         write_json_file(file_info_json, temp_file_path)
         response = export_data.upload_file_info_file(cookies, temp_file_path, **kwargs)
-        if not task.is_aborted() and response.status_code != 201:
+        if not task.is_aborted() and response.status_code not in [201, 204]:
             raise ExportDataTaskException(MSG_EXPORT_FAILED_UPLOAD_TO_LOCATION)
         logger.info(f'Created files information JSON file.'
                     f' ({time.time() - _step_start_time}s)')

--- a/admin/static/js/rdm_custom_storage_location/rdm-institutional-storage-page.js
+++ b/admin/static/js/rdm_custom_storage_location/rdm-institutional-storage-page.js
@@ -9,6 +9,8 @@ var sprintf = require('agh.sprintf').sprintf;
 
 var clipboard = require('js/clipboard');
 
+var constants = require('js/constants/constants');
+
 var no_storage_name_providers = ['osfstorage', 'onedrivebusiness'];
 // type1: get from admin/rdm_addons/api_v1/views.py
 var preload_accounts_type1 = ['dropboxbusiness'];
@@ -17,8 +19,8 @@ var preload_accounts_type2 = ['nextcloudinstitutions',
                 'ociinstitutions',
                 's3compatinstitutions']
 // delay time to show growl box; in millisecond
-var growlBoxDelay = 5000;
-var intervalCheckStatus = 5000;
+var growlBoxDelay = constants.GROWL_BOX_DELAY_TIME || 5000;
+var intervalCheckStatus = constants.CHECK_STATUS_INTERVAL || 10000;
 var list_file_info_export_fail = [];
 var list_file_info_restore_fail = [];
 var file_name_export_fail = '';

--- a/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
@@ -1379,6 +1379,66 @@ class TestCheckExportData(AdminTestCase):
         res = utils.deep_diff(a_new, a_standard, exclude_keys=['section1', 'section2'])
         nt.assert_not_equal(res, None)
 
+    @patch(f'{EXPORT_DATA_UTIL_PATH}.get_file_data')
+    def test_check_for_file_existent_on_export_location(self, mock_get_file_data):
+        test_response = requests.Response()
+        test_response.status_code = status.HTTP_200_OK
+        response_body = {
+            'data': [
+                {
+                    'id': '1',
+                    'attributes': {
+                        'name': '10a14359db515c709492b51cff52feaad4783c166ba9ad34fb03e74be1924c4d',
+                        'size': 8,
+                    }
+                }
+            ]
+        }
+        test_response._content = json.dumps(response_body).encode('utf-8')
+        mock_get_file_data.return_value = test_response
+
+        file_json = {
+            'files': [
+                {
+                    'materialized_path': '/test_path/file1.txt',
+                    'version': [
+                        {
+                            'version_name': 'file1.txt',
+                            'size': 10,
+                            'identifier': 1,
+                            'metadata': {
+                                'md5': '9193f63d5939cfbb102e677ca717465d',
+                                'sha256': '10a14359db515c709492b51cff52feaad4783c166ba9ad34fb03e74be1924c4d'
+                            }
+                        }
+                    ]
+                },
+                {
+                    'materialized_path': '/test_path/file2.txt',
+                    'version': [
+                        {
+                            'version_name': 'file2.txt',
+                            'size': 20,
+                            'identifier': 1,
+                            'metadata': {
+                                'md5': '273604bfeef7126abe1f9bff1e45126c',
+                                'sha256': '19ad8d7393d45c3a124d2e9bb5111412973a16fb3d24a0aa378bcd410c33fd3f'
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        result = utils.check_for_file_existent_on_export_location(file_json, TEST_PROJECT_ID, TEST_PROVIDER, '/test/', None, None, None)
+        expected_result = [
+            {
+                'path': '/test_path/file2.txt',
+                'size': 20,
+                'version_id': 1,
+                'reason': 'File does not exist on the Export Storage Location',
+            }
+        ]
+        nt.assert_equal(result, expected_result)
 
 @pytest.mark.feature_202210
 class TestCheckRestoreData(AdminTestCase):

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_export.py
@@ -607,6 +607,7 @@ class TestExportDataProcess(unittest.TestCase):
             nt.assert_equal(_task_result.get('export_data_status'), self.export_data.status)
 
     @pytest.mark.django_db
+    @mock.patch(f'{EXPORT_DATA_PATH}.ExportData.upload_file_info_full_data_file')
     @mock.patch(f'{EXPORT_DATA_PATH}.ExportData.upload_export_data_file')
     @mock.patch(f'{EXPORT_DATA_PATH}.ExportData.upload_file_info_file')
     @mock.patch(f'{EXPORT_DATA_PATH}.ExportData.copy_export_data_file_to_location')
@@ -624,6 +625,7 @@ class TestExportDataProcess(unittest.TestCase):
             mock_copy_export_data_file_to_location,
             mock_upload_file_info_file,
             mock_upload_export_data_file,
+            mock_upload_file_info_full_data_file
     ):
         mock_export_data.filter.return_value.first.return_value = self.export_data
         mock_export_data.filter.return_value.update.side_effect = self.update_fake
@@ -656,6 +658,7 @@ class TestExportDataProcess(unittest.TestCase):
         mock_copy_export_data_file_to_location.return_value.status_code = status.HTTP_201_CREATED
         mock_upload_file_info_file.return_value.status_code = status.HTTP_201_CREATED
         mock_upload_export_data_file.return_value.status_code = status.HTTP_201_CREATED
+        mock_upload_file_info_full_data_file.return_value.status_code = status.HTTP_201_CREATED
 
         _task_result = export.export_data_process(
             self.task, self.cookies, self.export_data.id,

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_management.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_management.py
@@ -717,8 +717,9 @@ class TestCheckExportData(AdminTestCase):
                 res = view.get(request, data_id=self.export_data.id)
         nt.assert_equals(res.status_code, 400)
 
+    @mock.patch('admin.rdm_custom_storage_location.export_data.views.management.check_for_file_existent_on_export_location')
     @mock.patch.object(ExportData, 'extract_file_information_json_from_source_storage')
-    def test_check_export_data_successful(self, mock_class):
+    def test_check_export_data_successful(self, mock_class, mock_check_exist):
         request = RequestFactory().get('/fake_path')
         request.user = self.user
         request.COOKIES = '213919sdasdn823193929'
@@ -730,6 +731,7 @@ class TestCheckExportData(AdminTestCase):
         mock_export_data = mock.MagicMock()
         mock_request = mock.MagicMock()
         mock_validate = mock.MagicMock()
+        mock_check_exist.return_value = []
         mock_validate.return_value = True
         mock_request.get.return_value = FakeRes(200)
         self.export_data.source._id = 'vcu'

--- a/osf/models/export_data.py
+++ b/osf/models/export_data.py
@@ -414,13 +414,13 @@ class ExportData(base.BaseModel):
         return self.upload_export_data_file(cookies, file_path, **kwargs)
 
     def get_file_info_full_data_filename(self, institution_guid=None):
-        """get file_info_{institution_guid}_{process_start_timestamp}.json file name for each institution"""
+        """get file_info_{institution_guid}_{process_start_timestamp}_full_data.json file name for each institution"""
         if not institution_guid:
             institution_guid = self.source.guid
         return f'file_info_{institution_guid}_{self.process_start_timestamp}_full_data.json'
 
     def upload_file_info_full_data_file(self, cookies, file_path, **kwargs):
-        """Upload export_{source.id}_{process_start_timestamp}/file_info_{institution_guid}_{process_start_timestamp}.json file
+        """Upload export_{source.id}_{process_start_timestamp}/file_info_{institution_guid}_{process_start_timestamp}_full_data.json file
            to the storage location"""
         file_name = self.get_file_info_full_data_filename(self.location.institution_guid)
         kwargs.setdefault('file_name', file_name)

--- a/osf/models/export_data.py
+++ b/osf/models/export_data.py
@@ -413,6 +413,19 @@ class ExportData(base.BaseModel):
         kwargs.setdefault('file_name', file_name)
         return self.upload_export_data_file(cookies, file_path, **kwargs)
 
+    def get_file_info_full_data_filename(self, institution_guid=None):
+        """get file_info_{institution_guid}_{process_start_timestamp}.json file name for each institution"""
+        if not institution_guid:
+            institution_guid = self.source.guid
+        return f'file_info_{institution_guid}_{self.process_start_timestamp}_full_data.json'
+
+    def upload_file_info_full_data_file(self, cookies, file_path, **kwargs):
+        """Upload export_{source.id}_{process_start_timestamp}/file_info_{institution_guid}_{process_start_timestamp}.json file
+           to the storage location"""
+        file_name = self.get_file_info_full_data_filename(self.location.institution_guid)
+        kwargs.setdefault('file_name', file_name)
+        return self.upload_export_data_file(cookies, file_path, **kwargs)
+
     def get_file_info_file_path(self, institution_guid=None):
         """get /export_{source.id}_{process_start_timestamp}/file_info_{institution_guid}_{process_start_timestamp}.json file path"""
         if not institution_guid:

--- a/website/static/js/constants/constants.js
+++ b/website/static/js/constants/constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+    GROWL_BOX_DELAY_TIME: 5000,
+    CHECK_STATUS_INTERVAL: 10000
+};


### PR DESCRIPTION
## Purpose


Relate to the following issue:
[NII Redmine#39836]エクスポート開始後、プロセスのステータスが"Pending"となり、エクスポート処理が開始されない
- Create a new File Info JSON with full data including failed files when exporting data.
- Add a function to check files exist on the Export storage location when clicking [Check Export data] button.

## Changes

No DB changes

## QA Notes

## Documentation

## Side Effects

## Ticket

