### PR TITLE
Hotfix/39988

### DIFF
--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -15,6 +15,7 @@ from osf.models import (
 from osf_tests.factories import (
     AuthUserFactory, ProjectFactory, UserFactory, InstitutionFactory, RegionFactory
 )
+from osf.utils.requests import check_select_for_update
 from website.util import web_url_for, quota
 from api.base import settings as api_settings
 
@@ -1297,12 +1298,20 @@ class TestSaveUsedQuota(OsfTestCase):
         mock_user_quota = mock.MagicMock()
         mock_base_file_node.objects.filter.return_value.order_by.return_value.first.return_value = self.base_file_node
         mock_file_info.objects.get.return_value = FileInfo(file=self.base_file_node, file_size=1000)
-        mock_user_quota.objects.filter.return_value.first.return_value = UserQuota(
-            user=self.project_creator,
-            storage_type=UserQuota.CUSTOM_STORAGE,
-            max_quota=api_settings.DEFAULT_MAX_QUOTA,
-            used=5500
-        )
+        if check_select_for_update():
+            mock_user_quota.objects.filter.return_value.select_for_update.return_value.first.return_value = UserQuota(
+                user=self.project_creator,
+                storage_type=UserQuota.CUSTOM_STORAGE,
+                max_quota=api_settings.DEFAULT_MAX_QUOTA,
+                used=5500
+            )
+        else:
+            mock_user_quota.objects.filter.return_value.first.return_value = UserQuota(
+                user=self.project_creator,
+                storage_type=UserQuota.CUSTOM_STORAGE,
+                max_quota=api_settings.DEFAULT_MAX_QUOTA,
+                used=5500
+            )
         with mock.patch('website.util.quota.BaseFileNode', mock_base_file_node):
             with mock.patch('website.util.quota.FileInfo', mock_file_info):
                 with mock.patch('website.util.quota.UserQuota', mock_user_quota):
@@ -1337,12 +1346,20 @@ class TestSaveUsedQuota(OsfTestCase):
                 _materialized_path='/testfolder/foldername', target_object_id=self.node.id, target_content_type_id=2)
         mock_base_file_node.objects.filter.return_value.all.return_value = [self.base_file_node, folder_element]
         mock_file_info.objects.get.return_value = FileInfo(file=self.base_file_node, file_size=1500)
-        mock_user_quota.objects.filter.return_value.first.return_value = UserQuota(
-            user=self.project_creator,
-            storage_type=UserQuota.CUSTOM_STORAGE,
-            max_quota=api_settings.DEFAULT_MAX_QUOTA,
-            used=5500
-        )
+        if check_select_for_update():
+            mock_user_quota.objects.filter.return_value.select_for_update.return_value.first.return_value = UserQuota(
+                user=self.project_creator,
+                storage_type=UserQuota.CUSTOM_STORAGE,
+                max_quota=api_settings.DEFAULT_MAX_QUOTA,
+                used=5500
+            )
+        else:
+            mock_user_quota.objects.filter.return_value.first.return_value = UserQuota(
+                user=self.project_creator,
+                storage_type=UserQuota.CUSTOM_STORAGE,
+                max_quota=api_settings.DEFAULT_MAX_QUOTA,
+                used=5500
+            )
         with mock.patch('website.util.quota.BaseFileNode', mock_base_file_node):
             with mock.patch('website.util.quota.FileInfo', mock_file_info):
                 with mock.patch('website.util.quota.UserQuota', mock_user_quota):

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -372,6 +372,7 @@ class TestSaveUsedQuota(OsfTestCase):
         self.file.save()
         self.base_file_node = BaseFileNode(type='osf.s3file', provider='s3', _path='/testfile',
                 _materialized_path='/testfile', target_object_id=self.node.id, target_content_type_id=2)
+        self.base_file_node.save()
         self.base_folder_node = BaseFileNode(type='osf.s3folder', provider='s3', _path='/testfolder',
                 _materialized_path='/testfolder', target_object_id=self.node.id, target_content_type_id=2)
 
@@ -1297,8 +1298,8 @@ class TestSaveUsedQuota(OsfTestCase):
         mock_file_info = mock.MagicMock()
         mock_user_quota = mock.MagicMock()
         mock_base_file_node.objects.filter.return_value.order_by.return_value.first.return_value = self.base_file_node
-        mock_file_info.objects.get.return_value = FileInfo(file=self.base_file_node, file_size=1000)
         if check_select_for_update():
+            mock_file_info.objects.filter.return_value.select_for_update.return_value.get.return_value = FileInfo(file=self.base_file_node, file_size=1000)
             mock_user_quota.objects.filter.return_value.select_for_update.return_value.first.return_value = UserQuota(
                 user=self.project_creator,
                 storage_type=UserQuota.CUSTOM_STORAGE,
@@ -1306,6 +1307,7 @@ class TestSaveUsedQuota(OsfTestCase):
                 used=5500
             )
         else:
+            mock_file_info.objects.get.return_value = FileInfo(file=self.base_file_node, file_size=1000)
             mock_user_quota.objects.filter.return_value.first.return_value = UserQuota(
                 user=self.project_creator,
                 storage_type=UserQuota.CUSTOM_STORAGE,
@@ -1345,8 +1347,8 @@ class TestSaveUsedQuota(OsfTestCase):
         folder_element = BaseFileNode(type='osf.s3folder', provider='s3', _path='/testfolder/foldername',
                 _materialized_path='/testfolder/foldername', target_object_id=self.node.id, target_content_type_id=2)
         mock_base_file_node.objects.filter.return_value.all.return_value = [self.base_file_node, folder_element]
-        mock_file_info.objects.get.return_value = FileInfo(file=self.base_file_node, file_size=1500)
         if check_select_for_update():
+            mock_file_info.objects.filter.return_value.select_for_update.return_value.get.return_value = FileInfo(file=self.base_file_node, file_size=1500)
             mock_user_quota.objects.filter.return_value.select_for_update.return_value.first.return_value = UserQuota(
                 user=self.project_creator,
                 storage_type=UserQuota.CUSTOM_STORAGE,
@@ -1354,6 +1356,7 @@ class TestSaveUsedQuota(OsfTestCase):
                 used=5500
             )
         else:
+            mock_file_info.objects.get.return_value = FileInfo(file=self.base_file_node, file_size=1500)
             mock_user_quota.objects.filter.return_value.first.return_value = UserQuota(
                 user=self.project_creator,
                 storage_type=UserQuota.CUSTOM_STORAGE,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Use select_for_update() to lock row of table to fix race condition on update user's quota.
Fix issue where size of previously deleted files would duplicately reduced from user's quota when deleting directory.

<!-- Describe the purpose of your changes -->

## Changes
Use select_for_update() to lock row of table to fix race condition on update user's quota.
Fix issue where size of previously deleted files would duplicately reduced from user's quota when deleting directory.

<!-- Briefly describe or list your changes  -->

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
  - What is the level of risk?
    - Any permissions code touched?
    - Is this an additive or subtractive change, other?
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
  - How will this impact performance?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
GRDM-39988
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
