### PR TITLE
Add escape sequence to '$' on extention of osf_rdmstatistics when plotting graph by matplotlib

### DIFF
--- a/admin/rdm_statistics/views.py
+++ b/admin/rdm_statistics/views.py
@@ -163,6 +163,7 @@ class ProviderData(object):
         self.size_df = pd.DataFrame(index=[], columns=cols)
         self.number_df = pd.DataFrame(index=[], columns=cols)
         for ext in self.ext_list:
+            ext = ext.replace('$', '\\$')
             size_row_list = []
             number_row_list = []
             for acquired_date in self.left:
@@ -216,7 +217,7 @@ class ProviderData(object):
             statistics_data.graphstyle = 'whitegrid'
             statistics_data.background = '#FFEEEE'
             for ext in self.ext_list:
-                statistics_data.add(ext, self.number_df[self.number_df['type'] == ext].height.values.tolist())
+                statistics_data.add(ext, self.number_df[self.number_df['type'] == ext.replace('$', '\\$')].height.values.tolist())
             statistics_data.image_string = create_image_string(statistics_data.provider, statistics_data=statistics_data)
         return statistics_data
 


### PR DESCRIPTION
Add escape sequence to '$' on extention of osf_rdmstatistics when plotting graph by matplotlib

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add escape sequence to '$' on extention of osf_rdmstatistics when plotting graph by matplotlib
<!-- Describe the purpose of your changes -->

## Changes
Add escape sequence to '$' on extention of osf_rdmstatistics when plotting graph by matplotlib
<!-- Briefly describe or list your changes  -->

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
  - What is the level of risk?
    - Any permissions code touched?
    - Is this an additive or subtractive change, other?
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
  - How will this impact performance?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
GRDM-44587
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
