### PR TITLE
[GRDM-45886] fix #518: bump xdist version to fix GHA ci - 開発用docker compose環境でpipインストールに失敗する問題の修正

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@
 # Testing
 pytest==5.0.0
 pytest-socket==0.3.5
-pytest-xdist==1.15.0
+pytest-xdist==1.34.0
 pytest-django==3.10.0
 python-coveralls==2.9.3
 pytest-testmon==1.0.3


### PR DESCRIPTION
## Purpose

Fix #518 - 開発用にdocker composeでサービス起動する場合において、 `invoke requirements --all` する際に `pytest-xdist` のインストールに失敗する問題を修正します。

## Changes

- Upstreamで2021年に実施されていたcommit https://github.com/CenterForOpenScience/osf.io/commit/2bf85d0762bb69c2cb67c73b77b456ea00e9f630 を取り込みました。

## QA Notes

None

## Documentation

None

## Side Effects

None - `requirements/dev.txt` に対する修正なので、リリースへの影響はありません。

## Ticket

- GRDM-45886