### PR TITLE
Feature/202210 institutional storage control/fixedbug/41741

### DIFF
--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -351,5 +351,5 @@ LOCALE_PATHS = (
 # The directory to store data temporarily.
 TEMPORARY_PATH = '/tmp/'
 
-# Time out for calling copy API
-EACH_FILE_EXPORT_TIME_OUT = 1800
+# Time out for calling copy API in Export/Restore processes
+EACH_FILE_EXPORT_RESTORE_TIME_OUT = 1800

--- a/admin/rdm_custom_storage_location/export_data/utils.py
+++ b/admin/rdm_custom_storage_location/export_data/utils.py
@@ -37,7 +37,7 @@ from website.settings import (
     ADDONS_HAS_MAX_KEYS
 )
 from website.util import inspect_info  # noqa
-from admin.base.settings import EACH_FILE_EXPORT_TIME_OUT
+from admin.base.settings import EACH_FILE_EXPORT_RESTORE_TIME_OUT
 
 logger = logging.getLogger(__name__)
 
@@ -714,7 +714,7 @@ def copy_file_to_other_storage(export_data, destination_node_id, destination_pro
                                  headers={'content-type': 'application/json'},
                                  cookies=cookies,
                                  json=request_body,
-                                 timeout=EACH_FILE_EXPORT_TIME_OUT)
+                                 timeout=EACH_FILE_EXPORT_RESTORE_TIME_OUT)
         return response.json() if response.status_code in [200, 201] else None
     except (requests.ConnectionError, requests.Timeout, requests.ReadTimeout) as e:
         logger.error(f'Timeout exception occurs: {e}')

--- a/admin/rdm_custom_storage_location/export_data/utils.py
+++ b/admin/rdm_custom_storage_location/export_data/utils.py
@@ -37,6 +37,7 @@ from website.settings import (
     ADDONS_HAS_MAX_KEYS
 )
 from website.util import inspect_info  # noqa
+from admin.base.settings import EACH_FILE_EXPORT_TIME_OUT
 
 logger = logging.getLogger(__name__)
 
@@ -712,9 +713,14 @@ def copy_file_to_other_storage(export_data, destination_node_id, destination_pro
         response = requests.post(copy_file_url,
                                  headers={'content-type': 'application/json'},
                                  cookies=cookies,
-                                 json=request_body)
+                                 json=request_body,
+                                 timeout=EACH_FILE_EXPORT_TIME_OUT)
         return response.json() if response.status_code in [200, 201] else None
-    except Exception:
+    except (requests.ConnectionError, requests.Timeout, requests.ReadTimeout) as e:
+        logger.error(f'Timeout exception occurs: {e}')
+        return None
+    except Exception as e:
+        logger.error(f'Exception: {e}')
         return None
 
 

--- a/osf/models/export_data.py
+++ b/osf/models/export_data.py
@@ -22,7 +22,7 @@ from osf.models import (
 from admin.base import settings as admin_settings
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import EncryptedJSONField
-from admin.base.settings import EACH_FILE_EXPORT_TIME_OUT
+from admin.base.settings import EACH_FILE_EXPORT_RESTORE_TIME_OUT
 
 logger = logging.getLogger(__name__)
 
@@ -534,7 +534,7 @@ class ExportData(base.BaseModel):
                              headers={'content-type': 'application/json'},
                              cookies=cookies,
                              json=request_body,
-                             timeout=EACH_FILE_EXPORT_TIME_OUT)
+                             timeout=EACH_FILE_EXPORT_RESTORE_TIME_OUT)
 
     def get_data_file_file_path(self, file_name):
         """get /export_{source.id}_{process_start_timestamp}/files/{file_name} file path"""


### PR DESCRIPTION
## Purpose

Workaround for the phenomenon that the Restore process stopping midway:  
* When restoring data, set the timeout value for rdm-osf-osf-worker at the time the API copy is called.

## Changes

* No DB changes

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

[Bug][41741]リストア処理実行時にリストア処理が途中で停止する事象について
