### PR TITLE
[GRDM-41444, 45619] 「掲載日・掲載更新日」を「任意」に修正 (RCOS環境)

### DIFF
--- a/website/project/metadata/e-rad-metadata-1.json
+++ b/website/project/metadata/e-rad-metadata-1.json
@@ -294,7 +294,6 @@
           "title": "掲載日・掲載更新日|Date (Issued / Updated)",
           "type": "string",
           "format": "date",
-          "required": true,
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
           "help": "例: 2010-01-01|E.g., 2010-01-01"
         },


### PR DESCRIPTION
## Purpose

「掲載日・掲載更新日」を「任意」に修正

## Changes

- 「掲載日・掲載更新日」を「任意」に修正 ... https://github.com/RCOSDP/RDM-osf.io/pull/533 にて誤った値に変更してしまったので修正

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-41444, 45619