### PR TITLE
[GRDM-46984] WEKOインデックス数が多い場合のアカウントインポート時エラー修正 (RCOS環境)

### DIFF
--- a/addons/weko/tests/utils.py
+++ b/addons/weko/tests/utils.py
@@ -10,7 +10,17 @@ fake_weko_indices = [
     {
         'id': 100,
         'name': 'Sample Index',
-        'children': [],
+        'children': [
+            {
+                'id': 'more',
+            },
+            {
+                'id': 'dummy',
+            }
+        ],
+    },
+    {
+        'id': 'more',
     },
 ]
 fake_weko_item = {
@@ -23,6 +33,9 @@ fake_weko_items = {
     'hits': {
         'hits': [
             fake_weko_item,
+            {
+                'id': 'dummy',
+            }
         ]
     },
 }


### PR DESCRIPTION

## Purpose

WEKOインデックス数が多い場合のアカウントインポート時エラー修正

## Changes

- インデックスおよびアイテム取得時に、期待するプロパティ(Indexの場合はid, name, Itemの場合はmetadata)がなければ無視する。無視した場合、Indexのmoreを除いて、warningメッセージをログに出力する

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-46984