### PR TITLE
[GRDM-47278] WEKOアドオンでCSVファイルが送信できない問題の修正

### DIFF
--- a/addons/weko/deposit.py
+++ b/addons/weko/deposit.py
@@ -120,7 +120,7 @@ def deposit_metadata(
         zip_path = os.path.join(tmp_dir, 'payload.zip')
         with ZipFile(zip_path, 'w') as zf:
             for download_file_name, _ in download_file_names:
-                with zf.open(os.path.join('data/', download_file_name), 'w') as df:
+                with zf.open(f'data/files/{download_file_name}', 'w') as df:
                     with open(download_file_path, 'rb') as sf:
                         shutil.copyfileobj(sf, df)
             with zf.open('data/index.csv', 'w') as f:

--- a/addons/weko/schema.py
+++ b/addons/weko/schema.py
@@ -25,7 +25,13 @@ columns_default = [
 
 def _generate_file_columns(index, download_file_name, download_file_type):
     columns = []
-    columns.append((f'.file_path[{index}]', f'.ファイルパス[{index}]', '', 'Allow Multiple', download_file_name))
+    columns.append((
+        f'.file_path[{index}]',
+        f'.ファイルパス[{index}]',
+        '',
+        'Allow Multiple',
+        f'files/{download_file_name}'
+    ))
     return columns
 
 def _get_metadata_value(file_metadata_data, item, lang, index):

--- a/addons/weko/tests/test_schema.py
+++ b/addons/weko/tests/test_schema.py
@@ -96,7 +96,7 @@ class TestWEKOSchema(OsfTestCase):
         )
         assert_equal(
             props.pop(),
-            ['.file_path[0]', '.ファイルパス[0]', '', 'Allow Multiple', 'test.jpg'],
+            ['.file_path[0]', '.ファイルパス[0]', '', 'Allow Multiple', 'files/test.jpg'],
         )
         feedback_mail = props.pop()
         assert_equal(
@@ -281,7 +281,7 @@ class TestWEKOSchema(OsfTestCase):
         )
         assert_equal(
             props.pop(),
-            ['.file_path[0]', '.ファイルパス[0]', '', 'Allow Multiple', 'test.jpg'],
+            ['.file_path[0]', '.ファイルパス[0]', '', 'Allow Multiple', 'files/test.jpg'],
         )
         feedback_mail = props.pop()
         assert_equal(


### PR DESCRIPTION
## Purpose

WEKOアドオンでWEKOに対しCSVファイルを含むPayloadをSWORD送信すると、WEKOがErrorを返し失敗する問題を修正します。

## Changes

- [GRDM-47278] SWORD送信時のpayload.zip内のファイル配置に関して、アイテムのデータを `data/` 直下ではなく `data/files/` に配置するよう修正

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-47278