### PR TITLE
Feature/202210-InstitutionalStorageControl/fixedbug/40871 

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -168,7 +168,9 @@
         "dropboxbusiness",
         "s3compatinstitutions",
         "ociinstitutions",
-        "onedrivebusiness"
+        "s3",
+        "s3compat",
+        "owncloud"
     ],
     "institutional_storage_bulk_mount_method": [
         "box",

--- a/addons.json
+++ b/addons.json
@@ -168,9 +168,7 @@
         "dropboxbusiness",
         "s3compatinstitutions",
         "ociinstitutions",
-        "s3",
-        "s3compat",
-        "owncloud"
+        "onedrivebusiness"
     ],
     "institutional_storage_bulk_mount_method": [
         "box",
@@ -182,5 +180,9 @@
         "s3",
         "s3compat",
         "owncloud"
+    ],
+    "addons_has_max_keys": [
+        "s3",
+        "s3compat"
     ]
 }

--- a/admin/rdm_custom_storage_location/export_data/utils.py
+++ b/admin/rdm_custom_storage_location/export_data/utils.py
@@ -30,7 +30,12 @@ from osf.models import (
     ExportDataLocation,
     ExternalAccount,
 )
-from website.settings import WATERBUTLER_URL, INSTITUTIONAL_STORAGE_ADD_ON_METHOD, INSTITUTIONAL_STORAGE_BULK_MOUNT_METHOD
+from website.settings import (
+    WATERBUTLER_URL,
+    INSTITUTIONAL_STORAGE_ADD_ON_METHOD,
+    INSTITUTIONAL_STORAGE_BULK_MOUNT_METHOD,
+    ADDONS_HAS_MAX_KEYS
+)
 from website.util import inspect_info  # noqa
 
 logger = logging.getLogger(__name__)
@@ -47,6 +52,7 @@ __all__ = [
     'write_json_file',
     'check_diff_between_version',
     'count_files_ng_ok',
+    'check_for_file_existent_on_export_location',
 ]
 ANY_BACKUP_FOLDER_REGEX = '^\\/backup_\\d{8,13}\\/.*$'
 
@@ -425,14 +431,17 @@ def count_files_ng_ok(exported_file_versions, storage_file_versions, exclude_key
     data['list_file_ng'] = list_file_ng if len(list_file_ng) <= 10 else list_file_ng[:10]
     return data
 
-def check_for_file_existent_on_export_location(file_info_json, node_id, provider, file_path, location_id, cookies, cookie):
-    response = get_file_data(node_id, provider, file_path, cookies, base_url=WATERBUTLER_URL, get_file_info=False,
-                             version=None, location_id=location_id, cookie=cookie)
+
+def check_for_file_existent_on_export_location(
+        file_info_json, node_id, provider, file_path, location_id,
+        cookies, cookie):
     # Get list file in export storage location
-    response_body = response.json() if response.status_code == 200 else None
-    file_list = response_body.get('data') if response_body is not None else None
-    if (file_list is None):
+    file_list = get_files_in_path(node_id, provider, file_path, cookies,
+                                  location_id=location_id, cookie=cookie)
+
+    if not file_list:
         return None
+
     attrs = ['name', 'size']
     storage_file_list = [{attr: file.get('attributes', {}).get(attr) for attr in attrs} for file in file_list]
     storage_file_dict = {file.get('name'): file for file in storage_file_list}
@@ -449,7 +458,13 @@ def check_for_file_existent_on_export_location(file_info_json, node_id, provider
             file_name = metadata.get('sha256', metadata.get('md5'))
             version_name = version.get('version_name')
             version_id = version.get('identifier')
-            file_versions.append({'path': file_path, 'name': file_name, 'version_name': version_name, 'version_id': version_id, 'size': size})
+            file_versions.append({
+                'path': file_path,
+                'name': file_name,
+                'version_name': version_name,
+                'version_id': version_id,
+                'size': size
+            })
 
     # compare file_list with file_versions
     list_file_ng = []
@@ -463,6 +478,7 @@ def check_for_file_existent_on_export_location(file_info_json, node_id, provider
             }
             list_file_ng.append(ng_content)
     return list_file_ng
+
 
 def check_for_any_running_restore_process(destination_id):
     return ExportDataRestore.objects.filter(destination_id=destination_id).exclude(
@@ -482,6 +498,47 @@ def get_file_data(node_id, provider, file_path, cookies, base_url=WATERBUTLER_UR
     return requests.get(file_url,
                         headers={'content-type': 'application/json'},
                         cookies=cookies)
+
+
+def get_files_in_path(node_id, provider, path, cookies, **kwargs):
+    file_list = []
+    next_token = None
+    _retries = 2
+    while next_token or _retries:
+        # Get list file in export storage location
+        if next_token:
+            kwargs['next_token'] = next_token
+        response = get_file_data(
+            node_id, provider, path, cookies,
+            **kwargs)
+
+        # handle response
+        if response.status_code == 200:
+            response_body = response.json()
+            new_file_list = response_body.get('data', [])
+            file_list = file_list + new_file_list
+            # request again if it has next_token
+            next_token = response_body.get('next_token')
+            _retries = 0
+        else:
+            _retries = max(_retries - 1, 0)
+            message = (f'Failed to get info of path "{path}" on destination storage,'
+                       f' create new folder on destination storage')
+            if _retries:
+                message = 'Try to get object list again'
+            logger.warning(message)
+            continue  # request again
+
+        # stop if response new_file_list is empty
+        if not new_file_list:
+            break
+
+        # stop if addon have not a max-keys (-like) option
+        if provider not in ADDONS_HAS_MAX_KEYS:
+            # _retries = 0
+            break
+
+    return file_list
 
 
 def create_folder(node_id, provider, parent_path, folder_name, cookies, callback_log=False, base_url=WATERBUTLER_URL, **kwargs):
@@ -526,15 +583,24 @@ def update_existing_file(node_id, provider, file_path, file_data, cookies, base_
         return None, None
 
 
-def create_folder_path(node_id, provider, folder_path, cookies, base_url=WATERBUTLER_URL, **kwargs):
+def create_folder_path(node_id, destination_region, folder_path, cookies, base_url=WATERBUTLER_URL, **kwargs):
     if not folder_path.startswith('/') and not folder_path.endswith('/'):
         # Invalid folder path, return immediately
         return
+
+    provider = destination_region.provider_name
+    is_destination_addon_storage = is_add_on_storage(provider)
+
     paths = folder_path.split('/')[1:-1]
     created_path = '/'
     created_materialized_path = '/'
     for index, path in enumerate(paths):
         try:
+            if not is_destination_addon_storage:
+                _msg = 'Ignore check folder existence in institution storage bulk-mount method'
+                logger.warning(_msg)
+                raise Exception(_msg)
+
             response = get_file_data(node_id, provider, created_path, cookies, base_url, get_file_info=False, **kwargs)
             if response.status_code != 200:
                 raise Exception('Cannot get folder info')
@@ -644,7 +710,9 @@ def copy_file_to_other_storage(export_data, destination_node_id, destination_pro
         return None
 
 
-def copy_file_from_location_to_destination(export_data, destination_node_id, destination_provider, location_file_path, destination_file_path, cookies, base_url=WATERBUTLER_URL, **kwargs):
+def copy_file_from_location_to_destination(
+        export_data, destination_node_id, destination_provider, location_file_path, destination_file_path, cookies,
+        base_url=WATERBUTLER_URL, **kwargs):
     if not destination_file_path.startswith('/') or destination_file_path.endswith('/'):
         # Invalid file path, return immediately
         return None
@@ -658,20 +726,23 @@ def copy_file_from_location_to_destination(export_data, destination_node_id, des
     for path in folder_paths:
         try:
             # Try to get path information
-            response = get_file_data(destination_node_id, destination_provider, created_folder_path,
-                                     cookies, base_url, get_file_info=True, **kwargs)
-            if response.status_code != 200:
-                raise Exception(f'Failed to get info of path "{created_folder_path}" on destination storage, create new folder on destination storage')
+            file_list = get_files_in_path(destination_node_id, destination_provider, created_folder_path, cookies,
+                                          base_url=base_url,
+                                          get_file_info=True,
+                                          **kwargs)
+            if not file_list:
+                raise Exception('Empty folder')
 
-            response_body = response.json()
             new_folder_path = f'{created_folder_materialized_path}{path}/'
-
-            existing_path_info = next((item for item in response_body['data'] if
+            existing_path_info = next((item for item in file_list if
                                        item['attributes']['materialized'] == new_folder_path),
                                       None)
 
             if existing_path_info is None:
-                raise Exception(f'Path "{new_folder_path}" is not found on destination storage, create new folder on destination storage')
+                message = (f'Path "{new_folder_path}" is not found on destination storage,'
+                           f' create new folder on destination storage')
+                logger.warning(message)
+                raise Exception(message)
 
             created_folder_path = existing_path_info['attributes']['path']
             created_folder_materialized_path = existing_path_info['attributes']['materialized']

--- a/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
@@ -1594,7 +1594,7 @@ class TestUtilsForRestoreData(AdminTestCase):
         })
         self.export_data = ExportDataFactory()
         self.export_data_restore = ExportDataRestoreFactory(status=ExportData.STATUS_RUNNING)
-        self.export_data_restore.destination.waterbutler_settings['storage']['provider'] = 'onedrivebusiness'
+        self.export_data_restore.destination.waterbutler_settings['storage']['provider'] = 'dropboxbusiness'
         self.export_data_restore.destination.save()
         self.destination_id = self.export_data_restore.destination.id
 
@@ -3386,17 +3386,19 @@ class TestUtilsForRestoreData(AdminTestCase):
         nt.assert_is_none(utils.is_add_on_storage(None))
         nt.assert_is_none(utils.is_add_on_storage('osf_storage'))
 
+        # both addon method and bulk-mount method
+        nt.assert_false(utils.is_add_on_storage('owncloud'))
+        nt.assert_false(utils.is_add_on_storage('s3compat'))
+        nt.assert_false(utils.is_add_on_storage('s3'))
+
         # only addon method providers
         nt.assert_true(utils.is_add_on_storage('nextcloudinstitutions'))
         nt.assert_true(utils.is_add_on_storage('s3compatinstitutions'))
         nt.assert_true(utils.is_add_on_storage('ociinstitutions'))
         nt.assert_true(utils.is_add_on_storage('dropboxbusiness'))
-        nt.assert_true(utils.is_add_on_storage('onedrivebusiness'))
 
         # only bulk-mount method providers
-        nt.assert_false(utils.is_add_on_storage('owncloud'))
-        nt.assert_false(utils.is_add_on_storage('s3compat'))
-        nt.assert_false(utils.is_add_on_storage('s3'))
+        nt.assert_false(utils.is_add_on_storage('onedrivebusiness'))
         nt.assert_false(utils.is_add_on_storage('swift'))
         nt.assert_false(utils.is_add_on_storage('box'))
         nt.assert_false(utils.is_add_on_storage('nextcloud'))

--- a/admin_tests/rdm_custom_storage_location/export_data/views/test_restore.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/views/test_restore.py
@@ -763,8 +763,9 @@ class TestRestoreDataFunction(AdminTestCase):
     @mock.patch(f'{RESTORE_EXPORT_DATA_PATH}.move_all_files_to_backup_folder')
     @mock.patch(f'{RESTORE_EXPORT_DATA_PATH}.check_if_restore_process_stopped')
     @mock.patch(f'{RESTORE_EXPORT_DATA_PATH}.read_file_info_and_check_schema')
-    def test_restore_export_data_process_bulk_mount_storage(self, mock_read_file_info, mock_check_process, mock_move_to_backup, mock_copy_to_destination,
-                                                            mock_add_tag_and_timestamp, mock_create_folder_path):
+    def test_restore_export_data_process_bulk_mount_storage(
+            self, mock_read_file_info, mock_check_process, mock_move_to_backup, mock_copy_to_destination,
+            mock_add_tag_and_timestamp, mock_create_folder_path):
         task = AbortableTask()
         task.request_stack = LocalStack()
         task.request.id = FAKE_TASK_ID
@@ -776,8 +777,8 @@ class TestRestoreDataFunction(AdminTestCase):
         mock_add_tag_and_timestamp.return_value = None
         mock_create_folder_path.return_value = None
 
-        self.view.restore_export_data_process(task, {}, self.export_data_restore.export.id,
-                                              self.export_data_restore.id, ['vcu'])
+        self.view.restore_export_data_process(task, {}, self.bulk_mount_data_restore.export.id,
+                                              self.bulk_mount_data_restore.id, ['vcu'])
         mock_read_file_info.assert_called()
         mock_check_process.assert_called()
         mock_move_to_backup.assert_not_called()
@@ -1556,8 +1557,8 @@ class TestRestoreDataFunction(AdminTestCase):
         task.request_stack = LocalStack()
         task.request.id = FAKE_TASK_ID
 
-        response = self.view.restore_export_data_rollback_process(task, None, self.export_data.id,
-                                                                  self.export_data_restore.id,
+        response = self.view.restore_export_data_rollback_process(task, None, self.bulk_mount_data_restore.export.id,
+                                                                  self.bulk_mount_data_restore.id,
                                                                   3)
 
         mock_read_file_info.assert_not_called()

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -272,6 +272,7 @@ with open(os.path.join(ROOT, 'addons.json')) as fp:
     ADDONS_OAUTH_NO_REDIRECT = addon_settings['addons_oauth_no_redirect']
     INSTITUTIONAL_STORAGE_ADD_ON_METHOD = addon_settings['institutional_storage_add_on_method']
     INSTITUTIONAL_STORAGE_BULK_MOUNT_METHOD = addon_settings['institutional_storage_bulk_mount_method']
+    ADDONS_HAS_MAX_KEYS = addon_settings['addons_has_max_keys']
 
 SYSTEM_ADDED_ADDONS = {
     'user': [],


### PR DESCRIPTION
## Purpose

It prioritizes fixes for 機関ストレージ(一括マウント方式)＋S3互換.  
Functionality is affected if the provider directory to be checked has more than 1000 objects:
- 「エクスポートデータチェック」
- 「リストア実行時」

## Changes

Update logic gets all files in a path from the provider for 
- 「エクスポートデータチェック」, 
  -  In the logic of checking files' existence in the Export location storage:
  -> [fixed] Update logic to get all objects in a path for checking.
- 「リストア実行時」
  - When restoring folders, check if the folder path is existing in the Restore destination storage  
    -> [fixed] In the case of 機関ストレージ(一括マウント方式), skip checking for folders' existence
  - When restoring files, check if the file path is existing in the Restore destination storage
     -> [fixed] Update logic to get all objects in a path for checking. 
     (* It is effective for 機関ストレージ(アドオン方式). No errors occurred in the case of 機関ストレージ(一括マウント方式))

The following tests were performed:
  * 「エクスポートデータチェック」, The cases of Export storage destination is s3compat, s3
  * 「リストア実行時」, The cases of Restore storage destination is s3compat, s3

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

[Bug] エクスポートデータ(/export_xx_xxxxxxxxxx/files/配下)として1000件以上のオブジェクトが存在すると「エクスポートデータチェック」でNGとなる