### PR TITLE
Fix process of rebuilding query, to fix TypeError at urlunparse when …

### DIFF
--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -3,7 +3,7 @@
 import furl
 from rest_framework import status as http_status
 import json
-from future.moves.urllib.parse import quote, urlparse, parse_qs, urlunparse
+from future.moves.urllib.parse import quote, urlparse, parse_qs, urlunparse, urlencode
 
 from lxml import etree
 import requests
@@ -260,7 +260,8 @@ def make_response_from_ticket(ticket, service_url):
     if 'ticket' in querys:
         querys.pop('ticket')
     client = get_client()
-    re_service_url = urlunparse(parsed_url._replace(query=querys))
+    re_query = urlencode(querys, True)
+    re_service_url = urlunparse(parsed_url._replace(query=re_query))
     cas_resp = client.service_validate(ticket, re_service_url)
     if cas_resp.authenticated:
         user, external_credential, action = get_user_from_cas_resp(cas_resp)

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -124,7 +124,8 @@ def before_request():
         parsed_url = urlparse(request.url)
         querys = parse_qs(parsed_url.query)
         querys.pop('ticket')
-        service_url = urlunparse(parsed_url._replace(query=querys))
+        re_query = urlencode(querys, True)
+        service_url = urlunparse(parsed_url._replace(query=re_query))
         # Attempt to authenticate wih CAS, and return a proper redirect response
         return cas.make_response_from_ticket(ticket=ticket, service_url=service_url)
 


### PR DESCRIPTION
…URL contains queries other than 'ticket'

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix process of rebuilding query, to fix TypeError at urlunparse when URL contains queries other than 'ticket'
<!-- Describe the purpose of your changes -->

## Changes
Fix process of rebuilding query, to fix TypeError at urlunparse when URL contains queries other than 'ticket'
<!-- Briefly describe or list your changes  -->

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
  - What is the level of risk?
    - Any permissions code touched?
    - Is this an additive or subtractive change, other?
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
  - How will this impact performance?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
GRDM-37502
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
