### PR TITLE
[GRDM-45900]Increased the maximum number of files when upload folder

### DIFF
--- a/addons/github/static/githubFangornConfig.js
+++ b/addons/github/static/githubFangornConfig.js
@@ -9,6 +9,7 @@ var URI = require('URIjs');
 var Fangorn = require('js/fangorn').Fangorn;
 var waterbutler = require('js/waterbutler');
 var $osf = require('js/osfHelpers');
+var gettext = require('js/rdmGettext')._;
 
 // Cross browser key codes for the Command key
 var commandKeys = [224, 17, 91, 93];
@@ -205,6 +206,13 @@ var _githubItemButtons = {
                 // If File and FileRead are not defined dropzone is not supported and neither is uploads
                 if (window.File && window.FileReader && item.data.permissions && item.data.permissions.edit) {
                     buttons.push(
+                        m.component(Fangorn.Components.button, {
+                            onclick: function (event) {
+                                Fangorn.ButtonEvents._uploadFolderEvent.call(tb, event, item);
+                            },
+                            icon: 'fa fa-plus',
+                            className: 'text-success'
+                        }, gettext('Upload Folder')),
                         m.component(Fangorn.Components.button, {
                             onclick: function (event) {
                                 Fangorn.ButtonEvents._uploadEvent.call(tb, event, item);

--- a/website/translations/ja/LC_MESSAGES/js_messages.po
+++ b/website/translations/ja/LC_MESSAGES/js_messages.po
@@ -4788,7 +4788,7 @@ msgstr "問題が解決しない場合は、%1$sにお問い合わせくださ�
 
 #: website/static/js/fangorn.js:1172
 msgid "The folder that wants to upload is empty."
-msgstr ""
+msgstr "空のフォルダはアップロードできません。"
 
 #: website/static/js/fangorn.js:1204
 msgid "Not enough quota to upload. The total size of the folder %1$s."


### PR DESCRIPTION
- Ticket:
GRDM-45900 

## Purpose
- Fix the error of can not upload files when the folder contains too many files (~1000 files)

## Changes
- Reduce the number of recursive calls when uploading a folder.
- Check the quota only once for the entire folder instead of checking it individually for each file.
<!-- Briefly describe or list your changes  -->

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
