### PR TITLE
[GRDM-42507] RdmAddonOptionのライフサイクル及び変更検知に関する問題の修正

### DIFF
--- a/addons/iqbrims/models.py
+++ b/addons/iqbrims/models.py
@@ -391,6 +391,9 @@ def update_folder_name(sender, instance, created, **kwargs):
         management_node=node
     ).exists():
         return
+    if iqbrims.folder_id is None:
+        logger.info('No folder_id for IQB-RIMS: node={}'.format(node._id))
+        return
     try:
         access_token = iqbrims.fetch_access_token()
         client = IQBRIMSClient(access_token)

--- a/addons/iqbrims/models.py
+++ b/addons/iqbrims/models.py
@@ -410,7 +410,9 @@ def update_folder_name(sender, instance, created, **kwargs):
 def change_iqbrims_addon_enabled(sender, instance, created, **kwargs):
     if IQBRIMSAddonConfig.short_name not in ws_settings.ADDONS_AVAILABLE_DICT:
         return
-
+    if instance.provider != IQBRIMSAddonConfig.short_name:
+        # Ignore if the changed instance is not for IQB-RIMS
+        return
     if instance.is_allowed and instance.management_node is not None:
         for node in AbstractNode.find_by_institutions(instance.institution):
             if instance.organizational_node:
@@ -429,6 +431,9 @@ def setup_iqbrims_addon_auth_of_management_node(sender, instance, created, **kwa
     if IQBRIMSAddonConfig.short_name not in ws_settings.ADDONS_AVAILABLE_DICT:
         return
     if GoogleDriveAddonConfig.short_name not in ws_settings.ADDONS_AVAILABLE_DICT:
+        return
+    if instance.provider != IQBRIMSAddonConfig.short_name:
+        # Ignore if the changed instance is not for IQB-RIMS
         return
     if instance.management_node is None:
         return

--- a/addons/iqbrims/tests/test_models.py
+++ b/addons/iqbrims/tests/test_models.py
@@ -16,7 +16,7 @@ from addons.iqbrims.tests.factories import (
     IQBRIMSNodeSettingsFactory,
     IQBRIMSUserSettingsFactory
 )
-from osf.models import RdmAddonOption
+from osf.models import AbstractNode, RdmAddonOption
 from osf_tests.factories import ProjectFactory, InstitutionFactory
 
 pytestmark = pytest.mark.django_db
@@ -174,6 +174,7 @@ class TestIQBRIMSNodeReceiver(unittest.TestCase):
     def setUp(self):
         super(TestIQBRIMSNodeReceiver, self).setUp()
         self.node = ProjectFactory()
+        self.user_node = ProjectFactory()
         self.user = self.node.creator
         self.external_account = IQBRIMSAccountFactory()
 
@@ -227,3 +228,43 @@ class TestIQBRIMSNodeReceiver(unittest.TestCase):
         self.node.save(force_update=True)
 
         assert_equal(mock_rename_folder.call_count, 0)
+
+    @mock.patch.object(AbstractNode, 'find_by_institutions')
+    def test_update_addon_state_for_iqbrims_option(self, mock_find_by_institutions):
+        # IQB-RIMS calls add/delete_addon method when the RdmAddonOption is updated
+        mock_find_by_institutions.return_value = [self.user_node]
+
+        option = RdmAddonOption(
+            provider=self.short_name,
+            institution=self.institution,
+            management_node=self.node,
+            is_allowed=True,
+        )
+        with mock.patch.object(self.user_node, 'add_addon') as mock_add_addon:
+            option.save()
+            assert_equal(mock_add_addon.call_count, 1)
+
+        with mock.patch.object(self.user_node, 'delete_addon') as mock_delete_addon:
+            option.is_allowed = False
+            option.save()
+            assert_equal(mock_delete_addon.call_count, 1)
+
+    @mock.patch.object(AbstractNode, 'find_by_institutions')
+    def test_update_addon_state_for_other_option(self, mock_find_by_institutions):
+        # IQB-RIMS ignores changes of RdmAddonOption of other add-ons
+        mock_find_by_institutions.return_value = [self.user_node]
+
+        option = RdmAddonOption(
+            provider='some_other_addon',
+            institution=self.institution,
+            management_node=self.node,
+            is_allowed=True,
+        )
+        with mock.patch.object(self.user_node, 'add_addon') as mock_add_addon:
+            option.save()
+            assert_equal(mock_add_addon.call_count, 0)
+
+        with mock.patch.object(self.user_node, 'delete_addon') as mock_delete_addon:
+            option.is_allowed = False
+            option.save()
+            assert_equal(mock_delete_addon.call_count, 0)

--- a/admin/rdm_addons/utils.py
+++ b/admin/rdm_addons/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 
 from django.urls import reverse
@@ -12,6 +13,10 @@ from admin.base.settings import BASE_DIR
 from admin.rdm.utils import get_institution_id
 from admin.base.settings import UNSUPPORTED_FORCE_TO_USE_ADDONS
 from admin import rdm_addons
+
+
+logger = logging.getLogger(__name__)
+
 
 def get_institusion_settings_template(config):
     """get template file settings"""
@@ -75,27 +80,45 @@ def _get_rdm_addon_option_get_only(institution_id, addon_name):
                 provider=addon_name)
         return rdm_addon_option
     except Exception:
+        # Since there are multiple exceptions that can be caught by this block,
+        # logging at the warning level will help to identify the problem.
+        logger.warning(
+            'Failed to get RdmAddonOption for institution_id={}, addon_name={}'.format(institution_id, addon_name),
+            exc_info=True,
+        )
         return None
+
+def _get_is_allowed_default(addon_name):
+    app = settings.ADDONS_AVAILABLE_DICT.get(addon_name)
+    if not app:
+        # If an add-on is requested even though it is not in ADDONS_AVAILABLE_DICT, it is probably a bug on the requestor's side,
+        # so output a log at the warning level.
+        logger.warning('The add-on "{}" is not in ADDONS_AVAILABLE_DICT.'.format(addon_name))
+        return None
+    # is_allowed_default is False when for_institutions is True
+    for_institutions = getattr(app, 'for_institutions', False)
+    return getattr(app, 'is_allowed_default', True) and not for_institutions
 
 def get_rdm_addon_option(institution_id, addon_name, create=True):
     """get model objects of RdmAddonOption or RdmAddonNoInstitutionOption"""
     if not create:
         return _get_rdm_addon_option_get_only(institution_id, addon_name)
+    defaults = {}
+    is_allowed_default = _get_is_allowed_default(addon_name)
+    if is_allowed_default is not None:
+        defaults['is_allowed'] = is_allowed_default
+
     if institution_id:
         rdm_addon_option, created = RdmAddonOption.objects.get_or_create(
-            institution_id=institution_id, provider=addon_name)
+            institution_id=institution_id,
+            provider=addon_name,
+            defaults=defaults,
+        )
     else:
-        rdm_addon_option, created = RdmAddonNoInstitutionOption.objects.get_or_create(provider=addon_name)
-    if not created:
-        return rdm_addon_option
-
-    app = settings.ADDONS_AVAILABLE_DICT.get(addon_name)
-    if app:
-        # is_allowed_default is False when for_institutions is True
-        for_institutions = getattr(app, 'for_institutions', False)
-        is_allowed_default = getattr(app, 'is_allowed_default', True) and not for_institutions
-        rdm_addon_option.is_allowed = is_allowed_default
-        rdm_addon_option.save()
+        rdm_addon_option, created = RdmAddonNoInstitutionOption.objects.get_or_create(
+            provider=addon_name,
+            defaults=defaults,
+        )
     return rdm_addon_option
 
 def update_with_rdm_addon_settings(addon_setting, user):

--- a/admin_tests/rdm_addons/test_utils.py
+++ b/admin_tests/rdm_addons/test_utils.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from nose import tools as nt
+
+from tests.base import AdminTestCase
+from osf_tests.factories import InstitutionFactory
+
+from admin.rdm_addons import utils
+
+import logging
+logging.getLogger('website.project.model').setLevel(logging.DEBUG)
+
+class TestRdmAddonOption(AdminTestCase):
+    def setUp(self):
+        super(TestRdmAddonOption, self).setUp()
+        self.institution = InstitutionFactory()
+
+    def tearDown(self):
+        super(TestRdmAddonOption, self).tearDown()
+        self.institution.delete()
+
+    def test_get_rdm_addon_option_without_create_option(self):
+        nt.assert_equal(None, utils.get_rdm_addon_option(self.institution.id, 's3', create=False))
+        nt.assert_equal(None, utils.get_rdm_addon_option(self.institution.id, 'dropboxbusiness', create=False))
+
+    def test_get_is_allowed_default(self):
+        # newly created option
+        option = utils.get_rdm_addon_option(self.institution.id, 's3')
+        nt.assert_true(option.is_allowed)
+
+        option = utils.get_rdm_addon_option(self.institution.id, 'dropboxbusiness')
+        nt.assert_false(option.is_allowed)
+
+        # option retrieved from database
+        option = utils.get_rdm_addon_option(self.institution.id, 's3', create=False)
+        nt.assert_true(option.is_allowed)
+
+        option = utils.get_rdm_addon_option(self.institution.id, 'dropboxbusiness', create=False)
+        nt.assert_false(option.is_allowed)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

GRDM-42507で発見した問題を修正します。

- 機関ストレージ制御用RdmAddonOptionのis_allowedの初期値がオブジェクト作成直後にtrueとなる 問題の修正
- IQB-RIMSが処理対象とすべきでないRdmAddonOption, Nodeに対して処理をしている  問題の修正

## Changes

- 機関ストレージ制御用RdmAddonOptionのis_allowedの初期値がオブジェクト作成直後にtrueとなる 問題の修正及びユニットテストの追加
- IQB-RIMSが処理対象とすべきでないpost_saveイベントに対して処理をしている  問題の修正及びユニットテストの追加

  - RdmAddonOptionに対する変更検知 - その他のアドオンに関する変更検知を無視するように修正
  - Nodeに対する変更検知 - folder_idがNoneであるが認証情報が設定されているNodeに対する変更検知を無視するように修正

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-42507