### PR TITLE
Workaround for CERTIFICATE_VERIFY_FAILED at python:3.6.3 on TravisCI (RCOS環境)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ install:
     - cp api/base/settings/local-travis.py api/base/settings/local.py
     - '[ -d $HOME/preprints ] || ( mkdir -p $HOME/preprints && touch $HOME/preprints/index.html )'
 
-    - travis_retry pip install --upgrade pip
+    - travis_retry pip install --upgrade pip --trusted-host pypi.python.org
     - travis_retry pip install invoke==0.13.0
     - travis_retry pip install flake8==2.4.0 --force-reinstall --upgrade
     - travis_retry invoke wheelhouse --dev --addons


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

[Workaround for CERTIFICATE_VERIFY_FAILED at python:3.6.3 on TravisCI](https://github.com/RCOSDP/RDM-osf.io/commit/96021e23ae267b08b9b7b839bb400c4cc469ed4b) をrcos-releaseにも反映する

## Changes

[Workaround for CERTIFICATE_VERIFY_FAILED at python:3.6.3 on TravisCI](https://github.com/RCOSDP/RDM-osf.io/commit/96021e23ae267b08b9b7b839bb400c4cc469ed4b) をrcos-releaseにも反映しました。
rcos-releaseに他のdevelopブランチを取り込んで混乱しないようにするため、cherry-pickとしてあります。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

None
