### PR TITLE
Feature/202210-InstitutionalStorageControl/fixedbug/41895

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -229,10 +229,10 @@ class OsfStorageFileNode(BaseFileNode):
             if save:
                 self.save()
 
-    def save(self):
+    def save(self, *args, **kwargs):
         self._path = ''
         self._materialized_path = ''
-        return super(OsfStorageFileNode, self).save()
+        return super(OsfStorageFileNode, self).save(*args, **kwargs)
 
 
 class OsfStorageFile(OsfStorageFileNode, File):
@@ -408,7 +408,7 @@ class OsfStorageFile(OsfStorageFileNode, File):
     def save(self, skip_search=False, *args, **kwargs):
         from website.search import search
 
-        ret = super(OsfStorageFile, self).save()
+        ret = super(OsfStorageFile, self).save(*args, **kwargs)
         if not skip_search:
             search.update_file(self)
         return ret

--- a/osf/models/export_data.py
+++ b/osf/models/export_data.py
@@ -209,8 +209,8 @@ class ExportData(base.BaseModel):
                 'materialized_path': file.materialized_path,
                 'name': file.name,
                 'provider': file.provider,
-                'created_at': file.created.strftime('%Y-%m-%d %H:%M:%S'),
-                'modified_at': file.modified.strftime('%Y-%m-%d %H:%M:%S'),
+                'created_at': str(file.created),
+                'modified_at': str(file.modified),
                 'project': {},
                 'tags': [],
                 'version': [],
@@ -260,8 +260,8 @@ class ExportData(base.BaseModel):
                 file_version_thru = version.get_basefilenode_version(file)
                 version_info = {
                     'identifier': version.identifier,
-                    'created_at': version.created.strftime('%Y-%m-%d %H:%M:%S'),
-                    'modified_at': version.modified.strftime('%Y-%m-%d %H:%M:%S'),
+                    'created_at': str(version.created),
+                    'modified_at': str(version.modified),
                     'size': version.size,
                     'version_name': file_version_thru.version_name if file_version_thru else file.name,
                     'contributor': version.creator.username,

--- a/osf/models/export_data_restore.py
+++ b/osf/models/export_data_restore.py
@@ -115,8 +115,8 @@ class ExportDataRestore(base.BaseModel):
                 'materialized_path': file.materialized_path,
                 'name': file.name,
                 'provider': file.provider,
-                'created_at': file.created.strftime('%Y-%m-%d %H:%M:%S'),
-                'modified_at': file.modified.strftime('%Y-%m-%d %H:%M:%S'),
+                'created_at': str(file.created),
+                'modified_at': str(file.modified),
                 'project': {},
                 'tags': [],
                 'version': [],
@@ -166,8 +166,8 @@ class ExportDataRestore(base.BaseModel):
                 file_version_thru = version.get_basefilenode_version(file)
                 version_info = {
                     'identifier': version.identifier,
-                    'created_at': version.created.strftime('%Y-%m-%d %H:%M:%S'),
-                    'modified_at': version.modified.strftime('%Y-%m-%d %H:%M:%S'),
+                    'created_at': str(version.created),
+                    'modified_at': str(version.modified),
                     'size': version.size,
                     'version_name': file_version_thru.version_name if file_version_thru else file.name,
                     'contributor': version.creator.username,

--- a/osf_tests/test_export_data.py
+++ b/osf_tests/test_export_data.py
@@ -47,7 +47,6 @@ class TestExportData(TestCase):
         cls.file1 = file1 = OsfStorageFileFactory.create(
             name='file1.txt',
             created=datetime.now(),
-            target_object_id=project.id,
             target=target
         )
         file_version = FileVersionFactory(region=inst_region, size=3,)
@@ -87,8 +86,8 @@ class TestExportData(TestCase):
                 'materialized_path': file1.materialized_path,
                 'name': file1.name,
                 'provider': file1.provider,
-                'created_at': file1.created.strftime('%Y-%m-%d %H:%M:%S'),
-                'modified_at': file1.modified.strftime('%Y-%m-%d %H:%M:%S'),
+                'created_at': str(file1.created),
+                'modified_at': str(file1.modified),
                 'project': {
                     'id': file1.target._id,
                     'name': file1.target.title,
@@ -96,8 +95,8 @@ class TestExportData(TestCase):
                 'tags': [],
                 'version': [{
                     'identifier': file_version.identifier,
-                    'created_at': file_version.created.strftime('%Y-%m-%d %H:%M:%S'),
-                    'modified_at': file_version.created.strftime('%Y-%m-%d %H:%M:%S'),
+                    'created_at': str(file_version.created),
+                    'modified_at': str(file_version.modified),
                     'size': file_version.size,
                     'version_name': file_versions_through.version_name if file_versions_through else file1.name,
                     'contributor': file_version.creator.username,
@@ -107,6 +106,7 @@ class TestExportData(TestCase):
                 'size': 0,
                 'location': file_version.location,
                 'timestamp': {},
+                'checkout_id': None,
             }]
         }
 
@@ -225,7 +225,7 @@ class TestExportData(TestCase):
         self.inst_region.name = self.default_region.name
         self.inst_region.save()
 
-    def test_extract_file_information_json_from_source_storage__99_abnormal_file_data(self):
+    def test_extract_file_information_json_from_source_storage__05_abnormal_file_data(self):
         test_file_info_json = copy.deepcopy(self.file_info_json)
         test_export_data_json = copy.deepcopy(self.export_data_json)
         test_export_data_json['files_numb'] -= 1

--- a/osf_tests/test_export_data_restore.py
+++ b/osf_tests/test_export_data_restore.py
@@ -45,7 +45,6 @@ class TestExportDataRestore(TestCase):
         cls.file1 = file1 = OsfStorageFileFactory.create(
             name='file1.txt',
             created=datetime.now(),
-            target_object_id=project.id,
             target=target
         )
         file_version = FileVersionFactory(region=inst_region, size=3,)
@@ -85,8 +84,8 @@ class TestExportDataRestore(TestCase):
                 'materialized_path': file1.materialized_path,
                 'name': file1.name,
                 'provider': file1.provider,
-                'created_at': file1.created.strftime('%Y-%m-%d %H:%M:%S'),
-                'modified_at': file1.modified.strftime('%Y-%m-%d %H:%M:%S'),
+                'created_at': str(file1.created),
+                'modified_at': str(file1.modified),
                 'project': {
                     'id': file1.target._id,
                     'name': file1.target.title,
@@ -94,8 +93,8 @@ class TestExportDataRestore(TestCase):
                 'tags': [],
                 'version': [{
                     'identifier': file_version.identifier,
-                    'created_at': file_version.created.strftime('%Y-%m-%d %H:%M:%S'),
-                    'modified_at': file_version.created.strftime('%Y-%m-%d %H:%M:%S'),
+                    'created_at': str(file_version.created),
+                    'modified_at': str(file_version.modified),
                     'size': file_version.size,
                     'version_name': file_versions_through.version_name if file_versions_through else file1.name,
                     'contributor': file_version.creator.username,
@@ -105,6 +104,7 @@ class TestExportDataRestore(TestCase):
                 'size': 0,
                 'location': file_version.location,
                 'timestamp': {},
+                'checkout_id': None,
             }]
         }
 


### PR DESCRIPTION
## Purpose

- When Restore, it is not necessary to change the `creator` / `created` / `modified` of osf_fileversion.  
- When Restore, it is necessary to change the `creator` / `created` / `modified` of osf_basefilenode.  
- Adjust the values saved in the JSON file and ensure that rounding of the value of the `created` / `modified` osf_basefilenode is not done on restore.

## Changes

- Updated the `save` method of OsfStorageFileNode and OsfStorageFile to be able to pass `args` and `kwargs` from the derived class to the superclass.
- Updated copy_files_from_export_data_to_destination method to update information in osf_fileversion and osf_basefilenode as required.
- Updated extract_file_information_json_* method to ignore rounding of `created` / `modified` information

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

[Bug][#41895] リストア処理実行時に osf_fileversion の modified に created_at を使用して更新している事象について
