### PR TITLE
officeファイルの編集機能(ONLYOFFICE連携)およびファイル新規作成機能の追加

### DIFF
--- a/addons/onlyoffice/proof_key.py
+++ b/addons/onlyoffice/proof_key.py
@@ -12,7 +12,35 @@ from datetime import datetime, timezone
 import logging
 logger = logging.getLogger(__name__)
 
-__author__ = 'Tyler Butler <tyler.butler@microsoft.com>'
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+"""
+This code is taken from the following URL and modified.
+https://github.com/microsoft/Office-Online-Test-Tools-and-Documentation/blob/master/samples/python/proof_keys/__init__.py
+"""
 
 ProofKeyDiscoveryData = namedtuple('ProofKeyDiscoveryData',
                                    ('value', 'modulus', 'exponent', 'oldvalue', 'oldmodulus', 'oldexponent'))

--- a/addons/onlyoffice/views.py
+++ b/addons/onlyoffice/views.py
@@ -216,7 +216,7 @@ def onlyoffice_edit_by_onlyoffice(**kwargs):
         # logger.info('edit_by_onlyoffice.index_view wopi_src = {}'.format(wopi_src))
         wopi_url = wopi_client_url \
             + 'rs=ja-jp&ui=ja-jp'  \
-            + '&wopisrc=' + wopi_src
+            + '&WOPISrc=' + wopi_src
 
     # logger.info('edit_by_online.index_view wopi_url = {}'.format(wopi_url))
 

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -567,7 +567,7 @@ var FileViewPage = {
                 }}, _('Revisions'))
             ]),
             (
-                window.contextVars.wopi.onlyoffice_url && ctrl.file.name.match(editExtensions) && ctrl.isLatestVersion
+                window.contextVars.wopi.onlyoffice_url && ctrl.file.name.match(editExtensions) && ctrl.isLatestVersion && ctrl.canEdit()
             ) ? m('.btn-group.m-t-xs', [
                     m('a.btn.btn-sm.btn-default.file-edit', {href: 'editonlyoffice/' + ctrl.file.id, target: '_blank'}, _('Edit(ONLYOFFICE)'))
             ]) : ''


### PR DESCRIPTION
## Purpose

 - 他から引用してきたコードへのCopyright 表示の追加
 - HTTP query パラメータ名の変更
 - 書き込み権限のないプロジェクト配下のファイルに対して、編集ボタンを表示しないように変更

## Changes

 - Copyright 表示の追加　　addons/onlyoffice/proof_key.py
 - HTTP query パラメータ名の変更　　addons/onlyoffice/views.py
 - 編集ボタンを隠す処理追加　　website/static/js/filepage/index.js

## QA Notes

  - none

## Documentation

 - none

## Side Effects

 - none

## Ticket

 - none