### PR TITLE
[GRDM-45886] Fix local cookie samesite config and use 'Lax' instead of 'None' - 開発用にdocker composeで起動した環境にログインできない問題の修正

### DIFF
--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -70,7 +70,8 @@ COOKIE_NAME = 'osf'
 OSF_COOKIE_DOMAIN = None
 SECRET_KEY = 'CHANGEME'
 SESSION_COOKIE_SECURE = SECURE_MODE
-SESSION_COOKIE_SAMESITE = 'None'
+# Cookie will be blocked if set to 'None' in local env with HTTP where COOKIE_SECURE is disabled
+SESSION_COOKIE_SAMESITE = 'Lax'
 OSF_SERVER_KEY = None
 OSF_SERVER_CERT = None
 


### PR DESCRIPTION
## Purpose

docker composeで起動したローカル環境で fakecas を使っている場合、localhost と 192.168.168.167 の2つのドメインを使う都合上、ドメイン不一致でログイン周りエラーが発生する問題を修正します。


## Changes

- Upstreamでの2022年の変更 https://github.com/CenterForOpenScience/osf.io/commit/1890c1bf84da495f145205da7d3219a8104b4884 を取り込みました。

## QA Notes

None

## Documentation

None

## Side Effects

None - `local-dist.py` への修正であり、そのままでは設定として読み込まれることはないため、リリースへの影響はありません。

## Ticket

GRDM-45886
