### PR TITLE
マイプロジェクトページのユーザ体験を向上施策

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -51,7 +51,10 @@ class OptimaizedPagination(pagination.PageNumberPagination):
             self.display_page_controls = True
 
         self.request = request
-        return self.page.object_list.iterator()
+        if hasattr(self.page.object_list, 'iterator'):
+            return self.page.object_list.iterator()
+        else:
+            return iter(self.page.object_list)
 
 class JSONAPIPagination(OptimaizedPagination):
     """

--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -53,7 +53,7 @@ class OptimaizedPagination(pagination.PageNumberPagination):
         self.request = request
         return self.page.object_list.iterator()
 
-class JSONAPIPagination(pagination.PageNumberPagination):
+class JSONAPIPagination(OptimaizedPagination):
     """
     Custom paginator that formats responses in a JSON-API compatible format.
 

--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -17,6 +17,38 @@ from api.base.utils import absolute_reverse
 from osf.models import AbstractNode, Comment, Preprint, Guid, DraftRegistration
 from website.search.elastic_search import DOC_TYPE_TO_MODEL
 
+class OptimaizedPagination(pagination.PageNumberPagination):
+    """
+    A pagination class that optimizes for the number of queries.
+    """
+    def paginate_queryset(self, queryset, request, view=None):
+        """
+        Paginate a queryset if required, either returning a
+        page object, or `None` if pagination is not configured for this view.
+        """
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return None
+
+        paginator = self.django_paginator_class(queryset, page_size)
+        page_number = request.query_params.get(self.page_query_param, 1)
+        if page_number in self.last_page_strings:
+            page_number = paginator.num_pages
+
+        try:
+            self.page = paginator.page(page_number)
+        except InvalidPage as exc:
+            msg = self.invalid_page_message.format(
+                page_number=page_number, message=six.text_type(exc)
+            )
+            raise NotFound(msg)
+
+        if paginator.num_pages > 1 and self.template is not None:
+            # The browsable API should display pagination controls.
+            self.display_page_controls = True
+
+        self.request = request
+        return self.page.object_list.iterator()
 
 class JSONAPIPagination(pagination.PageNumberPagination):
     """

--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -17,6 +17,9 @@ from api.base.utils import absolute_reverse
 from osf.models import AbstractNode, Comment, Preprint, Guid, DraftRegistration
 from website.search.elastic_search import DOC_TYPE_TO_MODEL
 
+"""
+https://github.com/RCOSDP/RDM-osf.io/pull/505
+"""
 class OptimaizedPagination(pagination.PageNumberPagination):
     """
     A pagination class that optimizes for the number of queries.
@@ -39,7 +42,7 @@ class OptimaizedPagination(pagination.PageNumberPagination):
             self.page = paginator.page(page_number)
         except InvalidPage as exc:
             msg = self.invalid_page_message.format(
-                page_number=page_number, message=six.text_type(exc)
+                page_number=page_number, message=six.text_type(exc),
             )
             raise NotFound(msg)
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -79,11 +79,6 @@ class JSONAPIBaseView(generics.GenericAPIView):
 
             request.parents.setdefault(type(item), {})[item._id] = item
 
-            """
-            https://github.com/RCOSDP/RDM-osf.io/pull/505
-            """
-            view_kwargs_tuple = tuple(value for key, value in view_kwargs.items())
-
             view_kwargs.update({
                 'request': request,
                 'is_embedded': True,
@@ -100,23 +95,13 @@ class JSONAPIBaseView(generics.GenericAPIView):
 
             if not isinstance(view, ListModelMixin):
                 try:
-                    """
-                    https://github.com/RCOSDP/RDM-osf.io/pull/505
-                    """
-                    _cache_key = (v.cls, view.get_serializer_class(), view_kwargs_tuple)
-                    if _cache_key in cache:
-                        # We already have the result for this embed, return it
-                        item = cache[_cache_key]
-                    else:
-                        item = view.get_object()
-                        cache[_cache_key] = item
+                    item = view.get_object()
                 except Exception as e:
                     with transaction.atomic():
                         ret = view.handle_exception(e).data
                     return ret
 
-            _cache_key = (v.cls, view.get_serializer_class(), (type(item), item.id))
-
+            _cache_key = (v.cls, field_name, view.get_serializer_class(), (type(item), item.id))
             if _cache_key in cache:
                 # We already have the result for this embed, return it
                 return cache[_cache_key]

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -97,8 +97,9 @@ class JSONAPIBaseView(generics.GenericAPIView):
 
             if not isinstance(view, ListModelMixin):
                 try:
-                    _cache_key = (v.cls, field_name, view.get_serializer_class(),view_kwargs_tuple)
+                    _cache_key = (v.cls, view.get_serializer_class(),view_kwargs_tuple)
                     if _cache_key in cache:
+                        # We already have the result for this embed, return it
                         item = cache[_cache_key]
                     else:
                         item = view.get_object()
@@ -108,7 +109,8 @@ class JSONAPIBaseView(generics.GenericAPIView):
                         ret = view.handle_exception(e).data
                     return ret
 
-            _cache_key = (v.cls, field_name, view.get_serializer_class(), (type(item), item.id))
+            _cache_key = (v.cls, view.get_serializer_class(), (type(item), item.id))
+
             if _cache_key in cache:
                 # We already have the result for this embed, return it
                 return cache[_cache_key]

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -97,7 +97,7 @@ class JSONAPIBaseView(generics.GenericAPIView):
 
             if not isinstance(view, ListModelMixin):
                 try:
-                    _cache_key = (v.cls, view.get_serializer_class(),view_kwargs_tuple)
+                    _cache_key = (v.cls, view.get_serializer_class(), view_kwargs_tuple)
                     if _cache_key in cache:
                         # We already have the result for this embed, return it
                         item = cache[_cache_key]

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -79,6 +79,9 @@ class JSONAPIBaseView(generics.GenericAPIView):
 
             request.parents.setdefault(type(item), {})[item._id] = item
 
+            """
+            https://github.com/RCOSDP/RDM-osf.io/pull/505
+            """
             view_kwargs_tuple = tuple(value for key, value in view_kwargs.items())
 
             view_kwargs.update({
@@ -97,6 +100,9 @@ class JSONAPIBaseView(generics.GenericAPIView):
 
             if not isinstance(view, ListModelMixin):
                 try:
+                    """
+                    https://github.com/RCOSDP/RDM-osf.io/pull/505
+                    """
                     _cache_key = (v.cls, view.get_serializer_class(), view_kwargs_tuple)
                     if _cache_key in cache:
                         # We already have the result for this embed, return it

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -333,7 +333,7 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, UserNodesFilte
         return (
             self.get_queryset_from_request()
             .select_related('node_license')
-            .include('contributor__user__guids', 'root__guids', limit_includes=10)
+            .include('root__guids', limit_includes=10)
         )
 
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -333,6 +333,9 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, UserNodesFilte
         return (
             self.get_queryset_from_request()
             .select_related('node_license')
+            """
+            https://github.com/RCOSDP/RDM-osf.io/pull/505
+            """
             .include('root__guids', limit_includes=10)
         )
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -329,13 +329,13 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, UserNodesFilte
         return self.optimize_node_queryset(default_queryset)
 
     # overrides ListAPIView
+    """
+    https://github.com/RCOSDP/RDM-osf.io/pull/505
+    """
     def get_queryset(self):
         return (
             self.get_queryset_from_request()
             .select_related('node_license')
-            """
-            https://github.com/RCOSDP/RDM-osf.io/pull/505
-            """
             .include('root__guids', limit_includes=10)
         )
 


### PR DESCRIPTION
## Purpose

OSFの上部のメニューにある「マイプロジェクト」を開いたときに５００ユーザがプロジェクトに所属しているとembed属性を取得するSQLが都度発行されるので
リクエスト内で一度取得した情報はキャッシュして再利用することで、レスポンスの高速化を図る
子要素毎に新しいビューを作成するリレーショナルフィールドでシリアル化プロセス全体で再起的な入れ子が発生するので改善する

## Changes

キャッシュの導入:
プロジェクトのコントリビュータデータの取得結果をキャッシュする
同じデータの再取得を避けることで、API呼び出しの数を削減

ページネーションの改善:
OptimizedPagination クラスを追加しページオブジェクトやページ数を確認後に、オブジェクトリストを非同期的に取得する
ページネーションの計算でクエリの処理を明確にしてデータを効率的に取得する


## QA Notes


## Documentation

施策前のnodeの実行時間は7秒前後
<img width="1504" alt="before myproject" src="https://github.com/user-attachments/assets/8df2a005-6a52-4145-a749-37cdb1852150">

施策後のnodeの実行時間は１秒ほど

<img width="1281" alt="after step2" src="https://github.com/user-attachments/assets/0fc228b5-f05f-4e8c-ad62-c52a14ac6953">

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/44093
