### PR TITLE
[GRDM-43834] メタデータのスキーマ・補完の強化他

### DIFF
--- a/addons/metadata/migrations/0008_add_metadata_asset_pool.py
+++ b/addons/metadata/migrations/0008_add_metadata_asset_pool.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import django_extensions.db.fields
+import osf.models.base
+import osf.utils.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('addons_metadata', '0007_user_to_file_metadata'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MetadataAssetPool',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, verbose_name='created')),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified')),
+                ('project', models.ForeignKey(blank=True, null=True,
+                                              on_delete=django.db.models.deletion.CASCADE,
+                                              related_name='metadata_asset_pool', to='addons_metadata.NodeSettings')),
+                ('path', models.TextField()),
+                ('metadata', models.TextField(blank=True, null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model, osf.models.base.QuerySetExplainMixin),
+        ),
+    ]

--- a/addons/metadata/migrations/0008_add_unique_file_metadata.py
+++ b/addons/metadata/migrations/0008_add_unique_file_metadata.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+
+from django.db import connection, migrations
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_unique_project_id_path(*args):
+    from addons.metadata.models import FileMetadata
+    # Deletes the newest from each set of FileMetadata
+    sql = """
+    SELECT f.id
+    FROM addons_metadata_filemetadata f
+    INNER JOIN (
+      SELECT project_id, path, MAX(modified) as max_modified
+      FROM addons_metadata_filemetadata
+      GROUP BY project_id, path
+    ) AS max_dates ON f.path = max_dates.path and f.project_id = max_dates.project_id
+    WHERE f.modified < max_dates.max_modified;
+    """
+    # It is possible that new duplicate data will be created during migration in the old service instance,
+    # in which case migration should fail, so have the migration run again.
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+        ids = list(sum(cursor.fetchall(), ()))
+        logger.info('Deleting duplicate FileMetadata ids: {}'.format(ids))
+        FileMetadata.objects.filter(id__in=ids).delete()
+        logger.info('Deleted.')
+
+
+def noop(*args):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('addons_metadata', '0007_user_to_file_metadata'),
+    ]
+
+    operations = [
+        migrations.RunPython(ensure_unique_project_id_path, noop),
+        migrations.AlterUniqueTogether(
+            name='filemetadata',
+            unique_together=set([('project_id', 'path')]),
+        ),
+    ]

--- a/addons/metadata/models.py
+++ b/addons/metadata/models.py
@@ -308,7 +308,7 @@ class NodeSettings(BaseNodeSettings):
                 }
                 self.set_file_metadata(dest_path_child, file_metadata, auth)
             if action in [NodeLog.FILE_RENAMED, NodeLog.FILE_MOVED, NodeLog.FILE_REMOVED]:
-                self.delete_file_metadata(src_path_child, auth)
+                source_addon.delete_file_metadata(src_path_child, auth)
 
     def get_metadata_assets(self):
         return [

--- a/addons/metadata/models.py
+++ b/addons/metadata/models.py
@@ -454,10 +454,10 @@ class FileMetadata(BaseModel):
     def load(cls, project_id, path, select_for_update=False):
         try:
             if select_for_update:
-                return cls.objects.filter(project__id=project_id, path=path, deleted__is_null=True) \
+                return cls.objects.filter(project__id=project_id, path=path, deleted__isnull=True) \
                     .select_for_update().get()
             else:
-                return cls.objects.get(project__id=project_id, path=path, deleted__is_null=True)
+                return cls.objects.get(project__id=project_id, path=path, deleted__isnull=True)
         except cls.DoesNotExist:
             return None
 

--- a/addons/metadata/search.py
+++ b/addons/metadata/search.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 
@@ -20,6 +21,11 @@ def _extract_metadata_text(file_metadata):
             continue
         for value in item['data'].values():
             if 'value' not in value:
+                continue
+            if value['value'] is None:
+                continue
+            if isinstance(value['value'], list) or isinstance(value['value'], dict):
+                text.append(json.dumps(value['value']))
                 continue
             text.append(value['value'])
     return ' '.join(text)

--- a/addons/metadata/settings/defaults.py
+++ b/addons/metadata/settings/defaults.py
@@ -1,3 +1,10 @@
 """
 Metadata addon default settings
 """
+USE_EXPORTING = False
+
+# Maximum size of files that can be exported ... 1GB
+MAX_EXPORTABLE_FILES_BYTES = 1024 * 1024 * 1024
+
+METADATA_ASSET_POOL_BASE_PATH = '.metadata'
+METADATA_ASSET_POOL_MAX_FILESIZE = 1024 * 1024 * 10  # 10MB

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -1538,7 +1538,7 @@ function MetadataButtons() {
                 }
                 const fromFilepath = from.data.provider + (from.data.materialized || '/');
                 const projectMetadata = context.projectMetadata;
-                const fromFilepaths = projectMetadata.files
+                var fromFilepaths = projectMetadata.files
                   .map(function(f) { return f.path; })
                   .filter(function(p) {
                     return p.substring(0, fromFilepath.length) === fromFilepath;
@@ -1547,7 +1547,7 @@ function MetadataButtons() {
                   return;
                 }
                 const toFilepath = item.data.provider + (item.data.materialized || '/');
-                const toFilepaths = fromFilepaths
+                var toFilepaths = fromFilepaths
                   .map(function(p) {
                     return toFilepath + p.replace(fromFilepath, '');
                   });
@@ -1561,8 +1561,8 @@ function MetadataButtons() {
                   console.log(logPrefix, 'fromNodeId is null');
                   return;
                 }
-                const toContext = self.findContextByNodeId(toNodeId);
-                const fromContext = self.findContextByNodeId(fromNodeId);
+                var toContext = self.findContextByNodeId(toNodeId);
+                var fromContext = self.findContextByNodeId(fromNodeId);
                 if (!toContext) {
                   console.log(logPrefix, 'toContext is null');
                   return;

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -10,7 +10,7 @@ const logPrefix = '[metadata] ';
 const rdmGettext = require('js/rdmGettext');
 const _ = rdmGettext._;
 
-const metadataFields = require('./metadata-fields.js');
+const QuestionPage = require('./metadata-fields.js').QuestionPage;
 const WaterButlerCache = require('./wbcache.js').WaterButlerCache;
 const registrations = require('./registration.js');
 const RegistrationSchemas = registrations.RegistrationSchemas;
@@ -33,75 +33,12 @@ const osfBlock = {
 
 const METADATA_CACHE_EXPIRATION_MSEC = 1000 * 60 * 5;
 
-
-function ERad() {
-  var self = this;
-
-  self.candidates = null;
-
-  self.load = function(baseUrl, callback) {
-    var url = baseUrl + 'erad/candidates';
-    console.log(logPrefix, 'loading: ', url);
-
-    return $.ajax({
-        url: url,
-        type: 'GET',
-        dataType: 'json'
-    }).done(function (data) {
-      console.log(logPrefix, 'loaded: ', data);
-      self.candidates = ((data.data || {}).attributes || {}).records;
-      callback();
-    }).fail(function(xhr, status, error) {
-      $osf.growl('Error', 'Error while retrieving erad candidates: ' + xhr.status);
-      Raven.captureMessage('Error while retrieving erad candidates', {
-          extra: {
-              url: url,
-              status: status,
-              error: error
-          }
-      });
-      callback();
-    });
-  };
-}
-
-function FileMetadataSuggestion(baseUrl) {
-  var self = this;
-
-  self.suggest = function(filepath, format) {
-    var url = baseUrl + 'file_metadata/suggestions/' + encodeURI(filepath);
-    return $.ajax({
-      url: url,
-      type: 'GET',
-      dataType: 'json',
-      data: {
-        format: format
-      }
-    }).catch(function(xhr, status, error) {
-      $osf.growl('Error', 'Error while retrieving file metadata suggestions: ' + xhr.status);
-      Raven.captureMessage('Error while retrieving file metadata suggestions', {
-        extra: {
-          url: url,
-          status: status,
-          error: error
-        }
-      });
-      return Promise.reject({xhr: xhr, status: status, error: error});
-    }).then(function (data) {
-      console.log(logPrefix, 'suggestion: ', data);
-      return ((data.data || {}).attributes || {}).suggestions || [];
-    });
-  };
-}
-
 function MetadataButtons() {
   var self = this;
   self.baseUrl = contextVars.node.urls.api + 'metadata/';
   self.loading = null;
   self.contexts = null;
   self.loadingMetadatas = {};
-  self.erad = new ERad();
-  self.fileMetadataSuggestion = new FileMetadataSuggestion(self.baseUrl);
   self.currentItem = null;
   self.registrationSchemas = new RegistrationSchemas();
   self.draftRegistrations = new DraftRegistrations();
@@ -124,11 +61,7 @@ function MetadataButtons() {
       callback(path);
     };
     self.registrationSchemas.load(function() {
-      self.loadMetadata(contextVars.node.id, contextVars.node.urls.api + 'metadata/', function(projectMetadata) {
-        if (projectMetadata && projectMetadata.editable) {
-          self.erad.load(self.baseUrl, loadedCallback);
-          return;
-        }
+      self.loadMetadata(contextVars.node.id, contextVars.node.urls.api + 'metadata/', function() {
         loadedCallback();
       });
     });
@@ -232,68 +165,16 @@ function MetadataButtons() {
     });
   };
 
+  self.lastQuestionPage = null;
   self.lastMetadata = null;
   self.lastFields = null;
   self.currentSchemaId = null;
 
-  self.createFields = function(schema, item, options, callback) {
-    const fields = [];
-    const itemData = options.multiple ? {} : item.data || {};
-    (schema.pages || []).forEach(function(page) {
-      (page.questions || []).forEach(function(question) {
-        if (!question.qid || !question.qid.match(/^grdm-file:.+/)) {
-          return;
-        }
-        const value = itemData[question.qid];
-        const field = metadataFields.createField(
-          self.erad,
-          self.fileMetadataSuggestion,
-          question,
-          value,
-          options,
-          callback
-        );
-        fields.push({ field: field, question: question });
-      });
-    });
-    return fields;
+  self.createQuestionPage = function(schema, item, options) {
+    const questionPage = new QuestionPage(schema, item, options);
+    questionPage.create();
+    return questionPage;
   };
-
-  self.fieldsChanged = function(event, options) {
-    if (!self.lastFields) {
-      return;
-    }
-    const fieldSetsAndValues = [];
-    self.lastFields.forEach(function(fieldSet) {
-      const value = fieldSet.field.getValue(fieldSet.input);
-      fieldSetsAndValues.push({ fieldSet: fieldSet, value: value });
-    });
-    fieldSetsAndValues.forEach(function(fieldSetAndValue) {
-      const fieldSet = fieldSetAndValue.fieldSet;
-      const value = fieldSetAndValue.value;
-      var error = null;
-      try {
-        metadataFields.validateField(
-          self.erad,
-          fieldSet.question,
-          value,
-          fieldSetsAndValues,
-          options
-        );
-      } catch(e) {
-        error = e.message;
-      }
-      if (fieldSet.lastError == error) {
-        return;
-      }
-      fieldSet.lastError = error;
-      if (error) {
-        fieldSet.errorContainer.text(error).show()
-      } else {
-        fieldSet.errorContainer.hide().text('')
-      }
-    });
-  }
 
   self.prepareFields = function(context, container, schema, filepath, fileitem, options) {
     var lastMetadataItem = {};
@@ -303,8 +184,7 @@ function MetadataButtons() {
         return resolved === schema.id;
       })[0] || {};
     }
-    container.empty();
-    const fields = self.createFields(
+    self.lastQuestionPage = self.createQuestionPage(
       schema.attributes.schema,
       lastMetadataItem,
       {
@@ -314,23 +194,14 @@ function MetadataButtons() {
         filepath: filepath,
         wbcache: context.wbcache,
         fileitem: fileitem
-      },
-      self.fieldsChanged
+      }
     );
-    self.lastFields = [];
-    fields.forEach(function(fieldSet) {
-      const errorContainer = $('<div></div>')
-        .css('color', 'red').hide();
-      const input = fieldSet.field.addElementTo(container, errorContainer);
-      self.lastFields.push({
-        field: fieldSet.field,
-        question: fieldSet.question,
-        input: input,
-        lastError: null,
-        errorContainer: errorContainer
-      });
+    self.lastFields = self.lastQuestionPage.fields;
+    container.empty();
+    self.lastFields.forEach(function(field) {
+      container.append(field.element);
     });
-    self.fieldsChanged(null, options);
+    self.lastQuestionPage.validateAll();
   }
 
   self.findSchemaById = function(schemaId) {
@@ -624,8 +495,8 @@ function MetadataButtons() {
       });
     }
     var jsonObject = {};
-    (self.lastFields || []).forEach(function(fieldSet) {
-      jsonObject[fieldSet.question.qid] = fieldSet.field.getValue(fieldSet.input);
+    (self.lastFields || []).forEach(function(field) {
+      jsonObject[field.question.qid] = field.getValue();
     });
     const text = JSON.stringify(jsonObject);
     navigator.clipboard.writeText(text).then(function() {
@@ -668,8 +539,8 @@ function MetadataButtons() {
   self.setMetadataFromJson = function(jsonText) {
     try {
       const jsonObject = JSON.parse(jsonText);
-      (self.lastFields || []).forEach(function(fieldSet) {
-        fieldSet.field.setValue(fieldSet.input, jsonObject[fieldSet.question.qid] || '');
+      (self.lastFields || []).forEach(function(field) {
+        field.setValue(jsonObject[field.question.qid] || '');
       });
     } catch(err) {
       $osf.growl('Error', _('Could not paste text'));
@@ -1021,65 +892,31 @@ function MetadataButtons() {
   };
 
   self.prepareReviewFields = function(container, draftSelectionContainer, schema, metadataItem) {
-    const fields = self.createFields(
+    self.lastQuestionPage = self.createQuestionPage(
       schema.attributes.schema,
       metadataItem,
       {
         readonly: true,
       }
     );
+    self.lastFields = self.lastQuestionPage.fields;
     container.empty();
-    var errors = 0;
-    self.lastFields = [];
-    const fieldSetsAndValues = [];
-    fields.forEach(function(fieldSet) {
-      const errorContainer = $('<div></div>')
-        .css('color', 'red').hide();
-      const input = fieldSet.field.addElementTo(container, errorContainer);
-      const value = fieldSet.field.getValue(input);
-      fieldSetsAndValues.push({
-        fieldSet: {
-          field: fieldSet.field,
-          question: fieldSet.question,
-          input: input,
-          lastError: null,
-          errorContainer: errorContainer
-        },
-        value: value
-      });
+    self.lastFields.forEach(function(field) {
+      container.append(field.element);
     });
-    fieldSetsAndValues.forEach(function(fieldSetAndValue) {
-      const fieldSet = fieldSetAndValue.fieldSet;
-      const value = fieldSetAndValue.value;
-      var error = null;
-      try {
-        metadataFields.validateField(
-          self.erad,
-          fieldSet.question,
-          value,
-          fieldSetsAndValues
-        );
-      } catch(e) {
-        error = e.message;
-      }
-      if (error) {
-        fieldSet.errorContainer.text(error).show()
-        errors ++;
-      } else {
-        fieldSet.errorContainer.hide().text('')
-      }
-      self.lastFields.push(fieldSet);
-    });
+    self.lastQuestionPage.validateAll();
     const message = $('<div></div>');
-    if (errors) {
+    if (self.lastQuestionPage.hasValidationError) {
       message.text(_('There are errors in some fields.')).css('color', 'red');
     }
     if (self.selectDraftDialog) {
-      self.selectDraftDialog.select.attr('disabled', errors > 0);
+      self.selectDraftDialog.select.attr('disabled', self.lastQuestionPage.hasValidationError);
     }
     draftSelectionContainer.empty();
     draftSelectionContainer.append(message);
-    draftSelectionContainer.append(self.createDraftsSelect(schema, errors > 0).css('margin', '1em 0'));
+    draftSelectionContainer.append(
+      self.createDraftsSelect(schema, self.lastQuestionPage.hasValidationError).css('margin', '1em 0')
+    );
   };
 
   self.openDraftModal = function(currentMetadata) {
@@ -1542,9 +1379,73 @@ function MetadataButtons() {
     const observer = new MutationObserver(refreshIfToolbarExists);
     const toggleBar = $('#toggleBar').get(0);
     observer.observe(toggleBar, {attributes: false, childList: true, subtree: false});
+
+    function resolveRows(items) {
+      if (items.length === 0) {
+        return;
+      }
+      const remains = items.filter(function(item) {
+        const text = $('.td-title.tb-td[data-id="' + item.id + '"] .title-text');
+        if (text.length === 0) {
+          return true;
+        }
+        const context = self.findContextByNodeId(item.data.nodeId);
+        if (!context) {
+          self.loadMetadata(item.data.nodeId, item.data.nodeApiUrl + 'metadata/');
+          return true;
+        }
+        if (!item.data.materialized) {
+          context.wbcache.setProvider(item);
+        }
+        return false;
+      });
+      if (remains.length === 0) {
+        return;
+      }
+      setTimeout(function() {
+        resolveRows(remains);
+      }, 1000);
+    }
+
     self.initBase(function(p) {
       path = p;
       refreshIfToolbarExists();
+      resolveRows(self.reservedRows);
+    });
+
+    Fangorn.config = new Proxy(Fangorn.config, {
+      get: function(targetprov, name) {
+        var obj = targetprov[name];
+        if (obj === undefined) {
+          obj = {};
+        }
+        return new Proxy(obj, {
+          get: function(target, propname) {
+            if (propname == 'resolveRows') {
+              return function(item) {
+                var base = null;
+                if (target[propname] !== undefined) {
+                  const prop = target[propname];
+                  const baseRows = typeof prop === 'function' ? prop.apply(this, [item]) : prop;
+                  if (baseRows !== undefined) {
+                    base = baseRows;
+                  }
+                }
+                if (self.contexts) {
+                  setTimeout(function() {
+                    resolveRows([item]);
+                  }, 500);
+                } else {
+                  self.reservedRows.push(item);
+                }
+                return base;
+              };
+            } else {
+              return target[propname];
+            }
+          }
+        });
+      }
     });
   }
 
@@ -1710,10 +1611,10 @@ function MetadataButtons() {
         data: {},
       };
       self.lastFields.forEach(function(field) {
-        metacontent.data[field.field.label] = {
+        metacontent.data[field.question.qid] = {
           extra: [],
           comments: [],
-          value: field.field.getValue(field.input)
+          value: field.getValue()
         };
       });
       metadata.items.unshift(metacontent);
@@ -1797,12 +1698,13 @@ function MetadataButtons() {
           data: Object.assign({}, oldMetacontent.data),
         };
         self.lastFields.forEach(function(field) {
-          const value = field.field.getValue(field.input);
-          const clear = field.field.checkedClear && field.field.checkedClear();
+          const value = field.getValue();
+          const clear = field.checkedClear();
+          const qid = field.question.qid;
           if (clear) {
-            delete metacontent.data[field.field.label];
+            delete metacontent.data[qid];
           } else if (value) {
-            metacontent.data[field.field.label] = {
+            metacontent.data[qid] = {
               extra: [],
               comments: [],
               value: value

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -542,6 +542,9 @@ function MetadataButtons() {
       (self.lastFields || []).forEach(function(field) {
         field.setValue(jsonObject[field.question.qid] || '');
       });
+      if (self.lastQuestionPage) {
+        self.lastQuestionPage.validateAll();
+      }
     } catch(err) {
       console.error(logPrefix, 'Could not paste text', err);
       $osf.growl('Error', _('Could not paste text'));
@@ -1267,6 +1270,8 @@ function MetadataButtons() {
           .addClass('metadata-indicator')
           .css('margin-left', '1em');
         text.append(indicator);
+      } else {
+        indicator.empty();
       }
       const filepath = item.data.provider + (item.data.materialized || '/');
       const metadata = self.findMetadataByPath(context.nodeId, filepath);
@@ -1283,7 +1288,6 @@ function MetadataButtons() {
         return false;
       }
       if (metadata) {
-        indicator.empty();
         indicator.append($('<span></span>')
           .text('{}')
           .css('font-weight', 'bold')
@@ -1291,7 +1295,6 @@ function MetadataButtons() {
           .attr('title', _('Metadata is defined')));
         self.setValidatedFile(context, filepath, item, metadata);
       } else {
-        indicator.empty();
         indicator.append($('<span></span>')
           .text('{}')
           .css('font-weight', 'bold')
@@ -1548,26 +1551,62 @@ function MetadataButtons() {
                   .map(function(p) {
                     return toFilepath + p.replace(fromFilepath, '');
                   });
+                const toNodeId = item.data ? item.data.nodeId : null;
+                const fromNodeId = from.data ? from.data.nodeId : null;
+                if (!toNodeId) {
+                  console.log(logPrefix, 'toNodeId is null');
+                  return;
+                }
+                if (!fromNodeId) {
+                  console.log(logPrefix, 'fromNodeId is null');
+                  return;
+                }
+                const toContext = self.findContextByNodeId(toNodeId);
+                const fromContext = self.findContextByNodeId(fromNodeId);
+                if (!toContext) {
+                  console.log(logPrefix, 'toContext is null');
+                  return;
+                }
+                if (!fromContext) {
+                  console.log(logPrefix, 'fromContext is null');
+                  return;
+                }
                 // try reload project metadata
                 const interval = 250;
                 const maxRetry = 10;
+                const intervalIncrease = 250;
                 var retry = 0;
                 function tryLoadMetadata() {
-                  self.loadMetadata(context.nodeId, context.baseUrl, function() {
-                    const context2 = self.findContextByNodeId(context.nodeId);
+                  // Retrieve metadata for the destination project
+                  self.loadMetadata(toContext.nodeId, toContext.baseUrl, function() {
+                    const toProjectMetadata = self.findProjectMetadataByNodeId(toContext.nodeId);
                     const matches = toFilepaths
                       .map(function(p) {
-                        return context2.projectMetadata.files.find(function(f) { return f.path === p; });
+                        return toProjectMetadata.files.find(function(f) { return f.path === p; });
                       });
                     const unmatchCount = matches.filter(function(m) { return !m; }).length;
                     console.log(logPrefix, 'reloaded metadata: ', {
-                      context: context2,
+                      context: toContext,
                       unmatchCount: unmatchCount,
                       expectedFilepaths: toFilepaths
                     });
                     if (!unmatchCount) {
-                      context2.wbcache.clearCache();
-                      m.redraw();
+                      // Retrieve metadata for the source project
+                      self.loadMetadata(fromContext.nodeId, fromContext.baseUrl, function() {
+                        const fromProjectMetadata = self.findProjectMetadataByNodeId(fromContext.nodeId);
+                        const matches = fromFilepaths
+                          .map(function(p) {
+                            return fromProjectMetadata.files.find(function(f) { return f.path === p; });
+                          });
+                        const matchCount = matches.filter(function(m) { return m; }).length;
+                        console.log(logPrefix, 'reloaded metadata: ', {
+                          context: fromContext,
+                          matchCount: matchCount,
+                          expectedFilepaths: fromFilepaths
+                        });
+                        toContext.wbcache.clearCache();
+                        m.redraw();
+                      });
                       return;
                     }
                     retry += 1;
@@ -1576,7 +1615,7 @@ function MetadataButtons() {
                       return;
                     }
                     console.log(logPrefix, retry + 'th retry reload metadata after ' + interval + 'ms: ');
-                    setTimeout(tryLoadMetadata, interval);
+                    setTimeout(tryLoadMetadata, interval + retry * intervalIncrease);
                   });
                 }
                 setTimeout(tryLoadMetadata, interval);

--- a/addons/metadata/static/files.js
+++ b/addons/metadata/static/files.js
@@ -543,6 +543,7 @@ function MetadataButtons() {
         field.setValue(jsonObject[field.question.qid] || '');
       });
     } catch(err) {
+      console.error(logPrefix, 'Could not paste text', err);
       $osf.growl('Error', _('Could not paste text'));
       Raven.captureMessage(_('Could not paste text'), {
         extra: {

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -434,6 +434,10 @@ const TextFormField = oop.extend(FormFieldInterface, {
 
   setValue: function(value) {
     const self = this;
+    if (self.getValue() === '' && value === '') {
+      // to avoid typehead bug
+      return;
+    }
     if (self.usedTypeahead) {
       self.input.typeahead('val', value).change();
     } else {

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -1,356 +1,200 @@
 'use strict';
 
+/******************************************************************************************
+ * QuestionPage has many QuestionField
+ * QuestionField has a FormFieldInterface.
+ *
+ * QuestionPage has many questions form for a page. It does suggestion and autofill logic.
+ * QuestionField has a form for a question. It has a FormFieldInterface and label, help, fill button.
+ * Implementation of FormFieldInterface depends on question format and question type.
+ * FormFieldInterface has many FormFieldInterface if question type is ArrayFormField or ObjectFormField.
+ ******************************************************************************************/
+
 const $ = require('jquery');
 const $osf = require('js/osfHelpers');
 const fangorn = require('js/fangorn');
 const rdmGettext = require('js/rdmGettext');
 const _ = rdmGettext._;
+const sprintf = require('agh.sprintf').sprintf;
 const datepicker = require('js/rdmDatepicker');
 require('typeahead.js');
+const oop = require('js/oop');
+const Emitter = require('component-emitter');
+const sift = require('sift').default;
+const util = require('./util');
+const sizeofFormat = require("./util").sizeofFormat;
+const getLocalizedText = util.getLocalizedText;
+const normalizeText = util.normalizeText;
 
 const logPrefix = '[metadata] ';
 
-function getLocalizedText(text) {
-  if (!text) {
-    return text;
-  }
-  if (!text.includes('|')) {
-    return text;
-  }
-  const texts = text.split('|');
-  if (rdmGettext.getBrowserLang() === 'ja') {
-    return texts[0];
-  }
-  return texts[1];
-}
 
-function createField(erad, fileMetadataSuggestion, question, valueEntry, options, onChange) {
-  if (question.type == 'string') {
-    return createStringField(erad, fileMetadataSuggestion, question, (valueEntry || {}).value, options, onChange);
-  }
-  if (question.type == 'choose') {
-    return createChooseField(erad, fileMetadataSuggestion, question, (valueEntry || {}).value, options, onChange);
-  }
-  throw new Error('Unsupported type: ' + question.type);
-}
+const QuestionPage = oop.defclass({
+  constructor: function(schema, fileItem, options) {
+    const self = this;
+    self.schema = schema;
+    self.fileItem = fileItem;
+    self.options = options;
+    self.fields = [];
+    self.hasValidationError = false;
+  },
 
-function validateField(erad, question, value, fieldSetAndValues, options) {
-  const multiple = (options || {}).multiple;
-  if (!multiple && question.qid == 'grdm-file:available-date') {
-    return validateAvailableDateField(erad, question, value, fieldSetAndValues);
-  }
-  if (!multiple && question.qid == 'grdm-file:data-man-email') {
-    return validateContactManagerField(erad, question, value, fieldSetAndValues);
-  }
-  if (!value) {
-    if (question.required && !multiple) {
-      throw new Error(_("This field can't be blank."))
-    }
-    return;
-  }
-  if (question.qid == 'grdm-file:creators') {
-    return validateCreators(erad, question, value);
-  }
-  if (question.type == 'string') {
-    return validateStringField(erad, question, value);
-  }
-  if (question.type == 'choose') {
-    return validateChooseField(erad, question, value);
-  }
-  throw new Error('Unsupported type: ' + question.type);
-}
-
-function createStringField(erad, fileMetadataSuggestion, question, value, options, onChange) {
-  if (question.format == 'text') {
-    return new SingleElementField(
-      createFormElement(function() {
-        return $('<input></input>');
-      }, question, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (question.format == 'textarea') {
-    return new SingleElementField(
-      createFormElement(function() {
-        return $('<textarea></textarea>');
-      }, question, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (question.format == 'date') {
-    return new SingleElementField(
-      createFormElement(function() {
-        const elem = $('<input></input>').addClass('datepicker');
-        datepicker.mount(elem, null);
-        return elem;
-      }, question, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (question.format == 'file-creators') {
-    return new SingleElementField(
-      createFileCreatorsFieldElement(erad, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (question.format == 'e-rad-researcher-number') {
-    return new SingleElementField(
-      createERadResearcherNumberFieldElement(erad, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (
-    question.format == 'e-rad-researcher-name-ja' ||
-    question.format == 'e-rad-researcher-name-en' ||
-    question.format == 'file-institution-identifier'
-  ) {
-    return new SingleElementField(
-      createFormElement(function() {
-        return $('<input></input>').addClass(question.format);
-      }, question, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (question.format == 'file-capacity') {
-    return new SingleElementField(
-      createFileCapacityFieldElement(function() {
-        return $('<input></input>');
-      }, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (question.format == 'file-data-number') {
-    return new SingleElementField(
-      createDataNoFieldElement(function() {
-        return $('<input></input>');
-      }, fileMetadataSuggestion, question, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (question.format == 'file-url') {
-    return new SingleElementField(
-      createFileURLFieldElement(function() {
-        return $('<input></input>');
-      }, options),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  } else if (
-    question.format == 'file-institution-ja' ||
-    question.format == 'file-institution-en'
-  ) {
-    return new SingleElementField(
-      createFileInstitutionFieldElement(options, question.format),
-      (options && options.multiple) ? createClearFormElement(question) : null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  }
-  return new SingleElementField(
-    createFormElement(function() {
-      return $('<input></input>');
-    }, question, options),
-    (options && options.multiple) ? createClearFormElement(question) : null,
-    question,
-    value,
-    options,
-    onChange
-  );
-}
-
-function createChooseField(erad, fileMetadataSuggestion, question, value, options, onChange) {
-  if (question.format == 'singleselect') {
-    return new SingleElementField(
-      createFormElement(function() {
-        return createChooser(question, options);
-      }, question, options),
-      null,
-      question,
-      value,
-      options,
-      onChange
-    );
-  }
-  return new SingleElementField(
-    createFormElement(function() {
-      return $('<input></input>');
-    }, question, options),
-    null,
-    question,
-    value,
-    options,
-    onChange
-  );
-}
-
-function validateStringField(erad, question, value) {
-  if (question.pattern && !(new RegExp(question.pattern).test(value))) {
-    throw new Error(_("Please enter the correct value. ") + getLocalizedText(question.help));
-  }
-}
-
-function validateChooseField(erad, question, value) {
-}
-
-function validateAvailableDateField(erad, question, value, fieldSetAndValues) {
-  const accessRightsPair = fieldSetAndValues.find(function(fieldSetAndValue) {
-    return fieldSetAndValue.fieldSet.question.qid === 'grdm-file:access-rights';
-  })
-  if (!accessRightsPair) return;
-  const requiredDateAccessRights = ['embargoed access'];
-  if (requiredDateAccessRights.includes(accessRightsPair.value) && !value) {
-    throw new Error(_("This field can't be blank."));
-  }
-}
-
-function validateContactManagerField(erad, question, value, fieldSetAndValues) {
-  function getFieldValue(qid) {
-    const field = fieldSetAndValues.find(function(fieldSetAndValue) {
-      return fieldSetAndValue.fieldSet.question.qid === qid;
-    });
-    if (!field) return null;
-    return field.value;
-  }
-
-  const email = value;
-  const tel = getFieldValue('grdm-file:data-man-tel');
-  const address = getFieldValue('grdm-file:data-man-address-ja') &&
-    getFieldValue('grdm-file:data-man-address-en');
-  const org = getFieldValue('grdm-file:data-man-org-ja') &&
-    getFieldValue('grdm-file:data-man-org-en');
-
-  if (!email && !(tel && address && org)) {
-    throw new Error(_("Contacts of data manager can't be blank. Please fill mail address, or organization name, address and phone number."));
-  }
-}
-
-function validateCreators(erad, question, value) {
-  const creators = JSON.parse(value);
-  if (!creators) {
-    return;
-  }
-  if (creators.some(function(creator) {
-    return ! /^[0-9a-zA-Z]*$/.test(creator.number || '');
-  })) {
-    throw new Error(_("Please enter the correct value. ") + getLocalizedText(question.help));
-  }
-}
-
-function createChooser(question, options) {
-  const select = $('<select></select>');
-  const defaultOption = $('<option></option>').attr('value', '');
-  if (options.multiple) {
-    defaultOption.text(_('(Not Modified)'));
-    defaultOption.attr('selected', true)
-  } else {
-    defaultOption.text(_('Choose...'));
-  }
-  select.append(defaultOption);
-  var groupElem = null;
-  (question.options || []).forEach(function(opt) {
-    if (opt.text && opt.text.startsWith('group:None:')) {
-      groupElem = null;
-    } else if (opt.text && opt.text.startsWith('group:')) {
-      groupElem = $('<optgroup></optgroup>').attr('label', getLocalizedText(opt.tooltip));
-      select.append(groupElem);
-    } else {
-      const optElem = $('<option></option>')
-        .attr('value', opt.text === undefined ? opt : opt.text)
-        .text(opt.text === undefined ? opt : getLocalizedText(opt.tooltip));
-      if (!options.multiple && opt.default) {
-        optElem.attr('selected', true);
-      }
-      if (groupElem) {
-        groupElem.append(optElem);
-      } else {
-        select.append(optElem);
-      }
-    }
-  });
-  return select;
-}
-
-function normalize(value) {
-  return value.replace(/\s+/g, ' ').trim();
-}
-
-function createFormElement(createHandler, question, options) {
-  return {
-    create: function(addToContainer, onChange) {
-      const self = this;
-      const elem = createHandler();
-      if (options && options.readonly) {
-        elem.attr('readonly', true);
-      }
-      if (onChange) {
-        elem.change(function(event) {
-          const value = event.target.value
-          if (value && question.space_normalization) {
-            const normalized = normalize(value);
-            if (value !== normalized) {
-              self.setValue(elem, normalized);
-            }
+  create: function() {
+    const self = this;
+    self.fields = [];
+    const fileItemData = self.options.multiple ? {} : self.fileItem.data || {};
+    (self.schema.pages || []).forEach(function(page) {
+      (page.questions || []).forEach(function(question) {
+        if (!question.qid || !question.qid.match(/^grdm-file:.+/)) {
+          return;
+        }
+        const value = (fileItemData[question.qid] || {}).value;
+        const field = createQuestionField(
+          question,
+          value,
+          self.options
+        );
+        field.on('change', function() {
+          self.validateAll();
+        });
+        field.on('suggestionSelected', function(suggestion, tree) {
+          const nextTree = tree.concat([self]);
+          if (suggestion.suggestion.autofill) {
+            self.suggestionAutofill(suggestion, nextTree);
           }
-          onChange(event, options);
+        });
+        self.fields.push(field);
+      });
+    });
+    return self.fields;
+  },
+
+  suggestionAutofill: function(suggestion, tree) {
+    const self = this;
+    const autofillMap = suggestion.suggestion.autofill;
+    Object.keys(autofillMap).forEach(function(path) {
+      const field = self._findFieldFromTree(path, tree.slice(1));
+      if (!field) {
+        throw new Error('No field for path: ' + path);
+      }
+      const value = suggestion.value[autofillMap[path]];
+      if (value != null) {
+        field.setValue(value);
+      }
+    });
+  },
+
+  _findFieldFromTree: function(path, tree) {
+    var node = tree.shift();
+    while (path && path.startsWith('../')) {
+      node = tree.shift();
+      path = path.substring(3);
+    }
+    return node.fields.find(function(field) {
+      return field.question.qid === path || field.question.id === path;
+    });
+  },
+
+  // required_if and enabled_if are not full supported for hierarchical fields.
+  validateAll: function() {
+    const self = this;
+    self.hasValidationError = false;
+    self.fields.forEach(function(field) {
+      const error = self._validateQuestionField(field, self.fields, self.options);
+      if (error) {
+        self.hasValidationError = true;
+      }
+      field.showError();
+      self._updateEnabledQuestionField(field, self.fields);
+    });
+  },
+
+  _validateQuestionField: function(questionField, questionFields, options) {
+    questionField.lastError = null;
+    function walk(field, fields) {
+      try {
+        validateField(field.question, field.getValue(), fields, options);
+      } catch (error) {
+        if (field !== questionField.formField) {
+          questionField.lastError = new Error('[' + getLocalizedText(field.question.title) + '] ' + error.message);
+        } else {
+          questionField.lastError = error;
+        }
+        return;
+      }
+      if (field instanceof ObjectFormField) {
+        field.fields.forEach(function (childField) {
+          walk(childField, field.fields);
+        });
+      } else if (field instanceof ArrayFormField) {
+        field.fields.forEach(function (row) {
+          row.forEach(function (childField) {
+            walk(childField, row);
+          });
         });
       }
-      elem.addClass('form-control');
-      addToContainer(elem);
-      return elem;
-    },
-    getValue: function(input) {
-      return input.val();
-    },
-    setValue: function(input, value) {
-      if (input.hasClass('datepicker')) {
-        input.datepicker('update', value);
-      } else {
-        input.val(value);
-      }
-    },
-    reset: function(input) {
-      input.val(null);
-    },
-    disable: function(input, disabled) {
-      input.attr('disabled', disabled);
-    },
-  };
+    }
+    walk(questionField.formField, questionFields.map(function(qf) {
+      return qf.formField;
+    }));
+    return questionField.lastError;
+  },
+
+  _updateEnabledQuestionField: function(questionField, questionFields) {
+    const cond = questionField.question.enabled_if;
+    questionField.updateEnabled(!cond || evaluateCond(cond, questionFields));
+  },
+});
+
+
+function createQuestionField(question, value, options) {
+  const formField = createFormField(question, options, value);
+  const questionForm = new QuestionField(formField, question, options);
+  questionForm.create();
+  return questionForm;
 }
 
-function createClearFormElement(question) {
-  return {
-    create: function() {
-      const clearId = 'clear-' + question.qid.replace(':', '-');
-      const clearField = $('<input></input>')
+const QuestionField = oop.extend(Emitter, {
+  constructor: function(formField, question, options) {
+    if (!question.qid) {
+      throw new Error('No labels');
+    }
+    this.super.constructor.call(this, {});
+    const self = this;
+    self.formField = formField;
+    self.question = question;
+    self.options = options;
+    self.element = null;
+    self.clearField = null;
+    self.errorContainer = null;
+    self.isDisplayedHelp = false;
+    self.lastError = null;
+    self.enabled = true;
+  },
+
+  create: function() {
+    const self = this;
+    self.element = $('<div></div>').addClass('form-group');
+
+    // construct header
+    const header = $('<div></div>');
+    self.element.append(header);
+
+    // construct label
+    const label = $('<label></label>')
+      .text(self.question.title ? getLocalizedText(self.question.title) : self.question.label);
+    if (self.question.required) {
+      label.append($('<span></span>')
+        .css('color', 'red')
+        .css('font-weight', 'bold')
+        .text('*'));
+    }
+    header.append(label);
+
+    // construct clear field
+    if (self.options.multiple) {
+      const clearId = 'clear-' + self.question.qid.replace(':', '-');
+      self.clearField = $('<input></input>')
         .addClass('form-check-input')
         .addClass('metadata-form-clear-checkbox')
         .attr('type', 'checkbox')
@@ -359,48 +203,12 @@ function createClearFormElement(question) {
         .addClass('form-check-label')
         .attr('for', clearId)
         .text(_('Clear'));
-      const clearForm = $('<div></div>')
+      const clearFormBlock = $('<div></div>')
         .addClass('form-check')
-        .append(clearField)
+        .css('float', 'right')
+        .append(self.clearField)
         .append(clearLabel);
-      return {
-        element: clearForm,
-        checked: function() {
-          return clearField.prop('checked');
-        }
-      };
-    }
-  };
-}
-
-
-function SingleElementField(formField, clearField, question, defaultValue, options, onChange) {
-  if (!question.qid) {
-    throw new Error('No labels');
-  }
-  const self = this;
-
-  self.formField = formField;
-  self.label = question.qid;
-  self.title = question.title;
-  self.help = question.help;
-  self.defaultValue = defaultValue;
-  self.clearField = null;
-
-  self.createFormGroup = function(input, errorContainer) {
-    const header = $('<div></div>');
-    const label = $('<label></label>').text(self.getDisplayText());
-    if (question.required) {
-      label.append($('<span></span>')
-        .css('color', 'red')
-        .css('font-weight', 'bold')
-        .text('*'));
-    }
-    header.append(label);
-    if (clearField) {
-      self.clearField = clearField.create();
-      self.clearField.element.css('float', 'right');
-      self.clearField.element.on('change', function() {
+      self.clearField.on('change', function() {
         if (self.clearField.checked()) {
           self.formField.reset(input);
           self.formField.disable(input, true);
@@ -408,106 +216,733 @@ function SingleElementField(formField, clearField, question, defaultValue, optio
           self.formField.disable(input, false);
         }
       });
-      header.append(self.clearField.element);
+      header.append(clearFormBlock);
     }
-    const group = $('<div></div>').addClass('form-group')
-      .append(header);
-    if (self.help) {
-      var isDisplayedHelp = false;
+
+    // construct help
+    if (self.question.help) {
+      self.isDisplayedHelp = false;
       const helpLink = $('<a></a>')
-          .addClass('help-toggle-button')
-          .text(_('Show example'));
+        .addClass('help-toggle-button')
+        .text(_('Show example'));
       const helpLinkBlock = $('<p></p>').append(helpLink);
       const help = $('<p></p>')
         .addClass('help-block')
-        .text(self.getHelpText())
+        .text(getLocalizedText(self.question.help))
         .hide();
-      helpLink.on('click', function(e) {
+      helpLink.on('click', function (e) {
         e.preventDefault();
-        if (isDisplayedHelp) {
+        if (self.isDisplayedHelp) {
           helpLink.text(_('Show example'));
           help.hide();
-          isDisplayedHelp = false;
+          self.isDisplayedHelp = false;
         } else {
           helpLink.text(_('Hide example'));
           help.show();
-          isDisplayedHelp = true;
+          self.isDisplayedHelp = true;
         }
       });
-      group.append(helpLinkBlock).append(help);
+      self.element.append(helpLinkBlock).append(help);
     }
-    group
-      .append(input)
-      .append(errorContainer);
-    return group;
-  }
 
-  self.getDisplayText = function() {
-    if (!self.title) {
-      return self.label;
+    // construct form field
+    self.element.append(self.formField.container)
+    self.formField.on('change', function(value) {
+      self.emit('change', value);
+    });
+    self.formField.on('suggestionSelected', function(suggestion, tree) {
+      self.emit('suggestionSelected', suggestion, tree);
+    });
+
+    // construct error container
+    self.errorContainer = $('<div></div>')
+      .css('color', 'red').hide();
+    self.element.append(self.errorContainer);
+
+    return self.element;
+  },
+
+  getValue: function() {
+    const self = this;
+    return self.formField.getValue();
+  },
+
+  setValue: function(value) {
+    const self = this;
+    self.formField.setValue(value);
+  },
+
+  checkedClear: function() {
+    const self = this;
+    return self.clearField && self.clearField.checked;
+  },
+
+  showError: function() {
+    const self = this;
+    if (self.lastError) {
+      self.errorContainer.text(self.lastError.message).show();
+    } else {
+      self.errorContainer.hide().text('');
     }
-    return getLocalizedText(self.title);
-  }
+  },
 
-  self.getHelpText = function() {
-    return getLocalizedText(self.help);
-  }
-
-  self.getValue = function(input) {
-    return formField.getValue(input);
-  };
-
-  self.setValue = function(input, value) {
-    formField.setValue(input, value);
-  };
-
-  self.checkedClear = function() {
-    return self.clearField && self.clearField.checked();
-  };
-
-  self.addElementTo = function(parent, errorContainer) {
-    const input = formField.create(
-      function(child) {
-        parent.append(self.createFormGroup(child, errorContainer));
-      },
-      onChange
-    );
-    if (self.defaultValue) {
-      formField.setValue(input, self.defaultValue);
+  updateEnabled: function(enabled) {
+    const self = this;
+    self.enabled = enabled;
+    if (self.enabled) {
+      self.element.show();
+    } else {
+      self.element.hide();
     }
-    return input;
-  };
+  },
+});
+
+function createFormField(question, options, value) {
+  var formField;
+  if (question.type === 'object') {
+    formField = new ObjectFormField(question, options);
+  } else if (question.type === 'array') {
+    formField = new ArrayFormField(question, options);
+  } else if (question.format === 'text') {
+    formField = new TextFormField(question, options);
+  } else if (question.format === 'textarea') {
+    formField = new TextareaFormField(question, options);
+  } else if (question.format === 'date') {
+    formField = new DatePickerFormField(question, options);
+  } else if (question.format === 'singleselect') {
+    formField = new SingleSelectFormField(question, options);
+  } else {
+    console.error(logPrefix + 'Unknown format: ' + question.format);
+    formField = new TextFormField(question, options);
+  }
+  formField.create();
+  try {
+    formField.setValue(value);
+  } catch (error) {
+    console.error('Cannot set default value for question ' + question.qid + ': ' + error.message, value);
+  }
+  return formField;
+}
+
+const noImplementation = function() {
+  throw new Error('no implementation');
+}
+const FormFieldInterface = oop.extend(Emitter, {
+  constructor: function() {
+    this.super.constructor.call(this, {});
+    this.container = null;
+  },
+  create: noImplementation,
+  getValue: noImplementation,
+  setValue: noImplementation,
+  reset: noImplementation,
+  disable: noImplementation,
+});
+
+const TextFormField = oop.extend(FormFieldInterface, {
+  constructor: function(question, options) {
+    const self = this;
+    self.question = question;
+    self.options = options || {};
+    self.container = null;
+    self.input = null;
+    self.usedTypeahead = false;
+  },
+
+  create: function() {
+    const self = this;
+    self.input = $('<input/>')
+      .addClass('form-control');
+    if (self.options.readonly) {
+      self.input.attr('readonly', true);
+    }
+    self.input.change(function(event) {
+      const value = event.target.value;
+      if (value && self.question.space_normalization) {
+        const normalized = normalizeText(value);
+        if (value !== normalized) {
+          self.setValue(normalized);
+          return;
+        }
+      }
+      self.emit('change', event.target.value);
+    });
+    self.container = $('<div>').append(self.input);
+
+    const buttonSuggestions = (self.question.suggestion || []).filter(function (suggestion) {
+      return suggestion.button;
+    });
+    if (!self.options.readonly && !self.options.multiple && buttonSuggestions.length) {
+      function onSuggested(value) {
+        self.setValue(value);
+      }
+      function enteredValue() {
+        const value = self.getValue();
+        return value != null && value !== '';
+      }
+      const suggestionContainer = createSuggestionButton(
+        self.question, buttonSuggestions, self.options,
+        onSuggested, enteredValue
+      );
+      self.container
+        .css('display', 'flex')
+        .append(suggestionContainer);
+    }
+
+    const templateSuggestions = (self.question.suggestion || []).filter(function (suggestion) {
+      return suggestion.template;
+    });
+    if (!self.options.readonly && !self.options.multiple && templateSuggestions.length) {
+      self.input.typeahead(
+        {
+          hint: false,
+          highlight: true,
+          minLength: 0
+        },
+        {
+          display: function(data) {
+            return data.display;
+          },
+          templates: {
+            suggestion: function(data) {
+              return data.template;
+            }
+          },
+          source: $osf.throttle(function (q, cb) {
+            suggestForTypeahead(self.question, templateSuggestions, q, self.options)
+              .then(function (results) {
+                cb(results.flat());
+              }).catch(function () {
+                console.error(error);
+                cb([]);
+              });
+          }, 500, {leading: false}),
+        }
+      )
+      self.input.bind('typeahead:selected', function(event, data) {
+        self.emit('suggestionSelected', data, [self]);
+      });
+      self.container.find('.twitter-typeahead').css('width', '100%');
+      self.usedTypeahead = true;
+    }
+  },
+
+  getValue: function() {
+    const self = this;
+    return self.input.val();
+  },
+
+  setValue: function(value) {
+    const self = this;
+    if (self.usedTypeahead) {
+      self.input.typeahead('val', value).change();
+    } else {
+      self.input.val(value);
+    }
+  },
+
+  reset: function() {
+    const self = this;
+    self.input.val(null);
+  },
+
+  disable: function(disabled) {
+    const self = this;
+    self.input.attr('disabled', disabled);
+  },
+});
+
+const TextareaFormField = oop.extend(FormFieldInterface, {
+  constructor: function(question, options) {
+    const self = this;
+    self.question = question;
+    self.options = options || {};
+    self.container = null;
+    self.input = null;
+  },
+
+  create: function() {
+    const self = this;
+    self.input = $('<textarea></textarea>')
+      .addClass('form-control');
+    if (self.options.readonly) {
+      self.input.attr('readonly', true);
+    }
+    self.input.change(function(event) {
+      const value = event.target.value;
+      if (value && self.question.space_normalization) {
+        const normalized = normalizeText(value);
+        if (value !== normalized) {
+          self.setValue(normalized);
+          return;
+        }
+      }
+      self.emit('change', event.target.value);
+    });
+    self.container = self.input;
+  },
+
+  getValue: function() {
+    const self = this;
+    return self.input.val();
+  },
+
+  setValue: function(value) {
+    const self = this;
+    self.input.val(value);
+  },
+
+  reset: function() {
+    const self = this;
+    self.input.val(null);
+  },
+
+  disable: function(disabled) {
+    const self = this;
+    self.input.attr('disabled', disabled);
+  },
+});
+
+const DatePickerFormField = oop.extend(FormFieldInterface, {
+  constructor: function(question, options) {
+    const self = this;
+    self.question = question;
+    self.options = options || {};
+    self.container = null;
+    self.input = null;
+  },
+
+  create: function() {
+    const self = this;
+    self.input = $('<input></input>')
+      .addClass('datepicker')
+      .addClass('form-control');
+    datepicker.mount(self.input, null);
+    if (self.options.readonly) {
+      self.input.attr('readonly', true);
+    }
+    self.input.change(function(event) {
+      self.emit('change', event.target.value);
+    });
+    self.container = self.input;
+  },
+
+  getValue: function() {
+    const self = this;
+    return self.input.val();
+  },
+
+  setValue: function(value) {
+    const self = this;
+    self.input.datepicker('update', value);
+  },
+
+  reset: function() {
+    const self = this;
+    self.input.val(null);
+  },
+
+  disable: function(disabled) {
+    const self = this;
+    self.input.attr('disabled', disabled);
+  },
+});
+
+const SingleSelectFormField = oop.extend(FormFieldInterface, {
+  constructor: function(question, options) {
+    const self = this;
+    self.question = question;
+    self.options = options || {};
+    self.container = null;
+    self.select = null;
+  },
+
+  create: function() {
+    const self = this;
+    self.select = $('<select></select>')
+      .addClass('form-control');
+    if (self.options.readonly) {
+      self.select.attr('readonly', true);
+    }
+    const defaultOption = $('<option></option>').attr('value', '');
+    if (self.options.multiple) {
+      defaultOption.text(_('(Not Modified)'));
+      defaultOption.attr('selected', true)
+    } else {
+      defaultOption.text(_('Choose...'));
+    }
+    self.select.append(defaultOption);
+    var groupElem = null;
+    (self.question.options || []).forEach(function(opt) {
+      if (opt.text && opt.text.startsWith('group:None:')) {
+        groupElem = null;
+      } else if (opt.text && opt.text.startsWith('group:')) {
+        groupElem = $('<optgroup></optgroup>').attr('label', getLocalizedText(opt.tooltip));
+        self.select.append(groupElem);
+      } else {
+        const optElem = $('<option></option>')
+          .attr('value', opt.text === undefined ? opt : opt.text)
+          .text(opt.text === undefined ? opt : getLocalizedText(opt.tooltip));
+        if (!self.options.multiple && opt.default) {
+          optElem.attr('selected', true);
+        }
+        if (groupElem) {
+          groupElem.append(optElem);
+        } else {
+          self.select.append(optElem);
+        }
+      }
+    });
+    self.select.change(function(event) {
+      self.emit('change', event.target.value);
+    });
+    self.container = self.select;
+  },
+
+  getValue: function() {
+    const self = this;
+    return self.select.val();
+  },
+
+  setValue: function(value) {
+    const self = this;
+    self.select.val(value);
+  },
+
+  reset: function() {
+    const self = this;
+    self.select.val(null);
+  },
+
+  disable: function(disabled) {
+    const self = this;
+    self.select.attr('disabled', disabled);
+  },
+});
+
+const ArrayFormField = oop.extend(FormFieldInterface, {
+  constructor: function(question, options) {
+    const self = this;
+    self.question = question;
+    self.fields = [];  // subquestions
+    self.options = options || {};
+    self.container = null;
+    self.tbody = null;
+    self.emptyLine = null;
+  },
+
+  create: function() {
+    const self = this;
+
+    const headRow = $('<tr>');
+    const thead = $('<thead>').append(headRow);
+    self.question.properties.forEach(function(prop) {
+      headRow.append($('<th>' + getLocalizedText(prop.title) + '</th>'));
+    });
+    headRow.append($('<th>'));  // remove button header
+
+    self.emptyLine = $('<td></td>')
+      .attr('colspan', '4')
+      .css('text-align', 'center')
+      .css('padding', '1em')
+      .text(_('No data'))
+      .show();
+    self.tbody = $('<tbody>').append(self.emptyLine);
+
+    const table = $('<table class="table responsive-table responsive-table-xxs">')
+      .append(thead)
+      .append(self.tbody);
+    self.container = $('<div>').append(table);
+    if (!self.options || !self.options.readonly) {
+      const addButton = $('<a class="btn btn-success btn-sm">')
+        .append($('<i class="fa fa-plus"></i>'))
+        .append($('<span></span>').text(_('Add')));
+      addButton.on('click', function (e) {
+        e.preventDefault();
+        self.addRow();
+        self.emit('change', self.getValue());
+      });
+      self.container.append(addButton);
+    }
+  },
+
+  addRow: function(value) {
+    const self = this;
+    const subFormFields = self.question.properties.map(function(prop) {
+      const subFormField = createFormField(prop, self.options);
+      subFormField.create();
+      if (value && value[prop.id]) {
+        subFormField.setValue(value[prop.id]);
+      }
+      subFormField.on('change', function() {
+        self.emit('change', self.getValue());
+      });
+      return subFormField;
+    });
+    subFormFields.forEach(function(subFormField) {
+      subFormField.on('suggestionSelected', function(suggestion, tree) {
+        const nextTree = tree.concat([
+          {fields: subFormFields},
+          self,
+        ]);
+        self.emit('suggestionSelected', suggestion, nextTree);
+      });
+    });
+    const tr = $('<tr>');
+    subFormFields.forEach(function(subFormField) {
+      tr.append($('<td>').append(subFormField.container));
+    });
+    if (!self.options || !self.options.readonly) {
+      const removeButton = $('<span class="remove-row"><i class="fa fa-times fa-2x remove-or-reject"></i></span>');
+      removeButton.on('click', function (e) {
+        e.preventDefault();
+        self.removeRow(subFormFields, tr);
+        self.emit('change', self.getValue());
+      });
+      tr.append($('<td>').append(removeButton));
+    }
+    self.tbody.append(tr);
+    self.emptyLine.hide();
+    self.fields.push(subFormFields);
+  },
+
+  removeRow: function(subquestion, tr) {
+    const self = this;
+    tr.remove();
+    self.fields.splice(self.fields.indexOf(subquestion), 1);
+    if (self.fields.length === 0) {
+      self.emptyLine.show();
+    }
+  },
+
+  getValue: function() {
+    const self = this;
+    const res = [];
+    self.fields.forEach(function(subquestionGroup) {
+      const row = {};
+      subquestionGroup.forEach(function(subquestion) {
+        row[subquestion.question.id] = subquestion.getValue();
+      });
+      if (Object.values(row).some(function(value) {
+        return value !== null && value !== '';
+      })) {
+        res.push(row);
+      }
+    });
+    return res;
+  },
+
+  setValue: function(value) {
+    const self = this;
+    self.reset();
+    var rows = [];
+    if (value && typeof value === 'string') {
+      rows = JSON.parse(value);
+    } else {
+      rows = value || [];
+    }
+    rows.forEach(function(row) {
+      self.addRow(row);
+    });
+  },
+
+  reset: function() {
+    const self = this;
+    self.tbody.empty();
+    self.fields = [];
+  },
+
+  disable: function(disabled) {
+    const self = this;
+    self.fields.forEach(function(subquestionGroup) {
+      subquestionGroup.forEach(function(subquestion) {
+        subquestion.disable(disabled);
+      });
+    });
+    const btn = self.container.find('.btn');
+    if (disabled) {
+      btn.addClass('disabled');
+    } else {
+      btn.removeClass('disabled');
+    }
+  },
+});
+
+const ObjectFormField = oop.extend(FormFieldInterface, {
+  constructor: function(question, options) {
+    const self = this;
+    self.question = question;
+    self.fields = [];  // subquestions
+    self.options = options || {};
+    self.container = null;
+    self.tbody = null;
+  },
+
+  create: function() {
+    const self = this;
+    const headRow = $('<tr>');
+    const thead = $('<thead>').append(headRow);
+    self.question.properties.forEach(function(prop) {
+      headRow.append($('<th>' + getLocalizedText(prop.title) + '</th>'));
+    });
+
+    self.fields = self.question.properties.map(function(prop) {
+      const subFormField = createFormField(prop, self.options);
+      subFormField.create();
+      subFormField.on('change', function() {
+        self.emit('change', self.getValue());
+      });
+      subFormField.on('suggestionSelected', function(suggestion, tree) {
+        const nextTree = tree.concat([self]);
+        self.emit('suggestionSelected', suggestion, nextTree);
+      });
+      return subFormField;
+    });
+    const tr = $('<tr>');
+    self.fields.forEach(function(subFormField) {
+      tr.append($('<td>').append(subFormField.container));
+    });
+    const tbody = $('<tbody>').append(tr);
+
+    const table = $('<table class="table responsive-table responsive-table-xxs" style="margin-bottom: 0">')
+      .append(thead)
+      .append(tbody);
+    self.container = $('<div>').append(table);
+  },
+
+  getValue: function() {
+    const self = this;
+    const res = {};
+    self.fields.forEach(function(subquestion) {
+      res[subquestion.question.id] = subquestion.getValue();
+    });
+    if (Object.values(res).some(function(value) {
+      return value !== null && value !== '';
+    })) {
+      return res;
+    }
+    return null;
+  },
+
+  setValue: function(value) {
+    const self = this;
+    self.reset();
+    var rows = value || {};
+    if (typeof(value) === 'string') {
+      rows = JSON.parse(value);
+    }
+    self.fields.forEach(function(subquestion) {
+      const value = rows[subquestion.question.id];
+      subquestion.setValue(value);
+    });
+  },
+
+  reset: function() {
+    const self = this;
+    self.fields.forEach(function (subquestion) {
+      subquestion.reset();
+    });
+  },
+
+  disable: function(disabled) {
+    const self = this;
+    self.fields.forEach(function (subquestion) {
+      subquestion.disable(disabled);
+    });
+  },
+});
+
+
+
+/// validation
+
+function validateField(question, value, questionFields, options) {
+  const multiple = (options || {}).multiple;
+  validateRequired(question, value, questionFields, multiple);
+  validatePattern(question, value);
+}
+
+function validatePattern(question, value) {
+  if (question.pattern && value && !(new RegExp(question.pattern).test(value))) {
+    throw new Error(_("Please enter the correct value. ") + getLocalizedText(question.help));
+  }
+}
+
+function validateRequired(question, value, questionFields, multiple) {
+  if (multiple || value) {
+    return;
+  }
+  if (question.enabled_if && !evaluateCond(question.enabled_if, questionFields)) {
+    return;
+  }
+  const cond = question.required_if;
+  const condErrorMessage = question.message_required_if;
+  if (cond) {
+    if (typeof(cond) === 'string') {
+      const otherField = questionFields.find(function(questionField) {
+        return questionField.question.qid === cond || questionField.question.id === cond;
+      });
+      if (!otherField) {
+        throw new Error('Schema error: invalid required_if: ' + cond);
+      }
+      if (!otherField.getValue()) {
+        throw new Error(
+          condErrorMessage ||
+          sprintf(_('One of this field or "%s" field must be filled.'),
+            getLocalizedText(otherField.question.title))
+        );
+      }
+    } else if (typeof(cond) === 'object') {
+      if (evaluateCond(cond, questionFields)) {
+        if (!condErrorMessage) {
+          throw new Error('Schema error: required message_required_if');
+        }
+        throw new Error(getLocalizedText(condErrorMessage));
+      }
+    } else {
+      throw new Error('Schema error: invalid required_if: ' + cond);
+    }
+  } else if (question.required) {
+    throw new Error(_("This field can't be blank."));
+  }
 }
 
 
-function createFileCapacityFieldElement(createHandler, options) {
-  // ref: website/project/util.py sizeof_fmt()
-  function sizeofFormat(num) {
-    const units = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z'];
-    for (var i = 0; i < units.length; i ++) {
-      const unit = units[i];
-      if (Math.abs(num) < 1000) {
-        return Math.round(num * 10) / 10 + unit + 'B';
-      }
-      num /= 1000.0
-    }
-    return Math.round(num * 10) / 10 + 'YB';
-  }
+// suggestion
 
-  function calcCapacity(input, calcIndicator, errorContainer) {
-    if (contextVars.file) {
-      return new Promise(function (resolve, reject) {
-        const totalSize = contextVars.file.size || 0;
-        console.log(logPrefix, 'totalSize: ', totalSize);
-        input.val(sizeofFormat(totalSize)).change();
-        resolve();
-      });
+function requestSuggestion(filepath, key, keyword) {
+  var url = contextVars.node.urls.api + 'metadata/file_metadata/suggestions/' + encodeURI(filepath);
+  return $.ajax({
+    url: url,
+    type: 'GET',
+    dataType: 'json',
+    data: {
+      key: key,
+      keyword: keyword
     }
-    errorContainer.hide().text('');
-    calcIndicator.show();
-    options.wbcache.clearCache();
-    const task = options.filepath.endsWith('/') ?
-      options.wbcache.listFiles(options.filepath, true)
+  }).catch(function(xhr, status, error) {
+    Raven.captureMessage('Error while retrieving file metadata suggestions', {
+      extra: {
+        url: url,
+        status: status,
+        error: error
+      }
+    });
+    return Promise.reject({xhr: xhr, status: status, error: error});
+  }).then(function (data) {
+    const res = ((data.data || {}).attributes || {}).suggestions || [];
+    console.log(logPrefix, 'suggestion: ', res);
+    return res;
+  });
+}
+
+function suggestForButton(question, suggestion, options) {
+  if (suggestion.key === 'file-size') {
+    const wbcache = options.wbcache;
+    const filepath = options.filepath;
+    wbcache.clearCache();
+    const task = filepath.endsWith('/') ?
+      wbcache.listFiles(filepath, true)
         .then(function (files) {
           return files.reduce(function(y, x) {
             return y + Number(x.item.attributes.size);
@@ -515,7 +950,7 @@ function createFileCapacityFieldElement(createHandler, options) {
         }) :
       new Promise(function (resolve, reject) {
         try {
-          options.wbcache.searchFile(options.filepath, function (item) {
+          wbcache.searchFile(filepath, function (item) {
             resolve(Number(item.attributes.size));
           });
         } catch (err) {
@@ -524,549 +959,116 @@ function createFileCapacityFieldElement(createHandler, options) {
       });
     return task
       .then(function (totalSize) {
-        console.log(logPrefix, 'totalSize: ', totalSize);
-        input.val(sizeofFormat(totalSize)).change();
+        return sizeofFormat(totalSize);
       })
-      .catch(function (err) {
-        console.error(err);
-        $osf.growl('Error', _('Could not list files') + ': ' + err.toString());
-        Raven.captureMessage(_('Could not list files'), {
-          extra: {
-            error: err.toString()
-          }
-        });
-        errorContainer.text(_('Could not list files')).show();
-      })
-      .then(function () {
-        calcIndicator.hide();
+  } else if (suggestion.key === 'file-url') {
+    return Promise.resolve(fangorn.getPersistentLinkFor(options.fileitem));
+  } else { // for key === file-data-number
+    const fileitem = options.fileitem;
+    const itemUrl = fangorn.getPersistentLinkFor(fileitem);
+    const filepath = itemUrl.substr(itemUrl.indexOf('files/'));
+    return requestSuggestion(filepath, suggestion.key)
+      .then(function (suggestions) {
+        return (suggestions.find(function (s) { return s.key === suggestion.key}) || {}).value;
       });
   }
-
-  return {
-    create: function(addToContainer, onChange) {
-      const input = createHandler();
-      if (options && options.readonly) {
-        input.attr('readonly', true);
-      }
-      if (onChange) {
-        input.change(function(event) {
-          onChange(event, options);
-        });
-      }
-      input.addClass('form-control');
-      const container = $('<div>').append(input);
-      if (!options || (!options.readonly && !options.multiple)) {
-        container.css('display', 'flex');
-        const calcIndicator = $('<i class="fa fa-spinner fa-pulse">')
-          .hide();
-        const calcButton = $('<a class="btn btn-default btn-sm">')
-          .append($('<i class="fa fa-refresh"></i>'))
-          .append($('<span></span>').text(_('Calculate')))
-          .append(calcIndicator);
-        const errorContainer = $('<span>')
-          .css('color', 'red').hide();
-        const calcContainer = $('<div>')
-          .css('margin', 'auto 0 auto 8px')
-          .append(calcButton)
-          .append(errorContainer);
-        var calculating = false;
-        calcButton.on('click', function (e) {
-          e.preventDefault();
-          if (!calculating) {
-            calculating = true;
-            calcButton.attr('disabled', true);
-            calcCapacity(input, calcIndicator, errorContainer)
-              .then(function () {
-                calculating = false;
-                calcButton.attr('disabled', false);
-              });
-          }
-        });
-        container.append(calcContainer)
-      }
-
-      addToContainer(container);
-      return container;
-    },
-    getValue: function(container) {
-      return container.find('input').val();
-    },
-    setValue: function(container, value) {
-      container.find('input').val(value);
-    },
-    reset: function(container) {
-      container.find('input').val(null);
-    },
-    disable: function(container, disabled) {
-      container.find('input').attr('disabled', disabled);
-    },
-  };
 }
 
-function createFileURLFieldElement(createHandler, options) {
-  return {
-    create: function(addToContainer, onChange) {
-      const input = createHandler();
-      if (options && options.readonly) {
-        input.attr('readonly', true);
-      }
-      if (onChange) {
-        input.change(function(event) {
-          onChange(event, options);
-        });
-      }
-      input.addClass('form-control');
-      const container = $('<div>').append(input);
-      if (!options || (!options.readonly && !options.multiple)) {
-        container.css('display', 'flex');
-        const fillButton = $('<a class="btn btn-default btn-sm">')
-          .append($('<i class="fa fa-refresh"></i>'))
-          .append($('<span></span>').text(_('Fill')));
-        const fillContainer = $('<div>')
-          .css('margin', 'auto 0 auto 8px')
-          .append(fillButton);
-        fillButton.on('click', function (e) {
-          e.preventDefault();
-          input.val(fangorn.getPersistentLinkFor(options.fileitem)).change();
-        });
-        container.append(fillContainer)
-      }
-      addToContainer(container);
-      return container;
-    },
-    getValue: function(container) {
-      return container.find('input').val();
-    },
-    setValue: function(container, value) {
-      container.find('input').val(value);
-    },
-    reset: function(container) {
-      container.find('input').val(null);
-    },
-    disable: function(container, disabled) {
-      container.find('input').attr('disabled', disabled);
-    },
-  };
-}
-
-function createDataNoFieldElement(createHandler, fileMetadataSuggestion, question, options) {
-  return {
-    create: function(addToContainer, onChange) {
-      const input = createHandler();
-      if (options && options.readonly) {
-        input.attr('readonly', true);
-      }
-      if (onChange) {
-        input.change(function(event) {
-          onChange(event, options);
-        });
-      }
-      input.addClass('form-control');
-      const container = $('<div>').append(input);
-      if (!options || (!options.readonly && !options.multiple)) {
-        container.css('display', 'flex');
-        const calcIndicator = $('<i class="fa fa-spinner fa-pulse">')
-          .hide();
-        const fillButton = $('<a class="btn btn-default btn-sm">')
-          .append($('<i class="fa fa-refresh"></i>'))
-          .append($('<span></span>').text(_('Fill')))
-          .append(calcIndicator);
-        const errorContainer = $('<span>')
-          .css('color', 'red').hide();
-        const fillContainer = $('<div>')
-          .css('margin', 'auto 0 auto 8px')
-          .append(fillButton)
-          .append(errorContainer);
-        var calculating = false;
-        fillButton.on('click', function (e) {
-          e.preventDefault();
-          if (!calculating) {
-            calculating = true;
-            fillButton.attr('disabled', true);
-            errorContainer.hide().text('');
-            calcIndicator.show();
-            generateDataNo(fileMetadataSuggestion, options.fileitem)
-              .then(function (value) {
-                input.val(value).change();
-              })
-              .catch(function (err) {
-                console.error(err);
-                errorContainer.text(_('Could not generate Data No.')).show();
-              })
-              .then(function () {
-                calculating = false;
-                fillButton.attr('disabled', false);
-                calcIndicator.hide();
-              });
-          }
-        });
-        container.append(fillContainer)
-      }
-      addToContainer(container);
-      return container;
-    },
-    getValue: function(container) {
-      return container.find('input').val();
-    },
-    setValue: function(container, value) {
-      container.find('input').val(value);
-    },
-    reset: function(container) {
-      container.find('input').val(null);
-    },
-    disable: function(container, disabled) {
-      container.find('input').attr('disabled', disabled);
-    },
-  };
-}
-
-function createFileCreatorsFieldElement(erad, options) {
-  const emptyLine = $('<td></td>')
-    .attr('colspan', '4')
-    .css('text-align', 'center')
-    .css('padding', '1em')
-    .text(_('No members'))
-    .show();
-
-  const addResearcher = function(container, defaultValues) {
-    const numberInput = $('<input class="form-control" name="file-creator-number">');
-    const nameJaInput = $('<input class="form-control" name="file-creator-name-ja">');
-    const nameEnInput = $('<input class="form-control" name="file-creator-name-en">');
-    if (options && options.readonly) {
-      numberInput.attr('readonly', true);
-      nameJaInput.attr('readonly', true);
-      nameEnInput.attr('readonly', true);
-    }
-    if (defaultValues) {
-      numberInput.val(defaultValues.number).change();
-      nameJaInput.val(defaultValues.name_ja).change();
-      nameEnInput.val(defaultValues.name_en).change();
-    }
-    const tr = $('<tr>')
-      .append($('<td>').append(numberInput))
-      .append($('<td>').append(nameJaInput))
-      .append($('<td>').append(nameEnInput));
-    if (!options || !options.readonly) {
-      tr.append('<td><span class="file-creator-remove"><i class="fa fa-times fa-2x remove-or-reject"></i></span></td>');
-    }
-    const tbody = container.find('tbody');
-    tbody.append(tr);
-    numberInput.typeahead(
-      {
-        hint: false,
-        highlight: true,
-        minLength: 0
-      },
-      {
-        display: function(data) {
-          return data.kenkyusha_no;
-        },
-        templates: {
-          suggestion: function(data) {
-            return '<div style="background-color: white;"><span>' + $osf.htmlEscape(data.kenkyusha_shimei) + '</span> ' +
-              '<span><small class="m-l-md text-muted">'+
-              $osf.htmlEscape(data.kenkyusha_no) + ' - ' +
-              $osf.htmlEscape(data.kenkyukikan_mei) + ' - ' +
-              $osf.htmlEscape(data.kadai_mei) + ' (' + data.nendo + ')'
-              + '</small></span></div>';
-          }
-        },
-        source: substringMatcher(erad.candidates),
-      }
-    );
-    numberInput.bind('typeahead:selected', function(event, data) {
-      if (!data.kenkyusha_no) {
-        return;
-      }
-      const names = data.kenkyusha_shimei.split('|');
-      const jaNames = names.slice(0, Math.floor(names.length / 2))
-      const enNames = names.slice(Math.floor(names.length / 2))
-      nameJaInput.val(jaNames.join('')).change();
-      nameEnInput.val(enNames.reverse().join(' ')).change();
-    });
-    tbody.find('.twitter-typeahead').css('width', '100%');
-    emptyLine.hide();
-  }
-
-  return {
-    create: function(addToContainer, onChange) {
-      const thead = $('<thead>')
-        .append($('<tr>')
-          .append($('<th>' + _('e-Rad Researcher Number') + '</th>'))
-          .append($('<th>' + _('Name (Japanese)') + '</th>'))
-          .append($('<th>' + _('Name (English)') + '</th>'))
-          .append($('<th></th>'))
-        );
-      const tbody = $('<tbody>');
-      const container = $('<div></div>')
-        .addClass('file-creators-container')
-        .append($('<table class="table responsive-table responsive-table-xxs">')
-          .append(thead)
-          .append(tbody)
-        );
-      tbody.append(emptyLine);
-      if (!options || !options.readonly) {
-        const addButton = $('<a class="btn btn-success btn-sm">')
-          .append($('<i class="fa fa-plus"></i>'))
-          .append($('<span></span>').text(_('Add')));
-        container.append(addButton);
-        addButton.on('click', function (e) {
-          e.preventDefault();
-          addResearcher(container);
-        });
-        tbody.on('click', '.file-creator-remove', function (e) {
-          e.preventDefault();
-          $(this).closest('tr').remove();
-          if (container.find('tbody tr').length === 0) {
-            emptyLine.show();
-          }
-          if (onChange) {
-            onChange(e, options);
-          }
-        });
-      }
-      tbody.on('change', 'input', function (e) {
-        const value = e.target.value
-        if (value && e.target.getAttribute('name').startsWith('file-creator-name')) {
-          const normalized = normalize(value);
-          if (value !== normalized) {
-            e.target.value = normalized;
-          }
-        }
-        if (onChange) {
-          onChange(e, options);
-        }
-      });
-      addToContainer(container);
-      return container;
-    },
-    getValue: function(container) {
-      const researchers = container.find('tbody tr').map(function () {
-        return {
-          'number': $(this).find('[name=file-creator-number]').val(),
-          'name_ja': $(this).find('[name=file-creator-name-ja]').val(),
-          'name_en': $(this).find('[name=file-creator-name-en]').val()
-        };
-      }).toArray().filter(function (researcher) {
-        return Object.values(researcher).some(function (v) { return v && v.trim().length > 0; });
-      });
-      if (researchers.length === 0) {
-        return '';
-      }
-      return JSON.stringify(researchers);
-    },
-    setValue: function(container, value) {
-      const researchers = value ? JSON.parse(value) : [];
-      researchers.forEach(function (researcher) {
-        addResearcher(container, researcher);
-      });
-    },
-    reset: function(container) {
-      container.find('tbody').empty();
-    },
-    disable: function(container, disabled) {
-      const btn = container.find('.btn');
-      if (disabled) {
-        btn.addClass('disabled');
-      } else {
-        btn.removeClass('disabled');
-      }
-    },
-  };
-}
-
-function createERadResearcherNumberFieldElement(erad, options) {
-  return {
-    create: function(addToContainer, onChange) {
-      const input = $('<input></input>').addClass('erad-researcher-number');
-      if (options && options.readonly) {
-        input.attr('readonly', true);
-      }
-      const container = $('<div></div>')
-        .addClass('erad-researcher-number-container')
-        .append(input.addClass('form-control'));
-      addToContainer(container);
-      input.typeahead(
-        {
-          hint: false,
-          highlight: true,
-          minLength: 0
-        },
-        {
-          display: function(data) {
-            return data.kenkyusha_no;
-          },
-          templates: {
-            suggestion: function(data) {
-              return '<div style="background-color: white;"><span>' + $osf.htmlEscape(data.kenkyusha_shimei) + '</span> ' +
-                '<span><small class="m-l-md text-muted">'+
-                $osf.htmlEscape(data.kenkyusha_no) + ' - ' +
-                $osf.htmlEscape(data.kenkyukikan_mei) + ' - ' +
-                $osf.htmlEscape(data.kadai_mei) + ' (' + data.nendo + ')'
-                + '</small></span></div>';
-            }
-          },
-          source: substringMatcher(erad.candidates),
-        }
-      );
-      input.bind('typeahead:selected', function(event, data) {
-        if (data.kenkyusha_shimei) {
-          const names = data.kenkyusha_shimei.split('|');
-          const jaNames = names.slice(0, Math.floor(names.length / 2))
-          const enNames = names.slice(Math.floor(names.length / 2))
-          $('.e-rad-researcher-name-ja').val(jaNames.join('')).change();
-          $('.e-rad-researcher-name-en').val(enNames.reverse().join(' ')).change();
-        }
-        if (data.kenkyukikan_mei) {
-          const names = data.kenkyukikan_mei.split('|');
-          const jaNames = names.slice(0, Math.floor(names.length / 2))
-          const enNames = names.slice(Math.floor(names.length / 2))
-          $('.file-institution-ja').typeahead('val', jaNames.join('')).change();
-          $('.file-institution-en').typeahead('val', enNames.join(' ')).change();
-        }
-      });
-      container.find('.twitter-typeahead').css('width', '100%');
-      if (onChange) {
-        input.change(function(event) {
-          onChange(event, options);
-        });
-      }
-      return container;
-    },
-    getValue: function(container) {
-      return container.find('input').val();
-    },
-    setValue: function(container, value) {
-      container.find('input').val(value);
-    },
-    reset: function(container) {
-      container.find('input').val(null);
-    },
-    disable: function(container, disabled) {
-      container.find('input').attr('disabled', disabled);
-    },
-  };
-}
-
-
-function createFileInstitutionFieldElement(options, format) {
-  return {
-    create: function(addToContainer, onChange) {
-      const input = $('<input></input>').addClass(format);
-      if (options && options.readonly) {
-        input.attr('readonly', true);
-      }
-      const container = $('<div></div>')
-        .addClass('erad-file-institution')
-        .append(input.addClass('form-control'));
-      addToContainer(container);
-      function getJaName(data) {
-        if (data && data.labels && data.labels.length) {
-          const ja = data.labels.filter(function(label) {
-            return label.iso639 === 'ja';
-          });
-          if (ja.length) {
-            return ja[0].label;
-          }
-        }
-        return null;
-      }
-      input.typeahead(
-        {
-          hint: false,
-          highlight: true,
-          minLength: 0
-        },
-        {
-          display: function(data) {
-            const ja = getJaName(data);
-            if (format.endsWith('ja') && ja) {
-              return ja;
-            }
-            return data.name;
-          },
-          templates: {
-            suggestion: function(data) {
-              const ja = getJaName(data);
-              return '<div style="background-color: white;"><span>' + $osf.htmlEscape(data.name) + '</span> ' +
-                '<span><small class="m-l-md text-muted">'+
-                (ja ? $osf.htmlEscape(ja) : '')
-                + '</small></span></div>';
-            }
-          },
-          source: $osf.throttle(function (q, cb) {
-            $.ajax({
-              method: 'GET',
-              url: 'https://api.ror.org/organizations',
-              data: {
-                query: q
-              },
-              cache: true,
-            }).then(function(result) {
-              cb(result && result.items || []);
-            }).catch(function(error) {
-              console.error(error);
-              cb([]);
-            });
-          }, 500, {leading: false}),
-        }
-      );
-      input.bind('typeahead:selected', function(event, data) {
-        const en = data.name;
-        const ja = getJaName(data) || en;
-        const id = data.id;
-        $('.file-institution-en').typeahead('val', en).change();
-        $('.file-institution-ja').typeahead('val', ja).change();
-        $('.file-institution-identifier').val(id).change();
-      });
-      container.find('.twitter-typeahead').css('width', '100%');
-      if (onChange) {
-        input.change(function(event) {
-          onChange(event, options);
-        });
-      }
-      return container;
-    },
-    getValue: function(container) {
-      return container.find('input').val();
-    },
-    setValue: function(container, value) {
-      container.find('input').val(value);
-    },
-    reset: function(container) {
-      container.find('input').val(null);
-    },
-    disable: function(container, disabled) {
-      container.find('input').attr('disabled', disabled);
-    },
-  };
-}
-
-
-function substringMatcher(candidates) {
-  return function findMatches(q, cb) {
-    const substrRegex = new RegExp(q, 'i');
-    const matches = (candidates || []).filter(function(c) {
-      if (!c.kenkyusha_no) {
-        return false;
-      }
-      return substrRegex.test(c.kenkyusha_no);
-    });
-    cb(matches);
-  };
-}
-
-function generateDataNo(fileMetadataSuggestion, fileitem) {
+function suggestForTypeahead(question, templateSuggestions, keyword, options) {
+  const fileitem = options.fileitem;
   const itemUrl = fangorn.getPersistentLinkFor(fileitem);
   const filepath = itemUrl.substr(itemUrl.indexOf('files/'));
-  const format = 'data_format_number';
-  return fileMetadataSuggestion.suggest(filepath, format)
-    .then(function (suggestions) {
-      return (suggestions.find(function (s) { return s.format === format}) || {}).value;
+  const keys = templateSuggestions.map(function (suggestion) { return suggestion.key; });
+  return requestSuggestion(filepath, keys, keyword)
+    .then(function (results) {
+      return results.map(function (result) {
+        const suggestion = templateSuggestions.find(function (s) { return s.key === result.key; });
+        if (!suggestion) {
+          return null;
+        }
+        const template = Object.keys(result.value).reduce(function (template, key) {
+          return template.replaceAll('{{' + key + '}}', result.value[key]);
+        }, suggestion.template);
+        const display = result.value.hasOwnProperty(result.key) ?
+          result.value[result.key] :
+          result.value[(suggestion.autofill || {})[question.qid]];
+        return {
+          template: template,
+          display: display,
+          value: result.value,
+          suggestion: suggestion,
+        }
+      }).filter(function(result) {
+        return result;
+      });
     });
 }
 
+function createSuggestionButton(question, buttonSuggestions, options, onSuggested, enteredValue) {
+  const suggestionContainer = $('<div>')
+    .css('margin', 'auto 0 auto 8px');
+  buttonSuggestions.forEach(function(suggestion) {
+    const errorContainer = $('<span>')
+      .css('color', 'red').hide();
+    const indicator = $('<i class="fa fa-spinner fa-pulse">')
+      .hide();
+    const button = $('<a class="btn btn-default btn-sm">')
+      .append($('<i class="fa fa-refresh"></i>'))
+      .append($('<span></span>').text(getLocalizedText(suggestion.button)))
+      .append(indicator);
+    var processing = false;
+    button.on('click', function (e) {
+      e.preventDefault();
+      if (enteredValue() && !window.confirm(_('Overwrite already entered value?'))) {
+        return;
+      }
+      if (!processing) {
+        processing = true;
+        button.attr('disabled', true);
+        errorContainer.hide().text('');
+        indicator.show();
+        suggestForButton(question, suggestion, options)
+          .then(function (value) {
+            onSuggested(value);
+          })
+          .catch(function (err) {
+            console.error(err);
+            Raven.captureMessage(_('Could not list files'), {
+              extra: {
+                error: err.toString()
+              }
+            });
+            errorContainer.text('Suggestion error: ' + err).show();
+          })
+          .then(function () {
+            processing = false;
+            button.attr('disabled', false);
+            indicator.hide();
+          });
+      }
+    });
+    suggestionContainer
+      .append(button)
+      .append(errorContainer);
+  });
+  return suggestionContainer;
+}
+
+
+// helper
+
+function evaluateCond(cond, questionFields) {
+  const values = {};
+  questionFields.forEach(function(field) {
+    const value = field.getValue();
+    if (value != null && value !== '') {
+      values[field.question.qid] = value;
+    }
+  });
+  return sift(cond)(values);
+}
+
+
 module.exports = {
-  createField: createField,
-  validateField: validateField
+  QuestionPage: QuestionPage,
 };

--- a/addons/metadata/static/metadata-fields.js
+++ b/addons/metadata/static/metadata-fields.js
@@ -209,11 +209,11 @@ const QuestionField = oop.extend(Emitter, {
         .append(self.clearField)
         .append(clearLabel);
       self.clearField.on('change', function() {
-        if (self.clearField.checked()) {
-          self.formField.reset(input);
-          self.formField.disable(input, true);
+        if (self.clearField.prop('checked')) {
+          self.formField.reset();
+          self.formField.disable(true);
         } else {
-          self.formField.disable(input, false);
+          self.formField.disable(false);
         }
       });
       header.append(clearFormBlock);
@@ -274,7 +274,7 @@ const QuestionField = oop.extend(Emitter, {
 
   checkedClear: function() {
     const self = this;
-    return self.clearField && self.clearField.checked;
+    return self.clearField && self.clearField.prop('checked');
   },
 
   showError: function() {
@@ -316,10 +316,12 @@ function createFormField(question, options, value) {
     formField = new TextFormField(question, options);
   }
   formField.create();
-  try {
-    formField.setValue(value);
-  } catch (error) {
-    console.error('Cannot set default value for question ' + question.qid + ': ' + error.message, value);
+  if (value != null && value !== '') {
+    try {
+      formField.setValue(value);
+    } catch (error) {
+      console.error('Cannot set default value for question ' + question.qid + ': ' + error.message, value);
+    }
   }
   return formField;
 }
@@ -733,7 +735,7 @@ const ArrayFormField = oop.extend(FormFieldInterface, {
         res.push(row);
       }
     });
-    return res;
+    return res.length ? res : null;
   },
 
   setValue: function(value) {
@@ -832,7 +834,7 @@ const ObjectFormField = oop.extend(FormFieldInterface, {
     const self = this;
     self.reset();
     var rows = value || {};
-    if (typeof(value) === 'string') {
+    if (value && typeof value === 'string') {
       rows = JSON.parse(value);
     }
     self.fields.forEach(function(subquestion) {

--- a/addons/metadata/static/util.js
+++ b/addons/metadata/static/util.js
@@ -1,0 +1,38 @@
+const rdmGettext = require('js/rdmGettext');
+
+function getLocalizedText(text) {
+  if (!text) {
+    return text;
+  }
+  if (!text.includes('|')) {
+    return text;
+  }
+  const texts = text.split('|');
+  if (rdmGettext.getBrowserLang() === 'ja') {
+    return texts[0];
+  }
+  return texts[1];
+}
+
+function normalizeText(value) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function sizeofFormat(num) {
+  // ref: website/project/util.py sizeof_fmt()
+  const units = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z'];
+  for (var i = 0; i < units.length; i ++) {
+    const unit = units[i];
+    if (Math.abs(num) < 1000) {
+      return Math.round(num * 10) / 10 + unit + 'B';
+    }
+    num /= 1000.0
+  }
+  return Math.round(num * 10) / 10 + 'YB';
+}
+
+module.exports = {
+  getLocalizedText: getLocalizedText,
+  normalizeText: normalizeText,
+  sizeofFormat: sizeofFormat,
+};

--- a/addons/metadata/suggestion.py
+++ b/addons/metadata/suggestion.py
@@ -1,0 +1,166 @@
+import logging
+
+import requests
+from rest_framework import status as http_status
+
+from framework.exceptions import HTTPError
+from osf.models import BaseFileNode
+from osf.models.files import UnableToResolveFileClass
+from osf.utils.fields import EncryptedTextField, EncryptedJSONField
+from . import SHORT_NAME
+from .models import ERadRecord
+
+logger = logging.getLogger(__name__)
+
+
+ERAD_COLUMNS = [
+    'KENKYUSHA_NO', 'KENKYUSHA_SHIMEI', 'KENKYUKIKAN_CD', 'KENKYUKIKAN_MEI',
+    'HAIBUNKIKAN_CD', 'HAIBUNKIKAN_MEI', 'NENDO', 'SEIDO_CD', 'SEIDO_MEI',
+    'JIGYO_CD', 'JIGYO_MEI', 'KADAI_ID', 'KADAI_MEI', 'BUNYA_CD', 'BUNYA_MEI',
+    'JAPAN_GRANT_NUMBER', 'PROGRAM_NAME_JA', 'PROGRAM_NAME_EN', 'FUNDING_STREAM_CODE',
+]
+
+ROR_URL = 'https://api.ror.org/organizations'
+
+
+def valid_suggestion_key(key):
+    if key == 'file-data-number':
+        return True
+    elif key == 'ror':
+        return True
+    elif key.startswith('erad:'):
+        return True
+    elif key.startswith('asset:'):
+        return True
+    return False
+
+
+def suggestion_metadata(key, keyword, filepath, node):
+    suggestions = []
+    if key == 'file-data-number':
+        suggestions.extend(suggestion_file_data_number(key, filepath, node))
+    elif key == 'ror':
+        suggestions.extend(suggestion_ror(key, keyword))
+    elif key.startswith('erad:'):
+        suggestions.extend(suggestion_erad(key, keyword, node))
+    elif key.startswith('asset:'):
+        suggestions.extend(suggestion_asset(key, keyword, node))
+    else:
+        raise KeyError('Invalid key: {}'.format(key))
+    return suggestions
+
+
+def suggestion_file_data_number(key, filepath, node):
+    parts = filepath.split('/')
+    is_dir = parts[0] == 'dir'
+    if is_dir:
+        value = 'files/{}'.format(filepath)
+    else:
+        provider = parts[0]
+        path = '/'.join(parts[1:])
+        try:
+            file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).get_or_create(node, path)
+        except UnableToResolveFileClass:
+            raise HTTPError(http_status.HTTP_404_NOT_FOUND)
+        guid = file_node.get_guid(create=True)
+        guid.referent.save()
+        value = guid._id
+    return [{
+        'key': key,
+        'value': value,
+    }]
+
+
+def suggestion_ror(key, keyword):
+    response = requests.get(
+        ROR_URL,
+        params={
+            'query': keyword,
+        }
+    )
+    response.raise_for_status()
+    res = []
+    for item in response.json()['items']:
+        labels = item.get('labels', [])
+        name_ja = next((l['label'] for l in labels if l['iso639'] == 'ja'), item['name'])
+        res.append({
+            'key': key,
+            'value': {
+                **item,
+                'name-ja': name_ja,
+            }
+        })
+    return res
+
+
+def suggestion_erad(key, keyword, node):
+    filter_field_name = key[5:]
+    filter_field = ERadRecord._meta.get_field(filter_field_name)
+    if isinstance(filter_field, EncryptedTextField) or isinstance(filter_field, EncryptedJSONField):
+        # cannot filter by encrypted field
+        candidates = [
+            r
+            for r in _erad_candidates_for_node(node)
+            if keyword.lower() in r[filter_field_name].lower()
+        ]
+    else:
+        candidates = _erad_candidates_for_node(node, **{f'{filter_field_name}__icontains': keyword})
+    res = []
+    for candidate in candidates:
+        names = candidate.get('kenkyusha_shimei', '').split('|')
+        ja_parts = names[:len(names) // 2]
+        en_parts = names[len(names) // 2:]
+        kikan_parts = candidate.get('kenkyukikan_mei', '').split('|')
+        kikan_ja = kikan_parts[0]
+        kikan_en = kikan_parts[1] if len(kikan_parts) > 1 else ''
+        res.append({
+            'key': key,
+            'value': {
+                **candidate,
+                'kenkyusha_shimei_ja': {
+                    'last': ja_parts[0],
+                    'middle': ''.join(ja_parts[1:-1]),
+                    'first': ja_parts[-1],
+                },
+                'kenkyusha_shimei_en': {
+                    'last': en_parts[0] if len(en_parts) > 0 else '',
+                    'middle': ''.join(en_parts[1:-1]),
+                    'first': en_parts[-1] if len(en_parts) > 0 else '',
+                },
+                'kenkyukikan_mei_ja': kikan_ja,
+                'kenkyukikan_mei_en': kikan_en,
+            },
+        })
+    return res
+
+
+def _erad_candidates_for_node(node, **pred):
+    return sum([  # flatten
+        _erad_candidates(**{**pred, 'kenkyusha_no': user.erad})
+        for user in node.contributors
+        if user.erad is not None
+    ], [])
+
+
+def _erad_candidates(**pred):
+    return [
+        dict([
+            (k.lower(), getattr(record, k.lower()))
+            for k in ERAD_COLUMNS
+        ])
+        for record in ERadRecord.objects.filter(**pred)
+    ]
+
+
+def suggestion_asset(key, keyword, node):
+    addon = node.get_addon(SHORT_NAME)
+    assets = addon.get_metadata_assets()
+    res = []
+    for asset in assets:
+        key_target = asset.get(key[6:], '').lower()
+        if len(key_target) > 0 and keyword in key_target:
+            res.append({
+                'key': key,
+                'value': asset,
+            })
+    return res

--- a/addons/metadata/tests/test_model.py
+++ b/addons/metadata/tests/test_model.py
@@ -19,6 +19,8 @@ class TestNodeSettings(unittest.TestCase):
 
     def setUp(self):
         super(TestNodeSettings, self).setUp()
+        self.mock_fetch_metadata_asset_files = mock.patch('addons.metadata.models.fetch_metadata_asset_files')
+        self.mock_fetch_metadata_asset_files.start()
         self.node = ProjectFactory()
         self.user = self.node.creator
 
@@ -29,6 +31,7 @@ class TestNodeSettings(unittest.TestCase):
         super(TestNodeSettings, self).tearDown()
         self.node.delete()
         self.user.delete()
+        self.mock_fetch_metadata_asset_files.stop()
 
     @mock.patch('website.search.search.update_file_metadata')
     def test_set_invalid_file_metadata(self, mock_update_file_metadata):

--- a/addons/metadata/tests/test_model.py
+++ b/addons/metadata/tests/test_model.py
@@ -755,8 +755,13 @@ class TestNodeSettings(unittest.TestCase):
 class TestFileMetadata(unittest.TestCase):
 
     def setUp(self):
+        self.mock_fetch_metadata_asset_files = mock.patch('addons.metadata.models.fetch_metadata_asset_files')
+        self.mock_fetch_metadata_asset_files.start()
         self.node = ProjectFactory()
         self.node_settings = NodeSettingsFactory(owner=self.node)
+
+    def tearDown(self):
+        self.mock_fetch_metadata_asset_files.stop()
 
     def test_duplicated_file_metadata(self):
         FileMetadata.objects.create(

--- a/addons/metadata/tests/test_suggestion.py
+++ b/addons/metadata/tests/test_suggestion.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 class TestSuggestion(BaseAddonTestCase, OsfTestCase):
 
     def setUp(self):
+        self.mock_fetch_metadata_asset_files = mock.patch('addons.metadata.models.fetch_metadata_asset_files')
+        self.mock_fetch_metadata_asset_files.start()
         super(TestSuggestion, self).setUp()
         self.erad = ERadRecord.objects.create(
             kenkyusha_no='0123456',
@@ -30,9 +32,10 @@ class TestSuggestion(BaseAddonTestCase, OsfTestCase):
         self.project.save()
 
     def tearDown(self):
-        super(TestSuggestion, self).tearDown()
         self.erad.delete()
         self.contributor.delete()
+        super(TestSuggestion, self).tearDown()
+        self.mock_fetch_metadata_asset_files.stop()
 
     @mock.patch('addons.metadata.suggestion.requests')
     def test_suggestion_ror(self, mock_requests):

--- a/addons/metadata/tests/test_suggestion.py
+++ b/addons/metadata/tests/test_suggestion.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+import logging
+import mock
+from nose.tools import *  # noqa
+
+from tests.base import OsfTestCase
+from osf_tests.factories import UserFactory
+
+from .utils import BaseAddonTestCase
+from addons.metadata.suggestion import suggestion_metadata
+from addons.metadata.models import ERadRecord
+
+
+logger = logging.getLogger(__name__)
+
+
+class TestSuggestion(BaseAddonTestCase, OsfTestCase):
+
+    def setUp(self):
+        super(TestSuggestion, self).setUp()
+        self.erad = ERadRecord.objects.create(
+            kenkyusha_no='0123456',
+            kenkyusha_shimei='姓|名|Last|First',
+            kenkyukikan_mei='研究機関名|Research Institute Name',
+        )
+        self.erad.save()
+
+        self.contributor = UserFactory()
+        self.project.add_contributor(self.contributor)
+        self.project.save()
+
+    def tearDown(self):
+        super(TestSuggestion, self).tearDown()
+        self.erad.delete()
+        self.contributor.delete()
+
+    @mock.patch('addons.metadata.suggestion.requests')
+    def test_suggestion_ror(self, mock_requests):
+        ror_data = {
+            'items': [
+                {
+                    'id': 'https://ror.org/0123456789',
+                    'name': 'Example University',
+                    'labels': [{
+                        'label': 'EXAMPLE UNIV.',
+                        'iso639': 'ja',
+                    }],
+                },
+            ],
+        }
+        mock_requests.get.return_value = mock.Mock(status_code=200, json=lambda: ror_data)
+        r = suggestion_metadata('ror', 'searchkey', None, self.project)
+        logger.info('ror suggestion: {}'.format(r))
+
+        assert len(r) == 1
+        assert r[0]['key'] == 'ror'
+        assert r[0]['value']['id'] == 'https://ror.org/0123456789'
+        assert r[0]['value']['name'] == 'Example University'
+        assert r[0]['value']['name-ja'] == 'EXAMPLE UNIV.'
+        assert len(r[0]['value']['labels']) == 1
+        assert r[0]['value']['labels'][0]['label'] == 'EXAMPLE UNIV.'
+        assert r[0]['value']['labels'][0]['iso639'] == 'ja'
+
+        mock_requests.get.assert_called_once()
+        assert mock_requests.get.call_args[1]['params']['query'] == 'searchkey'
+
+    def test_suggestion_erad(self):
+        r = suggestion_metadata('erad:kenkyusha_no', '0', None, self.project)
+        logger.info('erad suggestion: {}'.format(r))
+        assert len(r) == 0
+
+        self.user.erad = '0123456'
+        self.user.save()
+
+        r = suggestion_metadata('erad:kenkyusha_no', '0', None, self.project)
+        logger.info('erad suggestion: {}'.format(r))
+        assert len(r) == 1
+        assert r[0]['key'] == 'erad:kenkyusha_no'
+        assert r[0]['value']['kenkyusha_no'] == '0123456'
+        assert r[0]['value']['kenkyusha_shimei'] == '姓|名|Last|First'
+        assert r[0]['value']['kenkyusha_shimei_ja'] == {
+            'last': '姓',
+            'middle': '',
+            'first': '名',
+        }
+        assert r[0]['value']['kenkyusha_shimei_en'] == {
+            'last': 'Last',
+            'middle': '',
+            'first': 'First',
+        }
+        assert r[0]['value']['kenkyusha_shimei_ja_msfullname'] == '姓名'
+        assert r[0]['value']['kenkyusha_shimei_en_msfullname'] == 'First Last'
+        assert r[0]['value']['kenkyukikan_mei_ja'] == '研究機関名'
+        assert r[0]['value']['kenkyukikan_mei_en'] == 'Research Institute Name'
+
+    def test_suggestion_contributors(self):
+        self.user.erad = ''
+        self.user.family_name = 'Family'
+        self.user.middle_names = ''
+        self.user.given_name = 'Given'
+        self.user.family_name_ja = '姓'
+        self.user.middle_names_ja = ''
+        self.user.given_name_ja = '名'
+        self.user.save()
+
+        self.contributor.erad = '0123456'
+        self.contributor.family_name = 'Family2'
+        self.contributor.middle_names = 'Middle2'
+        self.contributor.given_name = 'Given2'
+        self.contributor.family_name_ja = '姓2'
+        self.contributor.middle_names_ja = '中間2'
+        self.contributor.given_name_ja = '名2'
+        self.contributor.save()
+
+        r = suggestion_metadata('contributor:erad', '0', None, self.project)
+        logger.info('contributors suggestion: {}'.format(r))
+        assert len(r) == 1
+        assert r[0]['key'] == 'contributor:erad'
+        assert r[0]['value']['erad'] == '0123456'
+        assert r[0]['value']['name-ja-full'] == '姓2|中間2|名2'
+        assert r[0]['value']['name-en-full'] == 'Family2|Middle2|Given2'
+        assert r[0]['value']['name-ja'] == {
+            'last': '姓2',
+            'middle': '中間2',
+            'first': '名2',
+        }
+        assert r[0]['value']['name-en'] == {
+            'last': 'Family2',
+            'middle': 'Middle2',
+            'first': 'Given2',
+        }
+        assert r[0]['value']['name-ja-msfullname'] == '姓2中間2名2'
+        assert r[0]['value']['name-en-msfullname'] == 'Given2 Middle2 Family2'
+
+        r = suggestion_metadata('contributor:erad', '', None, self.project)
+        logger.info('contributors suggestion: {}'.format(r))
+        assert len(r) == 2
+        assert r[0]['key'] == 'contributor:erad'
+        assert r[0]['value']['erad'] == ''
+        assert r[0]['value']['name-ja-full'] == '姓|名'
+        assert r[0]['value']['name-en-full'] == 'Family|Given'
+        assert r[0]['value']['name-ja'] == {
+            'last': '姓',
+            'middle': '',
+            'first': '名',
+        }
+        assert r[0]['value']['name-en'] == {
+            'last': 'Family',
+            'middle': '',
+            'first': 'Given',
+        }
+        assert r[0]['value']['name-ja-msfullname'] == '姓名'
+        assert r[0]['value']['name-en-msfullname'] == 'Given Family'
+        assert r[1]['key'] == 'contributor:erad'
+        assert r[1]['value']['erad'] == '0123456'
+        assert r[1]['value']['name-ja-full'] == '姓2|中間2|名2'
+        assert r[1]['value']['name-en-full'] == 'Family2|Middle2|Given2'
+        assert r[1]['value']['name-ja'] == {
+            'last': '姓2',
+            'middle': '中間2',
+            'first': '名2',
+        }
+        assert r[1]['value']['name-en'] == {
+            'last': 'Family2',
+            'middle': 'Middle2',
+            'first': 'Given2',
+        }
+        assert r[1]['value']['name-ja-msfullname'] == '姓2中間2名2'
+        assert r[1]['value']['name-en-msfullname'] == 'Given2 Middle2 Family2'

--- a/addons/metadata/utils.py
+++ b/addons/metadata/utils.py
@@ -34,6 +34,30 @@ def _convert_metadata_grdm_files(value, questions):
         r.append(obj)
     return r
 
+def _to_jinja_dict(value):
+    if value is None:
+        return value
+    if not isinstance(value, dict):
+        return value
+    r = {}
+    r.update(value)
+    for key in value.keys():
+        r[key.replace('-', '_')] = value[key]
+    return r
+
+def _to_jinja_list(value):
+    if value is None:
+        return value
+    if not isinstance(value, list):
+        return value
+    r = []
+    for v in value:
+        if isinstance(v, dict):
+            r.append(_to_jinja_dict(v))
+            continue
+        r.append(v)
+    return r
+
 def _convert_metadata_value(key, value, questions):
     if 'value' not in value:
         return [('', value)]
@@ -44,6 +68,12 @@ def _convert_metadata_value(key, value, questions):
             questions[key]['type'] == 'string' and 'format' in questions[key] and \
             questions[key]['format'] == 'file-creators':
         return [('', json.loads(v) if v != '' else [])]
+    if key in questions and 'type' in questions[key] and \
+            questions[key]['type'] == 'object':
+        return [('', _to_jinja_dict(v))]
+    if key in questions and 'type' in questions[key] and \
+            questions[key]['type'] == 'array':
+        return [('', _to_jinja_list(v))]
     if key in questions and 'type' in questions[key] and \
             questions[key]['type'] == 'choose' and 'options' in questions[key]:
         values = [('', v)]

--- a/addons/metadata/views.py
+++ b/addons/metadata/views.py
@@ -7,12 +7,12 @@ from flask import make_response
 import logging
 
 from . import SHORT_NAME
-from .models import ERadRecord, RegistrationReportFormat, get_draft_files, FIELD_GRDM_FILES, schema_has_field
+from .models import RegistrationReportFormat, get_draft_files, FIELD_GRDM_FILES, schema_has_field
 from .utils import make_report_as_csv
+from .suggestion import suggestion_metadata, _erad_candidates, valid_suggestion_key
 from framework.exceptions import HTTPError
 from framework.auth.decorators import must_be_logged_in
-from osf.models import AbstractNode, DraftRegistration, Registration, BaseFileNode
-from osf.models.files import UnableToResolveFileClass
+from osf.models import AbstractNode, DraftRegistration, Registration
 from osf.models.metaschema import RegistrationSchema
 from osf.utils.permissions import WRITE
 from website.project.decorators import (
@@ -25,13 +25,6 @@ from website.ember_osf_web.views import use_ember_app
 
 
 logger = logging.getLogger(__name__)
-
-ERAD_COLUMNS = [
-    'KENKYUSHA_NO', 'KENKYUSHA_SHIMEI', 'KENKYUKIKAN_CD', 'KENKYUKIKAN_MEI',
-    'HAIBUNKIKAN_CD', 'HAIBUNKIKAN_MEI', 'NENDO', 'SEIDO_CD', 'SEIDO_MEI',
-    'JIGYO_CD', 'JIGYO_MEI', 'KADAI_ID', 'KADAI_MEI', 'BUNYA_CD', 'BUNYA_MEI',
-    'JAPAN_GRANT_NUMBER', 'PROGRAM_NAME_JA', 'PROGRAM_NAME_EN', 'FUNDING_STREAM_CODE',
-]
 
 
 def _response_project_metadata(user, addon):
@@ -65,13 +58,6 @@ def _response_schemas(addon, schemas):
         }
     }
 
-def _erad_candidates(researcher_number):
-    r = []
-    for record in ERadRecord.objects.filter(kenkyusha_no=researcher_number):
-        r.append(dict([(k.lower(), getattr(record, k.lower()))
-                       for k in ERAD_COLUMNS]))
-    return r
-
 def _get_file_metadata_for_schema(schema_id, file_metadata):
     assert not file_metadata['generated']
     items = [item for item in file_metadata['items'] if item['schema'] == schema_id]
@@ -104,7 +90,7 @@ def metadata_get_erad_candidates(auth, **kwargs):
         rn = user.erad
         if rn is None:
             continue
-        candidates += _erad_candidates(rn)
+        candidates += _erad_candidates(kenkyusha_no=rn)
     return {
         'data': {
             'id': node._id,
@@ -326,42 +312,21 @@ def metadata_export_registrations_csv(auth, rid=None, **kwargs):
 @must_be_valid_project
 @must_be_logged_in
 @must_have_permission('write')
+@must_have_addon(SHORT_NAME, 'node')
 def metadata_file_metadata_suggestions(auth, filepath=None, **kwargs):
-    format_list = request.args.get('format', None)
+    key_list = request.args.getlist('key[]', None) or request.args.get('key', None)
+    if key_list is None:
+        raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
+    if type(key_list) is str:
+        key_list = [key_list]
+    if any([not valid_suggestion_key(key) for key in key_list]):
+        raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
+    keyword = request.args.get('keyword', '').lower()
     node = kwargs['node'] or kwargs['project']
-    parts = filepath.split('/')
-    is_dir = parts[0] == 'dir'
-    if is_dir:
-        provider = parts[1]
-        path = '/'.join(parts[2:])
-        file_node = None
-    else:
-        provider = parts[0]
-        path = '/'.join(parts[1:])
-        try:
-            file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).get_or_create(node, path)
-        except UnableToResolveFileClass:
-            raise HTTPError(http_status.HTTP_404_NOT_FOUND)
-
-    suggestions = []
-    if format_list is None:
-        format_list = ['data_format_number']
-    elif type(format_list) is str:
-        format_list = [format_list]
-    for format in format_list:
-        if format == 'data_format_number':
-            if file_node is None:
-                value = 'files/{}'.format(filepath)
-            else:
-                guid = file_node.get_guid(create=True)
-                guid.referent.save()
-                value = guid._id
-        else:
-            raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
-        suggestions.append({
-            'format': format,
-            'value': value,
-        })
+    suggestions = sum([  # flatten
+        suggestion_metadata(key, keyword, filepath, node)
+        for key in key_list
+    ], [])
     return {
         'data': {
             'id': node._id,

--- a/admin/rdm_metadata/erad.py
+++ b/admin/rdm_metadata/erad.py
@@ -3,7 +3,7 @@ from io import StringIO
 import logging
 import os
 from addons.metadata.models import ERadRecordSet
-from addons.metadata.views import ERAD_COLUMNS
+from addons.metadata.suggestion import ERAD_COLUMNS
 
 
 logger = logging.getLogger(__name__)

--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -44,6 +44,10 @@ class RegistrationSchemaBlockSerializer(JSONAPISerializer):
     default = ser.BooleanField(read_only=True)
     pattern = ser.CharField(read_only=True)
     space_normalization = ser.BooleanField(read_only=True)
+    required_if = ser.CharField(read_only=True)
+    message_required_if = ser.CharField(read_only=True)
+    enabled_if = ser.CharField(read_only=True)
+    suggestion = ser.CharField(read_only=True)
     index = ser.IntegerField(read_only=True, source='_order')
 
     links = LinksField({

--- a/osf/migrations/0233_add_columns_to_registration_schema_block.py
+++ b/osf/migrations/0233_add_columns_to_registration_schema_block.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
+
+
+def ensure_registration_reports(*args):
+    from api.base import settings
+    from addons.metadata import FULL_NAME
+    from addons.metadata.utils import ensure_registration_report
+    from addons.metadata.report_format import REPORT_FORMATS
+    if FULL_NAME not in settings.INSTALLED_APPS:
+        return
+    for schema_name, report_name, csv_template in REPORT_FORMATS:
+        ensure_registration_report(schema_name, report_name, csv_template)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0232_auto_20230830_0425'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='registrationschemablock',
+            name='required_if',
+            field=models.TextField(null=True),
+        ),
+        migrations.AddField(
+            model_name='registrationschemablock',
+            name='message_required_if',
+            field=models.TextField(null=True),
+        ),
+        migrations.AddField(
+            model_name='registrationschemablock',
+            name='enabled_if',
+            field=models.TextField(null=True),
+        ),
+        migrations.AddField(
+            model_name='registrationschemablock',
+            name='suggestion',
+            field=models.TextField(null=True),
+        ),
+        UpdateRegistrationSchemasAndSchemaBlocks(),
+        migrations.RunPython(ensure_registration_reports, ensure_registration_reports),
+    ]

--- a/osf/migrations/0236_add_columns_to_registration_schema_block.py
+++ b/osf/migrations/0236_add_columns_to_registration_schema_block.py
@@ -18,7 +18,7 @@ def ensure_registration_reports(*args):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('osf', '0232_auto_20230830_0425'),
+        ('osf', '0235_ensure_schema_and_reports'),
     ]
 
     operations = [

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -192,6 +192,10 @@ class RegistrationSchemaBlock(ObjectIDMixin, BaseModel):
     default = models.BooleanField(default=False)
     pattern = models.CharField(max_length=255, null=True)
     space_normalization = models.BooleanField(default=False)
+    required_if = models.TextField(null=True)
+    message_required_if = models.TextField(null=True)
+    enabled_if = models.TextField(null=True)
+    suggestion = models.TextField(null=True)
 
     @property
     def absolute_api_v2_url(self):

--- a/osf/models/validators.py
+++ b/osf/models/validators.py
@@ -320,6 +320,7 @@ class RegistrationResponsesValidator:
         properties = {
             question.registration_response_key: self._build_question_schema(question)
             for question in questions
+            if self._build_question_schema(question) is not None
         }
 
         json_schema = {
@@ -431,6 +432,8 @@ class RegistrationResponsesValidator:
                     'type': 'string',
                     'description': question_text,
                 }
+        elif question.block_type == 'section-heading' or question.block_type == 'subsection-heading':
+            return None
 
         raise ValueError('Unexpected `block_type`: {}'.format(question.block_type))
 

--- a/osf/models/validators.py
+++ b/osf/models/validators.py
@@ -420,7 +420,8 @@ class RegistrationResponsesValidator:
                                      'file-data-number-input',
                                      'file-url-input', 'file-institution-ja-input',
                                      'file-institution-en-input',
-                                     'file-institution-id-input'):
+                                     'file-institution-id-input',
+                                     'array-input'):
             if self.required_fields and question.required:
                 return {
                     'type': 'string',

--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -53,13 +53,15 @@ FORMAT_TYPE_TO_TYPE_MAP = {
     ('e-rad-bunnya', 'string'): 'e-rad-bunnya-input',
     ('file-metadata', 'string'): 'file-metadata-input',
     ('date', 'string'): 'date-input',
-    ('file-capacity', 'string'): 'file-capacity-input',
-    ('file-creators', 'string'): 'file-creators-input',
-    ('file-data-number', 'string'): 'file-data-number-input',
-    ('file-url', 'string'): 'file-url-input',
-    ('file-institution-ja', 'string'): 'file-institution-ja-input',
-    ('file-institution-en', 'string'): 'file-institution-en-input',
-    ('file-institution-identifier', 'string'): 'file-institution-id-input',
+    # deprecated format types are mapped to the simple text type
+    ('file-capacity', 'string'): 'short-text-input',
+    ('file-creators', 'string'): 'long-text-input',
+    ('file-data-number', 'string'): 'short-text-input',
+    ('file-title', 'string'): 'short-text-input',
+    ('file-url', 'string'): 'short-text-input',
+    ('file-institution-ja', 'string'): 'short-text-input',
+    ('file-institution-en', 'string'): 'short-text-input',
+    ('file-institution-identifier', 'string'): 'short-text-input',
 }
 
 def get_osf_models():
@@ -216,7 +218,8 @@ def remove_schemas(*args):
 
 def create_schema_block(state, schema_id, block_type, display_text='', required=False, help_text='',
         registration_response_key=None, schema_block_group_key='', example_text='',
-        default=False, pattern=None, space_normalization=False):
+        default=False, pattern=None, space_normalization=False, required_if=None,
+        message_required_if=None, enabled_if=None, suggestion=None):
     """
     For mapping schemas to schema blocks: creates a given block from the specified parameters
     """
@@ -254,6 +257,10 @@ def create_schema_block(state, schema_id, block_type, display_text='', required=
         'default': default,
         'pattern': pattern,
         'space_normalization': space_normalization,
+        'required_if': required_if,
+        'message_required_if': message_required_if,
+        'enabled_if': enabled_if,
+        'suggestion': suggestion,
     }
 
     try:
@@ -421,6 +428,10 @@ def create_schema_blocks_for_question(state, rs, question, sub=False):
             registration_response_key=get_registration_response_key(question),
             pattern=question.get('pattern', None),
             space_normalization=question.get('space_normalization', False),
+            required_if=question.get('required_if', None),
+            message_required_if=question.get('message_required_if', None),
+            enabled_if=question.get('enabled_if', None),
+            suggestion=question.get('suggestion', None),
         )
 
         # If there are multiple choice answers, create blocks for these as well.

--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -378,6 +378,8 @@ def create_schema_blocks_for_question(state, rs, question, sub=False):
                 rs.id,
                 block_type='subsection-heading' if sub else 'section-heading',
                 display_text=question.get('title', '') or question.get('description', ''),
+                schema_block_group_key=generate_object_id(),
+                registration_response_key=get_registration_response_key(question),
             )
         else:
             # the first subquestion has no text, so the "section" heading is better interpreted as a question label

--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -373,14 +373,45 @@ def create_schema_blocks_for_question(state, rs, question, sub=False):
 
         if first_subq_text:
             # the first subquestion has text, so this seems like an actual [sub]section
-            create_schema_block(
-                state,
-                rs.id,
-                block_type='subsection-heading' if sub else 'section-heading',
-                display_text=question.get('title', '') or question.get('description', ''),
-                schema_block_group_key=generate_object_id(),
-                registration_response_key=get_registration_response_key(question),
-            )
+            if question.get('type') == 'array':
+                schema_block_group_key = generate_object_id()
+                create_schema_block(
+                    state,
+                    rs.id,
+                    block_type='subsection-heading' if sub else 'section-heading',
+                    display_text=question.get('title', '') or question.get('description', ''),
+                    schema_block_group_key=schema_block_group_key,
+                )
+                create_schema_block(
+                    state,
+                    rs.id,
+                    block_type='array-input',
+                    schema_block_group_key=schema_block_group_key,
+                    registration_response_key=get_registration_response_key(question),
+                    required=question.get('required', False),
+                    pattern=question.get('pattern', None),
+                    space_normalization=question.get('space_normalization', False),
+                    required_if=question.get('required_if', None),
+                    message_required_if=question.get('message_required_if', None),
+                    enabled_if=question.get('enabled_if', None),
+                    suggestion=question.get('suggestion', None),
+                )
+            else:
+                create_schema_block(
+                    state,
+                    rs.id,
+                    block_type='subsection-heading' if sub else 'section-heading',
+                    display_text=question.get('title', '') or question.get('description', ''),
+                    schema_block_group_key=generate_object_id(),
+                    registration_response_key=get_registration_response_key(question),
+                    required=question.get('required', False),
+                    pattern=question.get('pattern', None),
+                    space_normalization=question.get('space_normalization', False),
+                    required_if=question.get('required_if', None),
+                    message_required_if=question.get('message_required_if', None),
+                    enabled_if=question.get('enabled_if', None),
+                    suggestion=question.get('suggestion', None),
+                )
         else:
             # the first subquestion has no text, so the "section" heading is better interpreted as a question label
             first_subquestion['title'] = question.get('title', '')

--- a/osf/utils/registrations.py
+++ b/osf/utils/registrations.py
@@ -81,6 +81,8 @@ def flatten_registration_metadata(schema, registered_meta):
     registration_responses = {}
     registration_response_keys = schema.schema_blocks.filter(
         registration_response_key__isnull=False
+    ).exclude(
+        block_type__in=('section-heading', 'subsection-heading')
     ).values(
         'registration_response_key',
         'block_type'
@@ -236,6 +238,8 @@ def expand_registration_responses(schema, registration_responses, file_storage_r
     # Pull out all registration_response_keys and their block types
     registration_response_keys = schema.schema_blocks.filter(
         registration_response_key__isnull=False
+    ).exclude(
+        block_type__in=('section-heading', 'subsection-heading')
     ).values(
         'registration_response_key',
         'block_type'

--- a/osf/utils/registrations.py
+++ b/osf/utils/registrations.py
@@ -245,6 +245,7 @@ def expand_registration_responses(schema, registration_responses, file_storage_r
         'block_type'
     )
 
+    array_input_keys = []
     metadata = {}
 
     for registration_response_key_dict in registration_response_keys:
@@ -253,6 +254,11 @@ def expand_registration_responses(schema, registration_responses, file_storage_r
         # ['confirmatory-analyses-further', 'value', 'further', 'value', 'question2c']
         nested_keys = response_key.replace('.', '.value.').split('.')
         block_type = registration_response_key_dict['block_type']
+        if any([response_key.startswith('{}.'.format(k)) for k in array_input_keys]):
+            # skip blocks under array-input
+            continue
+        if block_type == 'array-input':
+            array_input_keys.append(response_key)
 
         # Continues to add to metadata with every registration_response_key
         metadata = build_registration_metadata_dict(

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "pretty-data": "^0.40.0",
     "raw-loader": "^0.5.1",
     "select2": "3.5.1",
+    "sift": "^17.0.1",
     "style-loader": "^0.8.3",
     "treebeard": "https://github.com/CenterForOpenScience/treebeard.git#d2bb8f6f8104fcac040402727f431c26722b269e",
     "typeahead.js": "^0.10.5",

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -144,7 +144,8 @@
           "title": "プロジェクト名 (日本語)|Project name (Japanese)",
           "type": "string",
           "format": "e-rad-award-title-ja",
-          "required": true,
+          "required": false,
+          "required_if": "project-name-en",
           "space_normalization": true
         },
         {
@@ -153,7 +154,8 @@
           "title": "Project name (English)",
           "type": "string",
           "format": "e-rad-award-title-en",
-          "required": true,
+          "required": false,
+          "required_if": "project-name-ja",
           "space_normalization": true
         },
         {
@@ -230,9 +232,15 @@
           "nav": "データ No.",
           "title": "データ No.|Data No.",
           "type": "string",
-          "format": "file-data-number",
+          "format": "text",
           "required": false,
-          "space_normalization": true
+          "space_normalization": true,
+          "suggestion": [
+            {
+              "key": "file-data-number",
+              "button": "入力|Fill"
+            }
+          ]
         },
         {
           "qid": "grdm-file:title-ja",
@@ -240,8 +248,18 @@
           "title": "データの名称 (日本語)|Title (Japanese)",
           "type": "string",
           "format": "text",
-          "required": true,
-          "space_normalization": true
+          "required": false,
+          "required_if": "grdm-file:title-en",
+          "space_normalization": true,
+          "suggestion": [
+            {
+              "key": "asset:title",
+              "template": "<div style=\"background-color: white;\"><span>{{title}}</span></div>",
+              "autofill": {
+                "grdm-file:title-ja": "title"
+              }
+            }
+          ]
         },
         {
           "qid": "grdm-file:title-en",
@@ -249,8 +267,18 @@
           "title": "Title (English)",
           "type": "string",
           "format": "text",
-          "required": true,
-          "space_normalization": true
+          "required": false,
+          "required_if": "grdm-file:title-ja",
+          "space_normalization": true,
+          "suggestion": [
+            {
+              "key": "asset:title",
+              "template": "<div style=\"background-color: white;\"><span>{{title}}</span></div>",
+              "autofill": {
+                "grdm-file:title-en": "title"
+              }
+            }
+          ]
         },
         {
           "qid": "grdm-file:date-issued-updated",
@@ -268,7 +296,8 @@
           "title": "データの説明 (日本語)|Description (Japanese)",
           "type": "string",
           "format": "textarea",
-          "required": true,
+          "required": false,
+          "required_if": "grdm-file:data-description-en",
           "help": "例: 〇〇実証においてセンサより撮像したデータであり、道路の画像データ, 〇〇のシミュレーションにおいて〇〇の条件のもとで得られたデータ, 〇〇への応用が期待できる、〇〇〇〇のゲノム解析と、その効率的な化合物生産に役立てるための発現プロファイル情報"
         },
         {
@@ -277,7 +306,8 @@
           "title": "Description (English)",
           "type": "string",
           "format": "textarea",
-          "required": true
+          "required": false,
+          "required_if": "grdm-file:data-description-ja"
         },
         {
           "qid": "grdm-file:data-research-field",
@@ -410,10 +440,16 @@
           "nav": "概略データ量",
           "title": "概略データ量|File size",
           "type": "string",
-          "format": "file-capacity",
+          "format": "text",
           "required": false,
           "pattern": "^[><]?([0-9]+(\\.[0-9]+)?-)?([0-9]+)(\\.[0-9]+)?([A-Za-z]*B)$",
-          "help": "例: >100GB, <10GB, 100-10MB|E.g., >100GB, <10GB, 100-10MB"
+          "help": "例: >100GB, <10GB, 100-10MB|E.g., >100GB, <10GB, 100-10MB",
+          "suggestion": [
+            {
+              "key": "file-size",
+              "button": "計算|Calculate"
+            }
+          ]
         },
         {
           "qid": "grdm-file:data-policy-free",
@@ -565,7 +601,8 @@
           "title": "管理対象データの利活用・提供方針 (引用方法等・日本語)|Data utilization and provision policy (citation information, Japanese)",
           "type": "string",
           "format": "textarea",
-          "required": true
+          "required": false,
+          "required_if": "grdm-file:data-policy-cite-en"
         },
         {
           "qid": "grdm-file:data-policy-cite-en",
@@ -573,7 +610,8 @@
           "title": "Data utilization and provision policy (citation information, English)",
           "type": "string",
           "format": "textarea",
-          "required": true
+          "required": false,
+          "required_if": "grdm-file:data-policy-cite-ja"
         },
         {
           "qid": "grdm-file:access-rights",
@@ -609,7 +647,11 @@
           "format": "date",
           "required": false,
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-          "help": "例: 2010-01-01|E.g., 2010-01-01"
+          "help": "例: 2010-01-01|E.g., 2010-01-01",
+          "required_if": {
+            "grdm-file:access-rights": "embargoed access"
+          },
+          "message_required_if": "公開期間猶予の場合は必須項目です|This field is required for embargoed access"
         },
         {
           "qid": "grdm-file:repo-information-ja",
@@ -617,7 +659,8 @@
           "title": "リポジトリ情報 (日本語)|Repository information (Japanese)",
           "type": "string",
           "format": "text",
-          "required": true
+          "required": false,
+          "required_if": "grdm-file:repo-information-en"
         },
         {
           "qid": "grdm-file:repo-information-en",
@@ -625,81 +668,433 @@
           "title": "Repository information (English)",
           "type": "string",
           "format": "text",
-          "required": false
+          "required": false,
+          "required_if": "grdm-file:repo-information-ja"
         },
         {
           "qid": "grdm-file:repo-url-doi-link",
           "nav": "リポジトリURL・DOIリンク",
           "title": "リポジトリURL・DOIリンク|Repository URL/ DOI link",
           "type": "string",
-          "format": "file-url",
+          "format": "text",
           "required": false,
           "pattern": "[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)$",
-          "help": "例: https://example.com/example|E.g., https://example.com/example"
+          "help": "例: https://example.com/example|E.g., https://example.com/example",
+          "suggestion": [
+            {
+              "key": "file-url",
+              "button": "入力|Fill"
+            }
+          ]
         },
         {
           "qid": "grdm-file:creators",
           "nav": "データ作成者",
           "title": "データ作成者|Creator Name",
-          "type": "string",
-          "format": "file-creators",
+          "type": "array",
           "required": false,
-          "help": "e-Rad 研究者番号(半角数字)|e-Rad Researcher Number(single-byte numeric characters)"
+          "help": "e-Rad 研究者番号(半角数字)|e-Rad Researcher Number(single-byte numeric characters)",
+          "properties": [
+            {
+              "id": "number",
+              "title": "e-Rad 研究者番号|e-Rad Researcher Number",
+              "type": "string",
+              "format": "text",
+              "required": true,
+              "pattern": "^[0-9a-zA-Z]*$",
+              "space_normalization": true,
+              "suggestion": [
+                {
+                  "key": "erad:kenkyusha_no",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "number": "kenkyusha_no",
+                    "name-ja": "kenkyusha_shimei_ja",
+                    "name-en": "kenkyusha_shimei_en"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "name-ja",
+              "title": "名前(日本語)|Name (Japanese)",
+              "type": "object",
+              "required": false,
+              "required_if": "name-en",
+              "properties": [
+                {
+                  "id": "last",
+                  "title": "姓|Last Name",
+                  "type": "string",
+                  "format": "text",
+                  "required": false,
+                  "space_normalization": true,
+                  "suggestion": [
+                    {
+                      "key": "erad:kenkyusha_shimei",
+                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                      "autofill": {
+                        "../number": "kenkyusha_no",
+                        "../name-ja": "kenkyusha_shimei_ja",
+                        "../name-en": "kenkyusha_shimei_en"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "id": "middle",
+                  "title": "ミドルネーム|Middle Name",
+                  "type": "string",
+                  "format": "text",
+                  "required": false,
+                  "space_normalization": true,
+                  "suggestion": [
+                    {
+                      "key": "erad:kenkyusha_shimei",
+                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                      "autofill": {
+                        "../number": "kenkyusha_no",
+                        "../name-ja": "kenkyusha_shimei_ja",
+                        "../name-en": "kenkyusha_shimei_en"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "id": "first",
+                  "title": "名|First Name",
+                  "type": "string",
+                  "format": "text",
+                  "required": false,
+                  "space_normalization": true,
+                  "suggestion": [
+                    {
+                      "key": "erad:kenkyusha_shimei",
+                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                      "autofill": {
+                        "../number": "kenkyusha_no",
+                        "../name-ja": "kenkyusha_shimei_ja",
+                        "../name-en": "kenkyusha_shimei_en"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "name-en",
+              "title": "Name (English)",
+              "type": "object",
+              "required": false,
+              "required_if": "name-ja",
+              "properties": [
+                {
+                  "id": "last",
+                  "title": "Last Name",
+                  "type": "string",
+                  "format": "text",
+                  "required": false,
+                  "space_normalization": true,
+                  "suggestion": [
+                    {
+                      "key": "erad:kenkyusha_shimei",
+                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                      "autofill": {
+                        "../number": "kenkyusha_no",
+                        "../name-ja": "kenkyusha_shimei_ja",
+                        "../name-en": "kenkyusha_shimei_en"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "id": "middle",
+                  "title": "Middle Name",
+                  "type": "string",
+                  "format": "text",
+                  "required": false,
+                  "space_normalization": true,
+                  "suggestion": [
+                    {
+                      "key": "erad:kenkyusha_shimei",
+                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                      "autofill": {
+                        "../number": "kenkyusha_no",
+                        "../name-ja": "kenkyusha_shimei_ja",
+                        "../name-en": "kenkyusha_shimei_en"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "id": "first",
+                  "title": "First Name",
+                  "type": "string",
+                  "format": "text",
+                  "required": false,
+                  "space_normalization": true,
+                  "suggestion": [
+                    {
+                      "key": "erad:kenkyusha_shimei",
+                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                      "autofill": {
+                        "../number": "kenkyusha_no",
+                        "../name-ja": "kenkyusha_shimei_ja",
+                        "../name-en": "kenkyusha_shimei_en"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "qid": "grdm-file:hosting-inst-ja",
           "nav": "データ管理機関 (日本語)",
           "title": "データ管理機関 (日本語)|Hosting institution (Japanese)",
           "type": "string",
-          "format": "file-institution-ja",
-          "required": true,
-          "space_normalization": true
+          "format": "text",
+          "required": false,
+          "required_if": "grdm-file:hosting-inst-en",
+          "space_normalization": true,
+          "suggestion": [
+            {
+              "key": "ror",
+              "template": "<div style=\"background-color: white;\"><span>{{name}}</span> <span><small class=\"m-l-md text-muted\">{{name-ja}}</small></span></div>",
+              "autofill": {
+                "grdm-file:hosting-inst-ja": "name-ja",
+                "grdm-file:hosting-inst-en": "name",
+                "grdm-file:hosting-inst-id": "id"
+              }
+            }
+          ]
         },
         {
           "qid": "grdm-file:hosting-inst-en",
           "nav": "Hosting institution (English)",
           "title": "Hosting institution (English)",
           "type": "string",
-          "format": "file-institution-en",
-          "required": true,
-          "space_normalization": true
+          "format": "text",
+          "required": false,
+          "required_if": "grdm-file:hosting-inst-ja",
+          "space_normalization": true,
+          "suggestion": [
+            {
+              "key": "ror",
+              "template": "<div style=\"background-color: white;\"><span>{{name}}</span> <span><small class=\"m-l-md text-muted\">{{name-ja}}</small></span></div>",
+              "autofill": {
+                "grdm-file:hosting-inst-ja": "name-ja",
+                "grdm-file:hosting-inst-en": "name",
+                "grdm-file:hosting-inst-id": "id"
+              }
+            }
+          ]
         },
         {
           "qid": "grdm-file:hosting-inst-id",
           "nav": "データ管理機関コード",
           "title": "データ管理機関コード|Hosting institution Identifier",
           "type": "string",
-          "format": "file-institution-identifier",
+          "format": "text",
           "required": false,
           "space_normalization": true
+        },
+        {
+          "qid": "grdm-file:data-man-type",
+          "nav": "データ管理者の種類",
+          "title": "データ管理者の種類|Type of data manager",
+          "type": "choose",
+          "format": "singleselect",
+          "options": [
+            {
+              "text": "individual",
+              "tooltip": "個人|individual"
+            },
+            {
+              "text": "organization",
+              "tooltip": "組織|organization"
+            }
+          ],
+          "required": true
         },
         {
           "qid": "grdm-file:data-man-number",
           "nav": "データ管理者の e-Rad 研究者番号",
           "title": "データ管理者の e-Rad 研究者番号|Data manager identifier (e-Rad)",
           "type": "string",
-          "format": "e-rad-researcher-number",
+          "format": "text",
           "required": false,
           "pattern": "^[a-zA-Z0-9]+$",
-          "help": "e-Rad 研究者番号(半角数字)|e-Rad Researcher Number(single-byte numeric characters)"
+          "help": "e-Rad 研究者番号(半角数字)|e-Rad Researcher Number(single-byte numeric characters)",
+          "enabled_if": {
+            "grdm-file:data-man-type": "individual"
+          },
+          "suggestion": [
+            {
+              "key": "erad:kenkyusha_no",
+              "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+              "autofill": {
+                "grdm-file:data-man-number": "kenkyusha_no",
+                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                "grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+              }
+            }
+          ]
         },
         {
           "qid": "grdm-file:data-man-name-ja",
           "nav": "データ管理者 (日本語)",
           "title": "データ管理者 (日本語)|Data manager (Japanese)",
-          "type": "string",
-          "format": "e-rad-researcher-name-ja",
-          "required": true,
-          "space_normalization": true
+          "type": "object",
+          "required": false,
+          "required_if": "grdm-file:data-man-name-en",
+          "enabled_if": {
+            "grdm-file:data-man-type": "individual"
+          },
+          "properties": [
+            {
+              "id": "last",
+              "title": "姓|Last Name",
+              "type": "string",
+              "format": "text",
+              "required": false,
+              "space_normalization": true,
+              "suggestion": [
+                {
+                  "key": "erad:kenkyusha_shimei",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "kenkyusha_no",
+                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "middle",
+              "title": "ミドルネーム|Middle Name",
+              "type": "string",
+              "format": "text",
+              "required": false,
+              "space_normalization": true,
+              "suggestion": [
+                {
+                  "key": "erad:kenkyusha_shimei",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "kenkyusha_no",
+                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "first",
+              "title": "名|First Name",
+              "type": "string",
+              "format": "text",
+              "required": false,
+              "space_normalization": true,
+              "suggestion": [
+                {
+                  "key": "erad:kenkyusha_shimei",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "kenkyusha_no",
+                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+                  }
+                }
+              ]
+            }
+          ]
         },
         {
           "qid": "grdm-file:data-man-name-en",
           "nav": "Data manager (English)",
           "title": "Data manager (English)",
-          "type": "string",
-          "format": "e-rad-researcher-name-en",
-          "required": true,
-          "space_normalization": true
+          "type": "object",
+          "required": false,
+          "required_if": "grdm-file:data-man-name-ja",
+          "enabled_if": {
+            "grdm-file:data-man-type": "individual"
+          },
+          "properties": [
+            {
+              "id": "last",
+              "title": "Last Name",
+              "type": "string",
+              "format": "text",
+              "required": false,
+              "space_normalization": true,
+              "suggestion": [
+                {
+                  "key": "erad:kenkyusha_shimei",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "kenkyusha_no",
+                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "middle",
+              "title": "Middle Name",
+              "type": "string",
+              "format": "text",
+              "required": false,
+              "space_normalization": true,
+              "suggestion": [
+                {
+                  "key": "erad:kenkyusha_shimei",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "kenkyusha_no",
+                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "first",
+              "title": "First Name",
+              "type": "string",
+              "format": "text",
+              "required": false,
+              "space_normalization": true,
+              "suggestion": [
+                {
+                  "key": "erad:kenkyusha_shimei",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "kenkyusha_no",
+                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+                  }
+                }
+              ]
+            }
+          ]
         },
         {
           "qid": "grdm-file:data-man-org-ja",
@@ -708,8 +1103,32 @@
           "type": "string",
           "format": "text",
           "required": false,
+          "required_if": {
+            "$and": [
+              {
+                "grdm-file:data-man-email": {"$exists":  false}
+              },
+              {
+                "grdm-file:data-man-org-en": {"$exists":  false}
+              }
+            ]
+          },
+          "message_required_if": "「データ管理者の所属機関の連絡先メールアドレス」を入力する必要があります。もしくは、「データ管理者の所属組織名」(日英どちらか)および「データ管理者の所属機関の連絡先住所」(日英どちらか)、「データ管理者の所属機関の連絡先電話番号」を入力する必要があります。|\"Contact mail address of data manager\" must be filled. Or \"Contact organization of data manager\" (either Japanese or English), \"Contact address of data manager\" (either Japanese or English) and \"Contact phone number of data manager\" must be filled.",
           "space_normalization": true,
-          "help": "例: 〇〇研究所〇〇部門〇〇課, 〇〇大学〇〇研究室"
+          "help": "例: 〇〇研究所〇〇部門〇〇課, 〇〇大学〇〇研究室",
+          "suggestion": [
+            {
+              "key": "erad:kenkyukikan_mei",
+              "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+              "autofill": {
+                "grdm-file:data-man-number": "kenkyusha_no",
+                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                "grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+              }
+            }
+          ]
         },
         {
           "qid": "grdm-file:data-man-org-en",
@@ -718,7 +1137,31 @@
           "type": "string",
           "format": "text",
           "required": false,
-          "space_normalization": true
+          "required_if": {
+            "$and": [
+              {
+                "grdm-file:data-man-email": {"$exists":  false}
+              },
+              {
+                "grdm-file:data-man-org-ja": {"$exists":  false}
+              }
+            ]
+          },
+          "message_required_if": "「データ管理者の所属機関の連絡先メールアドレス」を入力する必要があります。もしくは、「データ管理者の所属組織名」(日英どちらか)および「データ管理者の所属機関の連絡先住所」(日英どちらか)、「データ管理者の所属機関の連絡先電話番号」を入力する必要があります。|\"Contact mail address of data manager\" must be filled. Or \"Contact organization of data manager\" (either Japanese or English), \"Contact address of data manager\" (either Japanese or English) and \"Contact phone number of data manager\" must be filled.",
+          "space_normalization": true,
+          "suggestion": [
+            {
+              "key": "erad:kenkyukikan_mei",
+              "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+              "autofill": {
+                "grdm-file:data-man-number": "kenkyusha_no",
+                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
+                "grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+              }
+            }
+          ]
         },
         {
           "qid": "grdm-file:data-man-address-ja",
@@ -727,6 +1170,17 @@
           "type": "string",
           "format": "text",
           "required": false,
+          "required_if": {
+            "$and": [
+              {
+                "grdm-file:data-man-email": {"$exists":  false}
+              },
+              {
+                "grdm-file:data-man-address-en": {"$exists":  false}
+              }
+            ]
+          },
+          "message_required_if": "「データ管理者の所属機関の連絡先メールアドレス」を入力する必要があります。もしくは、「データ管理者の所属組織名」(日英どちらか)および「データ管理者の所属機関の連絡先住所」(日英どちらか)、「データ管理者の所属機関の連絡先電話番号」を入力する必要があります。|\"Contact mail address of data manager\" must be filled. Or \"Contact organization of data manager\" (either Japanese or English), \"Contact address of data manager\" (either Japanese or English) and \"Contact phone number of data manager\" must be filled.",
           "space_normalization": true
         },
         {
@@ -736,6 +1190,17 @@
           "type": "string",
           "format": "text",
           "required": false,
+          "required_if": {
+            "$and": [
+              {
+                "grdm-file:data-man-email": {"$exists":  false}
+              },
+              {
+                "grdm-file:data-man-address-ja": {"$exists":  false}
+              }
+            ]
+          },
+          "message_required_if": "「データ管理者の所属機関の連絡先メールアドレス」を入力する必要があります。もしくは、「データ管理者の所属組織名」(日英どちらか)および「データ管理者の所属機関の連絡先住所」(日英どちらか)、「データ管理者の所属機関の連絡先電話番号」を入力する必要があります。|\"Contact mail address of data manager\" must be filled. Or \"Contact organization of data manager\" (either Japanese or English), \"Contact address of data manager\" (either Japanese or English) and \"Contact phone number of data manager\" must be filled.",
           "space_normalization": true
         },
         {
@@ -745,6 +1210,10 @@
           "type": "string",
           "format": "text",
           "required": false,
+          "required_if": {
+            "grdm-file:data-man-email": {"$exists":  false}
+          },
+          "message_required_if": "「データ管理者の所属機関の連絡先メールアドレス」を入力する必要があります。もしくは、「データ管理者の所属組織名」(日英どちらか)および「データ管理者の所属機関の連絡先住所」(日英どちらか)、「データ管理者の所属機関の連絡先電話番号」を入力する必要があります。|\"Contact mail address of data manager\" must be filled. Or \"Contact organization of data manager\" (either Japanese or English), \"Contact address of data manager\" (either Japanese or English) and \"Contact phone number of data manager\" must be filled.",
           "space_normalization": true
         },
         {
@@ -754,6 +1223,34 @@
           "type": "string",
           "format": "text",
           "required": false,
+          "required_if": {
+            "$or": [
+              {
+                "grdm-file:data-man-tel": {"$exists":  false}
+              },
+              {
+                "$and":  [
+                  {
+                    "grdm-file:data-man-address-ja": {"$exists":  false}
+                  },
+                  {
+                    "grdm-file:data-man-address-en": {"$exists":  false}
+                  }
+                ]
+              },
+              {
+                "$and":  [
+                  {
+                    "grdm-file:data-man-org-ja": {"$exists":  false}
+                  },
+                  {
+                    "grdm-file:data-man-org-en": {"$exists":  false}
+                  }
+                ]
+              }
+            ]
+          },
+          "message_required_if": "「データ管理者の所属機関の連絡先メールアドレス」を入力する必要があります。もしくは、「データ管理者の所属組織名」(日英どちらか)および「データ管理者の所属機関の連絡先住所」(日英どちらか)、「データ管理者の所属機関の連絡先電話番号」を入力する必要があります。|\"Contact mail address of data manager\" must be filled. Or \"Contact organization of data manager\" (either Japanese or English), \"Contact address of data manager\" (either Japanese or English) and \"Contact phone number of data manager\" must be filled.",
           "space_normalization": true
         },
         {

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -253,10 +253,14 @@
           "space_normalization": true,
           "suggestion": [
             {
-              "key": "asset:title",
-              "template": "<div style=\"background-color: white;\"><span>{{title}}</span></div>",
+              "key": "asset:title-ja",
+              "template": "<div style=\"background-color: white;\"><span>{{title-ja}} | {{title-en}}</span></div>",
               "autofill": {
-                "grdm-file:title-ja": "title"
+                "grdm-file:title-ja": "title-ja",
+                "grdm-file:title-en": "title-en",
+                "grdm-file:data-description-ja": "data-description-ja",
+                "grdm-file:data-description-en": "data-description-en",
+                "grdm-file:data-type": "data-type"
               }
             }
           ]
@@ -272,10 +276,14 @@
           "space_normalization": true,
           "suggestion": [
             {
-              "key": "asset:title",
-              "template": "<div style=\"background-color: white;\"><span>{{title}}</span></div>",
+              "key": "asset:title-en",
+              "template": "<div style=\"background-color: white;\"><span>{{title-ja}} | {{title-en}}</span></div>",
               "autofill": {
-                "grdm-file:title-en": "title"
+                "grdm-file:title-ja": "title-ja",
+                "grdm-file:title-en": "title-en",
+                "grdm-file:data-description-ja": "data-description-ja",
+                "grdm-file:data-description-en": "data-description-en",
+                "grdm-file:data-type": "data-type"
               }
             }
           ]
@@ -286,7 +294,6 @@
           "title": "掲載日・掲載更新日|Date (Issued / Updated)",
           "type": "string",
           "format": "date",
-          "required": true,
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
           "help": "例: 2010-01-01|E.g., 2010-01-01"
         },
@@ -659,8 +666,7 @@
           "title": "リポジトリ情報 (日本語)|Repository information (Japanese)",
           "type": "string",
           "format": "text",
-          "required": false,
-          "required_if": "grdm-file:repo-information-en"
+          "required": false
         },
         {
           "qid": "grdm-file:repo-information-en",
@@ -668,8 +674,7 @@
           "title": "Repository information (English)",
           "type": "string",
           "format": "text",
-          "required": false,
-          "required_if": "grdm-file:repo-information-ja"
+          "required": false
         },
         {
           "qid": "grdm-file:repo-url-doi-link",

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -712,6 +712,15 @@
                     "name-ja": "kenkyusha_shimei_ja",
                     "name-en": "kenkyusha_shimei_en"
                   }
+                },
+                {
+                  "key": "contributor:erad",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "autofill": {
+                    "number": "erad",
+                    "name-ja": "name-ja",
+                    "name-en": "name-en"
+                  }
                 }
               ]
             },
@@ -738,6 +747,15 @@
                         "../name-ja": "kenkyusha_shimei_ja",
                         "../name-en": "kenkyusha_shimei_en"
                       }
+                    },
+                    {
+                      "key": "contributor:name",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "autofill": {
+                        "../number": "erad",
+                        "../name-ja": "name-ja",
+                        "../name-en": "name-en"
+                      }
                     }
                   ]
                 },
@@ -757,6 +775,15 @@
                         "../name-ja": "kenkyusha_shimei_ja",
                         "../name-en": "kenkyusha_shimei_en"
                       }
+                    },
+                    {
+                      "key": "contributor:name",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "autofill": {
+                        "../number": "erad",
+                        "../name-ja": "name-ja",
+                        "../name-en": "name-en"
+                      }
                     }
                   ]
                 },
@@ -775,6 +802,15 @@
                         "../number": "kenkyusha_no",
                         "../name-ja": "kenkyusha_shimei_ja",
                         "../name-en": "kenkyusha_shimei_en"
+                      }
+                    },
+                    {
+                      "key": "contributor:name",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "autofill": {
+                        "../number": "erad",
+                        "../name-ja": "name-ja",
+                        "../name-en": "name-en"
                       }
                     }
                   ]
@@ -804,6 +840,15 @@
                         "../name-ja": "kenkyusha_shimei_ja",
                         "../name-en": "kenkyusha_shimei_en"
                       }
+                    },
+                    {
+                      "key": "contributor:name",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "autofill": {
+                        "../number": "erad",
+                        "../name-ja": "name-ja",
+                        "../name-en": "name-en"
+                      }
                     }
                   ]
                 },
@@ -823,6 +868,15 @@
                         "../name-ja": "kenkyusha_shimei_ja",
                         "../name-en": "kenkyusha_shimei_en"
                       }
+                    },
+                    {
+                      "key": "contributor:name",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "autofill": {
+                        "../number": "erad",
+                        "../name-ja": "name-ja",
+                        "../name-en": "name-en"
+                      }
                     }
                   ]
                 },
@@ -841,6 +895,15 @@
                         "../number": "kenkyusha_no",
                         "../name-ja": "kenkyusha_shimei_ja",
                         "../name-en": "kenkyusha_shimei_en"
+                      }
+                    },
+                    {
+                      "key": "contributor:name",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "autofill": {
+                        "../number": "erad",
+                        "../name-ja": "name-ja",
+                        "../name-en": "name-en"
                       }
                     }
                   ]
@@ -941,6 +1004,15 @@
                 "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                 "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
               }
+            },
+            {
+              "key": "contributor:erad",
+              "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+              "autofill": {
+                "grdm-file:data-man-number": "erad",
+                "grdm-file:data-man-name-ja": "name-ja",
+                "grdm-file:data-man-name-en": "name-en"
+              }
             }
           ]
         },
@@ -973,6 +1045,15 @@
                     "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                     "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
                   }
+                },
+                {
+                  "key": "contributor:name",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "erad",
+                    "../grdm-file:data-man-name-ja": "name-ja",
+                    "../grdm-file:data-man-name-en": "name-en"
+                  }
                 }
               ]
             },
@@ -994,6 +1075,15 @@
                     "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                     "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
                   }
+                },
+                {
+                  "key": "contributor:name",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "erad",
+                    "../grdm-file:data-man-name-ja": "name-ja",
+                    "../grdm-file:data-man-name-en": "name-en"
+                  }
                 }
               ]
             },
@@ -1014,6 +1104,15 @@
                     "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
                     "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                     "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+                  }
+                },
+                {
+                  "key": "contributor:name",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "erad",
+                    "../grdm-file:data-man-name-ja": "name-ja",
+                    "../grdm-file:data-man-name-en": "name-en"
                   }
                 }
               ]
@@ -1049,6 +1148,15 @@
                     "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                     "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
                   }
+                },
+                {
+                  "key": "contributor:name",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "erad",
+                    "../grdm-file:data-man-name-ja": "name-ja",
+                    "../grdm-file:data-man-name-en": "name-en"
+                  }
                 }
               ]
             },
@@ -1070,6 +1178,15 @@
                     "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                     "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
                   }
+                },
+                {
+                  "key": "contributor:name",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "erad",
+                    "../grdm-file:data-man-name-ja": "name-ja",
+                    "../grdm-file:data-man-name-en": "name-en"
+                  }
                 }
               ]
             },
@@ -1090,6 +1207,15 @@
                     "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
                     "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                     "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+                  }
+                },
+                {
+                  "key": "contributor:name",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "autofill": {
+                    "../grdm-file:data-man-number": "erad",
+                    "../grdm-file:data-man-name-ja": "name-ja",
+                    "../grdm-file:data-man-name-en": "name-en"
                   }
                 }
               ]

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -700,7 +700,7 @@
               "title": "e-Rad 研究者番号|e-Rad Researcher Number",
               "type": "string",
               "format": "text",
-              "required": true,
+              "required": false,
               "pattern": "^[0-9a-zA-Z]*$",
               "space_normalization": true,
               "suggestion": [
@@ -715,7 +715,7 @@
                 },
                 {
                   "key": "contributor:erad",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                   "autofill": {
                     "number": "erad",
                     "name-ja": "name-ja",
@@ -750,7 +750,7 @@
                     },
                     {
                       "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                       "autofill": {
                         "../number": "erad",
                         "../name-ja": "name-ja",
@@ -778,7 +778,7 @@
                     },
                     {
                       "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                       "autofill": {
                         "../number": "erad",
                         "../name-ja": "name-ja",
@@ -806,7 +806,7 @@
                     },
                     {
                       "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                       "autofill": {
                         "../number": "erad",
                         "../name-ja": "name-ja",
@@ -843,7 +843,7 @@
                     },
                     {
                       "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                       "autofill": {
                         "../number": "erad",
                         "../name-ja": "name-ja",
@@ -871,7 +871,7 @@
                     },
                     {
                       "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                       "autofill": {
                         "../number": "erad",
                         "../name-ja": "name-ja",
@@ -899,7 +899,7 @@
                     },
                     {
                       "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                       "autofill": {
                         "../number": "erad",
                         "../name-ja": "name-ja",
@@ -1007,7 +1007,7 @@
             },
             {
               "key": "contributor:erad",
-              "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+              "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
               "autofill": {
                 "grdm-file:data-man-number": "erad",
                 "grdm-file:data-man-name-ja": "name-ja",
@@ -1048,7 +1048,7 @@
                 },
                 {
                   "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                   "autofill": {
                     "../grdm-file:data-man-number": "erad",
                     "../grdm-file:data-man-name-ja": "name-ja",
@@ -1078,7 +1078,7 @@
                 },
                 {
                   "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                   "autofill": {
                     "../grdm-file:data-man-number": "erad",
                     "../grdm-file:data-man-name-ja": "name-ja",
@@ -1108,7 +1108,7 @@
                 },
                 {
                   "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                   "autofill": {
                     "../grdm-file:data-man-number": "erad",
                     "../grdm-file:data-man-name-ja": "name-ja",
@@ -1151,7 +1151,7 @@
                 },
                 {
                   "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                   "autofill": {
                     "../grdm-file:data-man-number": "erad",
                     "../grdm-file:data-man-name-ja": "name-ja",
@@ -1181,7 +1181,7 @@
                 },
                 {
                   "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                   "autofill": {
                     "../grdm-file:data-man-number": "erad",
                     "../grdm-file:data-man-name-ja": "name-ja",
@@ -1211,7 +1211,7 @@
                 },
                 {
                   "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}})</small></span></div>",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                   "autofill": {
                     "../grdm-file:data-man-number": "erad",
                     "../grdm-file:data-man-name-ja": "name-ja",

--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -1,6 +1,6 @@
 {
   "name": "公的資金による研究データのメタデータ登録",
-  "version": 2,
+  "version": 3,
   "description": "公的資金による研究データのメタデータ登録",
   "pages": [
     {
@@ -709,8 +709,8 @@
                   "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
                   "autofill": {
                     "number": "kenkyusha_no",
-                    "name-ja": "kenkyusha_shimei_ja",
-                    "name-en": "kenkyusha_shimei_en"
+                    "name_ja": "kenkyusha_shimei_ja_msfullname",
+                    "name_en": "kenkyusha_shimei_en_msfullname"
                   }
                 },
                 {
@@ -718,195 +718,65 @@
                   "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
                   "autofill": {
                     "number": "erad",
-                    "name-ja": "name-ja",
-                    "name-en": "name-en"
+                    "name_ja": "name-ja-msfullname",
+                    "name_en": "name-en-msfullname"
                   }
                 }
               ]
             },
             {
-              "id": "name-ja",
+              "id": "name_ja",
               "title": "名前(日本語)|Name (Japanese)",
-              "type": "object",
+              "type": "string",
+              "format": "text",
               "required": false,
-              "required_if": "name-en",
-              "properties": [
+              "required_if": "name_en",
+              "suggestion": [
                 {
-                  "id": "last",
-                  "title": "姓|Last Name",
-                  "type": "string",
-                  "format": "text",
-                  "required": false,
-                  "space_normalization": true,
-                  "suggestion": [
-                    {
-                      "key": "erad:kenkyusha_shimei",
-                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                      "autofill": {
-                        "../number": "kenkyusha_no",
-                        "../name-ja": "kenkyusha_shimei_ja",
-                        "../name-en": "kenkyusha_shimei_en"
-                      }
-                    },
-                    {
-                      "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                      "autofill": {
-                        "../number": "erad",
-                        "../name-ja": "name-ja",
-                        "../name-en": "name-en"
-                      }
-                    }
-                  ]
+                  "key": "erad:kenkyusha_shimei",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "number": "kenkyusha_no",
+                    "name_ja": "kenkyusha_shimei_ja_msfullname",
+                    "name_en": "kenkyusha_shimei_en_msfullname"
+                  }
                 },
                 {
-                  "id": "middle",
-                  "title": "ミドルネーム|Middle Name",
-                  "type": "string",
-                  "format": "text",
-                  "required": false,
-                  "space_normalization": true,
-                  "suggestion": [
-                    {
-                      "key": "erad:kenkyusha_shimei",
-                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                      "autofill": {
-                        "../number": "kenkyusha_no",
-                        "../name-ja": "kenkyusha_shimei_ja",
-                        "../name-en": "kenkyusha_shimei_en"
-                      }
-                    },
-                    {
-                      "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                      "autofill": {
-                        "../number": "erad",
-                        "../name-ja": "name-ja",
-                        "../name-en": "name-en"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "id": "first",
-                  "title": "名|First Name",
-                  "type": "string",
-                  "format": "text",
-                  "required": false,
-                  "space_normalization": true,
-                  "suggestion": [
-                    {
-                      "key": "erad:kenkyusha_shimei",
-                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                      "autofill": {
-                        "../number": "kenkyusha_no",
-                        "../name-ja": "kenkyusha_shimei_ja",
-                        "../name-en": "kenkyusha_shimei_en"
-                      }
-                    },
-                    {
-                      "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                      "autofill": {
-                        "../number": "erad",
-                        "../name-ja": "name-ja",
-                        "../name-en": "name-en"
-                      }
-                    }
-                  ]
+                  "key": "contributor:name",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
+                  "autofill": {
+                    "number": "erad",
+                    "name_ja": "name-ja-msfullname",
+                    "name_en": "name-en-msfullname"
+                  }
                 }
               ]
             },
             {
-              "id": "name-en",
+              "id": "name_en",
               "title": "Name (English)",
-              "type": "object",
+              "type": "string",
+              "format": "text",
               "required": false,
-              "required_if": "name-ja",
-              "properties": [
+              "required_if": "name_ja",
+              "suggestion": [
                 {
-                  "id": "last",
-                  "title": "Last Name",
-                  "type": "string",
-                  "format": "text",
-                  "required": false,
-                  "space_normalization": true,
-                  "suggestion": [
-                    {
-                      "key": "erad:kenkyusha_shimei",
-                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                      "autofill": {
-                        "../number": "kenkyusha_no",
-                        "../name-ja": "kenkyusha_shimei_ja",
-                        "../name-en": "kenkyusha_shimei_en"
-                      }
-                    },
-                    {
-                      "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                      "autofill": {
-                        "../number": "erad",
-                        "../name-ja": "name-ja",
-                        "../name-en": "name-en"
-                      }
-                    }
-                  ]
+                  "key": "erad:kenkyusha_shimei",
+                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+                  "autofill": {
+                    "number": "kenkyusha_no",
+                    "name_ja": "kenkyusha_shimei_ja_msfullname",
+                    "name_en": "kenkyusha_shimei_en_msfullname"
+                  }
                 },
                 {
-                  "id": "middle",
-                  "title": "Middle Name",
-                  "type": "string",
-                  "format": "text",
-                  "required": false,
-                  "space_normalization": true,
-                  "suggestion": [
-                    {
-                      "key": "erad:kenkyusha_shimei",
-                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                      "autofill": {
-                        "../number": "kenkyusha_no",
-                        "../name-ja": "kenkyusha_shimei_ja",
-                        "../name-en": "kenkyusha_shimei_en"
-                      }
-                    },
-                    {
-                      "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                      "autofill": {
-                        "../number": "erad",
-                        "../name-ja": "name-ja",
-                        "../name-en": "name-en"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "id": "first",
-                  "title": "First Name",
-                  "type": "string",
-                  "format": "text",
-                  "required": false,
-                  "space_normalization": true,
-                  "suggestion": [
-                    {
-                      "key": "erad:kenkyusha_shimei",
-                      "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                      "autofill": {
-                        "../number": "kenkyusha_no",
-                        "../name-ja": "kenkyusha_shimei_ja",
-                        "../name-en": "kenkyusha_shimei_en"
-                      }
-                    },
-                    {
-                      "key": "contributor:name",
-                      "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                      "autofill": {
-                        "../number": "erad",
-                        "../name-ja": "name-ja",
-                        "../name-en": "name-en"
-                      }
-                    }
-                  ]
+                  "key": "contributor:name",
+                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
+                  "autofill": {
+                    "number": "erad",
+                    "name_ja": "name-ja-msfullname",
+                    "name_en": "name-en-msfullname"
+                  }
                 }
               ]
             }
@@ -972,7 +842,8 @@
           "options": [
             {
               "text": "individual",
-              "tooltip": "個人|individual"
+              "tooltip": "個人|individual",
+              "default": true
             },
             {
               "text": "organization",
@@ -999,8 +870,8 @@
               "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
               "autofill": {
                 "grdm-file:data-man-number": "kenkyusha_no",
-                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                "grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja_msfullname",
+                "grdm-file:data-man-name-en": "kenkyusha_shimei_en_msfullname",
                 "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                 "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
               }
@@ -1010,8 +881,8 @@
               "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
               "autofill": {
                 "grdm-file:data-man-number": "erad",
-                "grdm-file:data-man-name-ja": "name-ja",
-                "grdm-file:data-man-name-en": "name-en"
+                "grdm-file:data-man-name-ja": "name-ja-msfullname",
+                "grdm-file:data-man-name-en": "name-en-msfullname"
               }
             }
           ]
@@ -1020,102 +891,33 @@
           "qid": "grdm-file:data-man-name-ja",
           "nav": "データ管理者 (日本語)",
           "title": "データ管理者 (日本語)|Data manager (Japanese)",
-          "type": "object",
+          "type": "string",
+          "format": "text",
           "required": false,
           "required_if": "grdm-file:data-man-name-en",
           "enabled_if": {
             "grdm-file:data-man-type": "individual"
           },
-          "properties": [
+          "suggestion": [
             {
-              "id": "last",
-              "title": "姓|Last Name",
-              "type": "string",
-              "format": "text",
-              "required": false,
-              "space_normalization": true,
-              "suggestion": [
-                {
-                  "key": "erad:kenkyusha_shimei",
-                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "kenkyusha_no",
-                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
-                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
-                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
-                  }
-                },
-                {
-                  "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "erad",
-                    "../grdm-file:data-man-name-ja": "name-ja",
-                    "../grdm-file:data-man-name-en": "name-en"
-                  }
-                }
-              ]
+              "key": "erad:kenkyusha_shimei",
+              "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+              "autofill": {
+                "grdm-file:data-man-number": "kenkyusha_no",
+                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja_msfullname",
+                "grdm-file:data-man-name-en": "kenkyusha_shimei_en_msfullname",
+                "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+              }
             },
             {
-              "id": "middle",
-              "title": "ミドルネーム|Middle Name",
-              "type": "string",
-              "format": "text",
-              "required": false,
-              "space_normalization": true,
-              "suggestion": [
-                {
-                  "key": "erad:kenkyusha_shimei",
-                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "kenkyusha_no",
-                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
-                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
-                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
-                  }
-                },
-                {
-                  "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "erad",
-                    "../grdm-file:data-man-name-ja": "name-ja",
-                    "../grdm-file:data-man-name-en": "name-en"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "first",
-              "title": "名|First Name",
-              "type": "string",
-              "format": "text",
-              "required": false,
-              "space_normalization": true,
-              "suggestion": [
-                {
-                  "key": "erad:kenkyusha_shimei",
-                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "kenkyusha_no",
-                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
-                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
-                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
-                  }
-                },
-                {
-                  "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "erad",
-                    "../grdm-file:data-man-name-ja": "name-ja",
-                    "../grdm-file:data-man-name-en": "name-en"
-                  }
-                }
-              ]
+              "key": "contributor:name",
+              "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
+              "autofill": {
+                "grdm-file:data-man-number": "erad",
+                "grdm-file:data-man-name-ja": "name-ja-msfullname",
+                "grdm-file:data-man-name-en": "name-en-msfullname"
+              }
             }
           ]
         },
@@ -1123,102 +925,33 @@
           "qid": "grdm-file:data-man-name-en",
           "nav": "Data manager (English)",
           "title": "Data manager (English)",
-          "type": "object",
+          "type": "string",
+          "format": "text",
           "required": false,
           "required_if": "grdm-file:data-man-name-ja",
           "enabled_if": {
             "grdm-file:data-man-type": "individual"
           },
-          "properties": [
+          "suggestion": [
             {
-              "id": "last",
-              "title": "Last Name",
-              "type": "string",
-              "format": "text",
-              "required": false,
-              "space_normalization": true,
-              "suggestion": [
-                {
-                  "key": "erad:kenkyusha_shimei",
-                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "kenkyusha_no",
-                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
-                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
-                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
-                  }
-                },
-                {
-                  "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "erad",
-                    "../grdm-file:data-man-name-ja": "name-ja",
-                    "../grdm-file:data-man-name-en": "name-en"
-                  }
-                }
-              ]
+              "key": "erad:kenkyusha_shimei",
+              "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
+              "autofill": {
+                "grdm-file:data-man-number": "kenkyusha_no",
+                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja_msfullname",
+                "grdm-file:data-man-name-en": "kenkyusha_shimei_en_msfullname",
+                "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
+                "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
+              }
             },
             {
-              "id": "middle",
-              "title": "Middle Name",
-              "type": "string",
-              "format": "text",
-              "required": false,
-              "space_normalization": true,
-              "suggestion": [
-                {
-                  "key": "erad:kenkyusha_shimei",
-                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "kenkyusha_no",
-                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
-                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
-                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
-                  }
-                },
-                {
-                  "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "erad",
-                    "../grdm-file:data-man-name-ja": "name-ja",
-                    "../grdm-file:data-man-name-en": "name-en"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "first",
-              "title": "First Name",
-              "type": "string",
-              "format": "text",
-              "required": false,
-              "space_normalization": true,
-              "suggestion": [
-                {
-                  "key": "erad:kenkyusha_shimei",
-                  "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "kenkyusha_no",
-                    "../grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                    "../grdm-file:data-man-name-en": "kenkyusha_shimei_en",
-                    "../grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
-                    "../grdm-file:data-man-org-en": "kenkyukikan_mei_en"
-                  }
-                },
-                {
-                  "key": "contributor:name",
-                  "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
-                  "autofill": {
-                    "../grdm-file:data-man-number": "erad",
-                    "../grdm-file:data-man-name-ja": "name-ja",
-                    "../grdm-file:data-man-name-en": "name-en"
-                  }
-                }
-              ]
+              "key": "contributor:name",
+              "template": "<div style=\"background-color: white;\"><span>{{name-ja-full}}|{{name-en-full}}</span><span><small class=\"m-l-md text-muted\">{{erad}}</small></span></div>",
+              "autofill": {
+                "grdm-file:data-man-number": "erad",
+                "grdm-file:data-man-name-ja": "name-ja-msfullname",
+                "grdm-file:data-man-name-en": "name-en-msfullname"
+              }
             }
           ]
         },
@@ -1248,8 +981,8 @@
               "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
               "autofill": {
                 "grdm-file:data-man-number": "kenkyusha_no",
-                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                "grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja_msfullname",
+                "grdm-file:data-man-name-en": "kenkyusha_shimei_en_msfullname",
                 "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                 "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
               }
@@ -1281,8 +1014,8 @@
               "template": "<div style=\"background-color: white;\"><span>{{kenkyusha_shimei}}</span><span><small class=\"m-l-md text-muted\">{{kenkyusha_no}} - {{kenkyukikan_mei}} - {{kadai_mei}} ({{nendo}})</small></span></div>",
               "autofill": {
                 "grdm-file:data-man-number": "kenkyusha_no",
-                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja",
-                "grdm-file:data-man-name-en": "kenkyusha_shimei_en",
+                "grdm-file:data-man-name-ja": "kenkyusha_shimei_ja_msfullname",
+                "grdm-file:data-man-name-en": "kenkyusha_shimei_en_msfullname",
                 "grdm-file:data-man-org-ja": "kenkyukikan_mei_ja",
                 "grdm-file:data-man-org-en": "kenkyukikan_mei_en"
               }

--- a/website/translations/en/LC_MESSAGES/js_messages.po
+++ b/website/translations/en/LC_MESSAGES/js_messages.po
@@ -225,8 +225,13 @@ msgid ""
 "browser menu."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:47
-#: addons/metadata/static/metadata-fields.js:220
+#: addons/metadata/static/metadata-fields.js:55
+#, python-format
+msgid "One of this field or \"%s\" field must be filled."
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:59
+#: addons/metadata/static/metadata-fields.js:250
 msgid "This field can't be blank."
 msgstr ""
 

--- a/website/translations/ja/LC_MESSAGES/js_messages.po
+++ b/website/translations/ja/LC_MESSAGES/js_messages.po
@@ -227,8 +227,13 @@ msgstr ""
 "[この操作が必要な理由] "
 "このブラウザでは、ボタン操作でのクリップボードの値取得が禁止されています。そのため、ショートカットキーまたはブラウザメニューの貼り付けにより明示的にクリップボード操作を指示する必要があります。"
 
-#: addons/metadata/static/metadata-fields.js:47
-#: addons/metadata/static/metadata-fields.js:220
+#: addons/metadata/static/metadata-fields.js:55
+#, python-format
+msgid "One of this field or \"%s\" field must be filled."
+msgstr "このフィールドか「%s」フィールドのいずれかを入力する必要があります。"
+
+#: addons/metadata/static/metadata-fields.js:59
+#: addons/metadata/static/metadata-fields.js:250
 msgid "This field can't be blank."
 msgstr "このフィールドは必須項目です。"
 

--- a/website/translations/js_messages.pot
+++ b/website/translations/js_messages.pot
@@ -224,8 +224,13 @@ msgid ""
 "browser menu."
 msgstr ""
 
-#: addons/metadata/static/metadata-fields.js:47
-#: addons/metadata/static/metadata-fields.js:220
+#: addons/metadata/static/metadata-fields.js:55
+#, python-format
+msgid "One of this field or \"%s\" field must be filled."
+msgstr ""
+
+#: addons/metadata/static/metadata-fields.js:59
+#: addons/metadata/static/metadata-fields.js:250
 msgid "This field can't be blank."
 msgstr ""
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5069,6 +5069,11 @@ shelljs@0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
 
+sift@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-17.0.1.tgz#70abec7e615923b45ce1b34e4795706d9233178c"
+  integrity sha512-10rmPF5nuz5UdKuhhxgfS7Vz1aIRGmb+kn5Zy6bntCgNwkbZc0a7Z2dUw2Y9wSoRrBzf7Oim81SUsYdOkVnI8Q==
+
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

ember側の実装は https://github.com/RCOSDP/RDM-ember-osf-web/pull/122 です。同時にマージしてください。

## Purpose

メタデータスキーマの表現能力を向上するため、スキーマ定義の拡張を行います。
また、コンポーネントをまたいだ移動においてファイルメタデータがコピーされない問題など、いくつかの問題を修正します。

https://github.com/RCOSDP/RDM-osf.io/pull/472 と https://github.com/RCOSDP/RDM-osf.io/pull/473 、 https://github.com/RCOSDP/RDM-osf.io/pull/471 をまとめて反映するものです。

## Changes

- GRDM-38885: 条件付きの必須プロパティ(required_if, message_required_if)を実装しました
- GRDM-38885: 条件付き有効化プロパティ(enabled_if)を実装しました
- GRDM-36922: .metadata フォルダを使う補完機能を実装しました
- GRDM-36922: 補完定義プロパティ(suggestion)を実装しました
- GRDM-39551, GRDM-39553: 複数のプロパティを持つ type: array および type: object を実装しました
- GRDM-40633: project.contributorsを利用する補完機能を実装しました
- GRDM-44424: アドオン上での（！）アイコンのメタデータ削除後の挙動を修正しました
- GRDM-44425: コンポーネントをまたいだメタデータつきファイルの移動の問題を修正しました
- GRDM-44426: ファイル名変更時にメタデータが追従しない問題を修正しました
- GRDM-39994: FileMetadata の作成時にトランザクション処理を追加し、FileMetadata の (project_id, path) で unique key を作成することで、同じ path のデータが同時に作成されることのないよう修正しました。
- 今後のスキーマ拡張に備え、スキーマ表現の自由度を高める目的で、メタデータの配列ブロック(array-inputタイプ)を実装しました。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-43834 (代表チケット)