### PR TITLE
[GRDMー45768] オフィスソフトウェア連携機能実装(ONLYOFFICE連携)

### DIFF
--- a/addons/onlyoffice/proof_key.py
+++ b/addons/onlyoffice/proof_key.py
@@ -9,9 +9,6 @@ from Crypto.Signature import PKCS1_v1_5
 
 from datetime import datetime, timezone
 
-import logging
-logger = logging.getLogger(__name__)
-
 
 """
 The MIT License (MIT)
@@ -119,7 +116,6 @@ class ProofKeyHelper(object):
             self.current_key = generate_key(discovery_data.modulus, discovery_data.exponent)
             self.old_key = generate_key(discovery_data.oldmodulus, discovery_data.oldexponent)
             self.key_registered = True
-        logger.info('proof key helper initialized.')
 
     def setKey(self, discovery_data):
         self.current_key = generate_key(discovery_data.modulus, discovery_data.exponent)

--- a/addons/onlyoffice/settings/__init__.py
+++ b/addons/onlyoffice/settings/__init__.py
@@ -1,6 +1,5 @@
 import os
 import warnings
-import itertools
 
 from .defaults import *  # noqa
 

--- a/addons/onlyoffice/settings/__init__.py
+++ b/addons/onlyoffice/settings/__init__.py
@@ -1,10 +1,19 @@
-import logging
+import os
+import warnings
+import itertools
+
 from .defaults import *  # noqa
-
-
-logger = logging.getLogger(__name__)
 
 try:
     from .local import *  # noqa
 except ImportError:
-    logger.warn('No local.py settings file found')
+    warnings.warn(
+        'No addons/onlyoffice/settings/local.py settings file found. Did you remember to '
+        'copy local-dist.py to local.py?', ImportWarning,
+    )
+
+if not DEV_MODE and os.environ.get('DJANGO_SETTINGS_MODULE') == 'addons.onlyoffice.settings':
+    from . import local
+    from . import defaults
+    for setting in ('OFFICESERVER_JWE_SECRET', 'OFFICESERVER_JWE_SALT', 'OFFICESERVER_JWT_SECRET'):
+        assert getattr(local, setting, None) and getattr(local, setting, None) != getattr(defaults, setting, None), '{} must be specified in local.py when DEV_MODE is False'.format(setting)

--- a/addons/onlyoffice/settings/defaults.py
+++ b/addons/onlyoffice/settings/defaults.py
@@ -1,4 +1,3 @@
-import os
 from website import settings as osf_settings
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/addons/onlyoffice/settings/defaults.py
+++ b/addons/onlyoffice/settings/defaults.py
@@ -1,6 +1,23 @@
+import os
+from website import settings as osf_settings
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEV_MODE = osf_settings.DEV_MODE
+DEBUG = osf_settings.DEBUG_MODE
+
+OFFICESERVER_JWE_SALT = 'xxxxx'
+OFFICESERVER_JWE_SECRET = 'yyyyy'
+OFFICESERVER_JWT_SECRET = 'zzzzz'
+OFFICESERVER_JWT_ALGORITHM = 'HS256'
+
+
 # WOPI settings.
-# Session timer (seconds). Default is 24 hour.
-WOPI_TOKEN_TTL = 24 * 60 * 60
+# Session timer (seconds). Default is 10 hour.
+WOPI_TOKEN_TTL = 10 * 60 * 60
+
+# Difference between access_token_ttl and expiration timer encrypted in access_token. (seconds)
+# Default is 60 sec.
+WOPI_EXPIRATION_TIMER_DELAY = 60
 
 # WOPI_CLIENT_ONLYOFFICE is ONLYOFFICE online editor's host and port FROM web server.
 WOPI_CLIENT_ONLYOFFICE = None

--- a/addons/onlyoffice/settings/local-dist.py
+++ b/addons/onlyoffice/settings/local-dist.py
@@ -1,0 +1,11 @@
+# Secrets.
+OFFICESERVER_JWE_SALT = 'xxxxx'
+OFFICESERVER_JWE_SECRET = 'yyyyy'
+OFFICESERVER_JWT_SECRET = 'zzzzz'
+OFFICESERVER_JWT_ALGORITHM = 'HS256'
+
+# WOPI_CLIENT_ONLYOFFICE is ONLYOFFICE online editor's host and port FROM web server.
+WOPI_CLIENT_ONLYOFFICE = None
+
+# WOPI_SRC_HOST is web server's host and port which can access FROM WOPI CLIENT.
+WOPI_SRC_HOST = None

--- a/addons/onlyoffice/tests/test_token.py
+++ b/addons/onlyoffice/tests/test_token.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""token tests for the onlyoffice addon."""
+import pytest
+import mock
+
+from addons.onlyoffice.token import _check_schema, encrypt, decrypt, check_token
+from framework.auth import Auth
+from osf.exceptions import ValidationError
+from osf.models import Guid
+from osf_tests.factories import AuthUserFactory, UserFactory, ProjectFactory, NodeFactory
+from tests.base import OsfTestCase
+from datetime import datetime, timezone, timedelta
+
+from .. import settings
+
+Cookie = "67890f9f68b3c544fdd08572.LVImKq5n7UYcIzIGP1NX0hYLwME"
+File_id = "660a5294e3c53a000a8165ed"
+
+class TestOnlyofficeToken(OsfTestCase):
+    def test_case1(self):
+        # 'auth' is not exist : False
+        data = {
+            'data' : {
+                'file_id' : File_id
+                },
+            'exp' : int(datetime.now(timezone.utc).timestamp() +
+                      timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
+                      settings.WOPI_EXPIRATION_TIMER_DELAY
+        }
+        assert _check_schema(data) == False
+
+    def test_case2(self):
+        # 'file_id' is not exist : False
+        data = {
+            'data' : {
+                'auth' : Cookie
+                },
+            'exp' : int(datetime.now(timezone.utc).timestamp() +
+                        timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
+                        settings.WOPI_EXPIRATION_TIMER_DELAY
+        }
+        assert _check_schema(data) == False
+
+    def test_case3(self):
+        #  exp timeouted : False
+        data = {
+            'data' : {
+                'auth' : Cookie,
+                'file_id' : File_id
+                },
+            'exp' : int(datetime.now(timezone.utc).timestamp() -
+                      timedelta(seconds=10).seconds)
+            }
+        assert check_token(data, File_id) == False
+
+    def test_case4(self):
+        # fair token : True
+        data = {
+            'data' : {
+                'auth' : Cookie,
+                'file_id' : File_id
+                },
+            'exp' : int(datetime.now(timezone.utc).timestamp() +
+                      timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
+                      settings.WOPI_EXPIRATION_TIMER_DELAY
+            }
+        assert _check_schema(data) == True
+        
+    def test_encrypt(self):
+        encrypted = encrypt(Cookie, File_id)
+        decrypted = decrypt(encrypted)
+        
+        assert decrypted['data']['auth'] == Cookie
+        assert decrypted['data']['file_id'] ==  File_id

--- a/addons/onlyoffice/tests/test_token.py
+++ b/addons/onlyoffice/tests/test_token.py
@@ -13,8 +13,8 @@ from datetime import datetime, timezone, timedelta
 
 from .. import settings
 
-Cookie = "67890f9f68b3c544fdd08572.LVImKq5n7UYcIzIGP1NX0hYLwME"
-File_id = "660a5294e3c53a000a8165ed"
+Cookie = '67890f9f68b3c544fdd08572.LVImKq5n7UYcIzIGP1NX0hYLwME'
+File_id = '660a5294e3c53a000a8165ed'
 
 class TestOnlyofficeToken(OsfTestCase):
     def test_case1(self):

--- a/addons/onlyoffice/tests/test_token.py
+++ b/addons/onlyoffice/tests/test_token.py
@@ -20,55 +20,55 @@ class TestOnlyofficeToken(OsfTestCase):
     def test_case1(self):
         # 'auth' is not exist : False
         data = {
-            'data' : {
-                'file_id' : File_id
+            'data': {
+                'file_id': File_id
                 },
-            'exp' : int(datetime.now(timezone.utc).timestamp() +
-                      timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
-                      settings.WOPI_EXPIRATION_TIMER_DELAY
+            'exp': int(datetime.now(timezone.utc).timestamp() +
+                       timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
+                       settings.WOPI_EXPIRATION_TIMER_DELAY
         }
         assert _check_schema(data) == False
 
     def test_case2(self):
         # 'file_id' is not exist : False
         data = {
-            'data' : {
-                'auth' : Cookie
+            'data': {
+                'auth': Cookie
                 },
-            'exp' : int(datetime.now(timezone.utc).timestamp() +
-                        timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
-                        settings.WOPI_EXPIRATION_TIMER_DELAY
+            'exp': int(datetime.now(timezone.utc).timestamp() +
+                       timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
+                       settings.WOPI_EXPIRATION_TIMER_DELAY
         }
         assert _check_schema(data) == False
 
     def test_case3(self):
         #  exp timeouted : False
         data = {
-            'data' : {
-                'auth' : Cookie,
-                'file_id' : File_id
+            'data': {
+                'auth': Cookie,
+                'file_id': File_id
                 },
-            'exp' : int(datetime.now(timezone.utc).timestamp() -
-                      timedelta(seconds=10).seconds)
+            'exp': int(datetime.now(timezone.utc).timestamp() -
+                       timedelta(seconds=10).seconds)
             }
         assert check_token(data, File_id) == False
 
     def test_case4(self):
         # fair token : True
         data = {
-            'data' : {
-                'auth' : Cookie,
-                'file_id' : File_id
+            'data': {
+                'auth': Cookie,
+                'file_id': File_id
                 },
-            'exp' : int(datetime.now(timezone.utc).timestamp() +
-                      timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
-                      settings.WOPI_EXPIRATION_TIMER_DELAY
+            'exp': int(datetime.now(timezone.utc).timestamp() +
+                       timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
+                       settings.WOPI_EXPIRATION_TIMER_DELAY
             }
         assert _check_schema(data) == True
-        
+
     def test_encrypt(self):
         encrypted = encrypt(Cookie, File_id)
         decrypted = decrypt(encrypted)
-        
+
         assert decrypted['data']['auth'] == Cookie
-        assert decrypted['data']['file_id'] ==  File_id
+        assert decrypted['data']['file_id'] == File_id

--- a/addons/onlyoffice/tests/test_view.py
+++ b/addons/onlyoffice/tests/test_view.py
@@ -5,6 +5,7 @@ import mock
 
 from addons.onlyoffice.util import _ext_to_app_name_onlyoffice, get_onlyoffice_url, get_file_info
 from addons.onlyoffice.views import onlyoffice_edit_by_onlyoffice, onlyoffice_check_file_info
+from addons.onlyoffice.proof_key import ProofKeyHelper
 from framework.auth import Auth
 from osf.exceptions import ValidationError
 from osf.models import Guid
@@ -13,19 +14,28 @@ from tests.base import OsfTestCase
 
 from flask import request
 import requests
+# from datetime import datetime, timezone, timedelta
 from osf.models import BaseFileNode
 from .. import settings
 from .. import util as onlyoffice_util
+from .. import token as onlyoffice_token
+from .. import proof_key as onlyoffice_proof_key
+from .. import views as onlyoffice_views
 from website import settings as websettings
 
-
-class Response():
-    status_code = 0
-    text = ''
-    content = ''
+#class Response():
+#    status_code = 0
+#    text = ''
+#    content = ''
+#    def raise_for_status(self):
+#        return 1
 
 class Filenode():
     name = ''
+
+#class Pkhelper():
+#    def hasKey():
+#        return True
 
 
 class TestOnlyofficeAddon(OsfTestCase):
@@ -41,14 +51,41 @@ class TestOnlyofficeAddon(OsfTestCase):
         assert _ext_to_app_name_onlyoffice('pptx') == 'PowerPoint'
 
     def test_get_onlyoffice_url(self):
-        mock_response = Response()
-        mock_response.text = '<?xml version="1.0" encoding="utf-8"?><wopi-discovery><net-zone name="external-http"><app name="Word" favIconUrl="http://192.168.1.1:8002/web-apps/apps/documenteditor/main/resources/img/favicon.ico"><action name="edit" ext="docx" urlsrc="http://192.168.1.1:8002/hosting/wopi/word/view?&amp;&lt;rs=DC_LLCC&amp;&gt;&lt;dchat=DISABLE_CHAT&amp;&gt;&lt;embed=EMBEDDED&amp;&gt;&lt;fs=FULLSCREEN&amp;&gt;&lt;hid=HOST_SESSION_ID&amp;&gt;&lt;rec=RECORDING&amp;&gt;&lt;sc=SESSION_CONTEXT&amp;&gt;&lt;thm=THEME_ID&amp;&gt;&lt;ui=UI_LLCC&amp;&gt;&lt;wopisrc=WOPI_SOURCE&amp;&gt;&amp;" /></app></net-zone></wopi-discovery>'
+        mock_discovery = '<?xml version="1.0" encoding="utf-8"?><wopi-discovery><net-zone name="external-http"><app name="Word" favIconUrl="http://192.168.1.1:8002/web-apps/apps/documenteditor/main/resources/img/favicon.ico"><action name="edit" ext="docx" urlsrc="http://192.168.1.1:8002/hosting/wopi/word/view?&amp;&lt;rs=DC_LLCC&amp;&gt;&lt;dchat=DISABLE_CHAT&amp;&gt;&lt;embed=EMBEDDED&amp;&gt;&lt;fs=FULLSCREEN&amp;&gt;&lt;hid=HOST_SESSION_ID&amp;&gt;&lt;rec=RECORDING&amp;&gt;&lt;sc=SESSION_CONTEXT&amp;&gt;&lt;thm=THEME_ID&amp;&gt;&lt;ui=UI_LLCC&amp;&gt;&lt;wopisrc=WOPI_SOURCE&amp;&gt;&amp;" /></app></net-zone></wopi-discovery>'
 
-        with mock.patch.object(requests, 'get', return_value=mock_response):
+        with mock.patch.object(onlyoffice_util, '_get_onlyoffice_discovery', return_value=mock_discovery):
             url = get_onlyoffice_url('server', 'edit', 'docx')
         assert url == 'http://192.168.1.1:8002/hosting/wopi/word/view?'
 
+    '''
+    def test_edit_by_onlyoffice(self):
+        mock_pkhelper = Pkhelper()
+        mock_filenode = Filenode()
+        mock_filenode.name = 'filename1.docx'
+        #mock_pkhelper = True
+        mock_encrypt = 'Cookie String'
+        mock_get_url_value = 'http://192.168.1.1:8002/onlyoffice/'
+        settings.WOPI_SRC_HOST = 'http://srchost'
+
+        with mock.patch.object(request.cookies, 'get', return_value='Cookie String'):
+            with mock.patch.object(BaseFileNode, 'load', return_value=mock_filenode):
+                with mock.patch.object(onlyoffice_views, 'pkhelper', return_value=mock_pkhelper):
+                    with mock.patch.object(onlyoffice_util, 'get_onlyoffice_url', return_value=mock_get_url_value):
+                        with mock.patch.object(onlyoffice_token, 'encrypt', return_value=mock_encrypt):
+                            context = onlyoffice_edit_by_onlyoffice(file_id='ABCDEFG')
+        assert context['wopi_url'] == 'http://192.168.1.1:8002/onlyoffice/rs=ja-jp&ui=ja-jp&wopisrc=http://srchost/wopi/files/ABCDEFG'
+        assert context['access_token'] == 'Cookie String'
+    '''
+
     def test_check_file_info(self):
+        mock_jsonobj = {
+                         'data' :
+                            { 'auth' : 'cookie string',
+                              'file_id' : 'ABCDEFG'
+                            }
+                       }
+        mock_check_token = True
+        mock_proof_key = True
         mock_filenode = Filenode()
         mock_filenode.name = 'filename.docx'
         mock_user_info = {'user_id': 'userid', 'full_name': 'fullname', 'display_name': 'dispname'}
@@ -58,6 +95,9 @@ class TestOnlyofficeAddon(OsfTestCase):
         with mock.patch.object(BaseFileNode, 'load', return_value=mock_filenode):
             with mock.patch.object(request.args, 'get', return_value=mock_access_token):
                 with mock.patch.object(onlyoffice_util, 'get_user_info', return_value=mock_user_info):
-                    with mock.patch.object(onlyoffice_util, 'get_file_info', return_value=mock_file_info):
-                        res = onlyoffice_check_file_info(file_id='ABCDEFG')
+                    with mock.patch.object(onlyoffice_token, 'decrypt', return_value=mock_jsonobj):
+                        with mock.patch.object(onlyoffice_token, 'check_token', return_value=mock_check_token):
+                            with mock.patch.object(onlyoffice_util, 'get_file_info', return_value=mock_file_info):
+                                with mock.patch.object(onlyoffice_util, 'check_proof_key', return_value=mock_proof_key):
+                                    res = onlyoffice_check_file_info(file_id='ABCDEFG')
         assert res['BaseFileName'] == 'filename.docx'

--- a/addons/onlyoffice/tests/test_view.py
+++ b/addons/onlyoffice/tests/test_view.py
@@ -92,7 +92,7 @@ class TestOnlyofficeAddon(OsfTestCase):
         mock_file_info = {'name': 'filename.docx'}
         mock_access_token = {websettings.COOKIE_NAME: 'cookie'}
 
-        with mock.patch.object(BaseFileNode, 'load', return_value=mock_filenode):
+        with mock.patch.object(BaseFileNode.objects, 'get', return_value=mock_filenode):
             with mock.patch.object(request.args, 'get', return_value=mock_access_token):
                 with mock.patch.object(onlyoffice_util, 'get_user_info', return_value=mock_user_info):
                     with mock.patch.object(onlyoffice_token, 'decrypt', return_value=mock_jsonobj):

--- a/addons/onlyoffice/token.py
+++ b/addons/onlyoffice/token.py
@@ -18,10 +18,10 @@ token_schema = {
         "exp" : {"type" : "number"},
         "data" : {
             "type": "object",
-            "required": ["auth", "fileid"],
+            "required": ["auth", "file_id"],
             "properties" : {
                 "auth" : {"type" : "string"},
-                "fileid" : {"type" : "string"}
+                "file_id" : {"type" : "string"}
             }
         }
     }
@@ -46,7 +46,7 @@ def encrypt(cookie, file_id):
         {
             'data' : {
                 'auth': cookie,
-                'fileid': file_id
+                'file_id': file_id
             },
             'exp': int(datetime.now(timezone.utc).timestamp() +
                        timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
@@ -79,9 +79,9 @@ def check_token(jsonobj, file_id):
         return False
 
     # file_id check
-    if file_id != jsonobj['data']['fileid']:
+    if file_id != jsonobj['data']['file_id']:
         logger.info('token file_id check failed.')
-        logger.info('file_id, token file_id : {}  {}'.format(file_id, jsonobj['data']['fileid']))
+        logger.info('file_id, token file_id : {}  {}'.format(file_id, jsonobj['data']['file_id']))
         return False
 
     # expiration check

--- a/addons/onlyoffice/token.py
+++ b/addons/onlyoffice/token.py
@@ -1,7 +1,7 @@
 import jwe
 import jwt
 
-from jsonschema import validate
+import jsonschema
 from datetime import datetime, timezone, timedelta
 import logging
 
@@ -34,7 +34,7 @@ def _get_timestamp():
 
 def _check_schema(token):
     try:
-        validate(instance=token, schema=token_schema)
+        jsonschema.validate(instance=token, schema=token_schema)
         return True
     except jsonschema.exceptions.ValidationError as e:
         logger.info('token schema error : {}'.format(e))

--- a/addons/onlyoffice/token.py
+++ b/addons/onlyoffice/token.py
@@ -1,0 +1,98 @@
+import jwe
+import jwt
+
+from jsonschema import validate
+from datetime import datetime, timezone, timedelta
+import logging
+
+from . import settings
+
+logger = logging.getLogger(__name__)
+
+OFFICESERVER_JWE_KEY = jwe.kdf(settings.OFFICESERVER_JWE_SECRET.encode('utf-8'), settings.OFFICESERVER_JWE_SALT.encode('utf-8'))
+
+token_schema = {
+    "type": "object",
+    "required": ["exp", "data"],
+    "properties": {
+        "exp" : {"type" : "number"},
+        "data" : {
+            "type": "object",
+            "required": ["auth", "fileid"],
+            "properties" : {
+                "auth" : {"type" : "string"},
+                "fileid" : {"type" : "string"}
+            }
+        }
+    }
+}
+
+def _get_timestamp():
+    nt = datetime.now(timezone.utc).timestamp()
+    return nt
+
+
+def _check_schema(token):
+    try:
+        validate(instance=token, schema=token_schema)
+        return True
+    except jsonschema.exceptions.ValidationError as e:
+        logger.info('token schema error : {}'.format(e))
+        return False
+
+
+def encrypt(cookie, file_id):
+    jwte = jwt.encode(
+        {
+            'data' : {
+                'auth': cookie,
+                'fileid': file_id
+            },
+            'exp': int(datetime.now(timezone.utc).timestamp() +
+                       timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
+                       settings.WOPI_EXPIRATION_TIMER_DELAY
+        },
+        settings.OFFICESERVER_JWT_SECRET, algorithm=settings.OFFICESERVER_JWT_ALGORITHM)
+        #websettings.JWT_SECRET, algorithm=websettings.JWT_ALGORITHM)
+    #print(jwte)
+    encstr = jwe.encrypt(jwte, OFFICESERVER_JWE_KEY).decode()
+    #print(encstr)
+    logger.info('token encstr = {}'.format(encstr))
+    return encstr
+
+
+def decrypt(encstr):
+    try:
+        decstr = jwe.decrypt(encstr.encode('utf-8'), OFFICESERVER_JWE_KEY)
+        jsonobj = jwt.decode(decstr, settings.OFFICESERVER_JWT_SECRET, algorithms=settings.OFFICESERVER_JWT_ALGORITHM)
+        #jsonobj = jwt.decode(decstr, websettings.JWT_SECRET, algorithms=websettings.JWT_ALGORITHM)
+    except Exception as e:
+        logger.info('decrypt failed.')
+        jsonobj = None
+    return jsonobj
+
+
+def check_token(jsonobj, file_id):
+    # token schema check
+    if _check_schema(jsonobj) is False:
+        logger.info('check_schema failed.')
+        return False
+
+    # file_id check
+    if file_id != jsonobj['data']['fileid']:
+        logger.info('token file_id check failed.')
+        logger.info('file_id, token file_id : {}  {}'.format(file_id, jsonobj['data']['fileid']))
+        return False
+
+    # expiration check
+    nt = int(_get_timestamp())
+    if nt > jsonobj['exp']:
+        logger.info('token time expire failed.')
+        logger.info('nt, token expire : {}  {}'.format(nt, jsonobj['exp']))
+        return False
+
+    return True
+
+
+def get_cookie(jsonobj):
+    return jsonobj['data']['auth']

--- a/addons/onlyoffice/token.py
+++ b/addons/onlyoffice/token.py
@@ -12,16 +12,16 @@ logger = logging.getLogger(__name__)
 OFFICESERVER_JWE_KEY = jwe.kdf(settings.OFFICESERVER_JWE_SECRET.encode('utf-8'), settings.OFFICESERVER_JWE_SALT.encode('utf-8'))
 
 token_schema = {
-    "type": "object",
-    "required": ["exp", "data"],
-    "properties": {
-        "exp" : {"type" : "number"},
-        "data" : {
-            "type": "object",
-            "required": ["auth", "file_id"],
-            "properties" : {
-                "auth" : {"type" : "string"},
-                "file_id" : {"type" : "string"}
+    'type': 'object',
+    'required': ['exp', 'data'],
+    'properties': {
+        'exp': {'type': 'number'},
+        'data': {
+            'type': 'object',
+            'required': ['auth', 'file_id'],
+            'properties': {
+                'auth': {'type': 'string'},
+                'file_id': {'type': 'string'}
             }
         }
     }
@@ -44,7 +44,7 @@ def _check_schema(token):
 def encrypt(cookie, file_id):
     jwte = jwt.encode(
         {
-            'data' : {
+            'data': {
                 'auth': cookie,
                 'file_id': file_id
             },

--- a/addons/onlyoffice/token.py
+++ b/addons/onlyoffice/token.py
@@ -50,7 +50,7 @@ def encrypt(cookie, file_id):
             },
             'exp': int(datetime.now(timezone.utc).timestamp() +
                        timedelta(seconds=settings.WOPI_TOKEN_TTL).seconds) +
-                       settings.WOPI_EXPIRATION_TIMER_DELAY
+            settings.WOPI_EXPIRATION_TIMER_DELAY
         },
         settings.OFFICESERVER_JWT_SECRET, algorithm=settings.OFFICESERVER_JWT_ALGORITHM)
     encstr = jwe.encrypt(jwte, OFFICESERVER_JWE_KEY).decode()
@@ -62,7 +62,7 @@ def decrypt(encstr):
     try:
         decstr = jwe.decrypt(encstr.encode('utf-8'), OFFICESERVER_JWE_KEY)
         jsonobj = jwt.decode(decstr, settings.OFFICESERVER_JWT_SECRET, algorithms=settings.OFFICESERVER_JWT_ALGORITHM)
-    except Exception as e:
+    except Exception:
         logger.warning('onlyoffice: token decrypt failed.')
         jsonobj = None
     return jsonobj

--- a/addons/onlyoffice/util.py
+++ b/addons/onlyoffice/util.py
@@ -85,7 +85,7 @@ def _get_onlyoffice_discovery(server):
     try:
         response = requests.get(server + '/hosting/discovery')
         response.raise_for_status()
-    except RequestException as e:
+    except RequestException:
         logger.warning('onlyoffice: Could not get discovery message from onlyoffice.')
         return None
     return response.text

--- a/addons/onlyoffice/views.py
+++ b/addons/onlyoffice/views.py
@@ -32,7 +32,7 @@ def onlyoffice_check_file_info(**kwargs):
         return Response(response='', status=500)
 
     jsonobj = token.decrypt(access_token)
-    # logger.info('check_file_info jsonobj = {}'.format(jsonobj))
+    # logger.info('onlyoffice: check_file_info jsonobj = {}'.format(jsonobj))
     if jsonobj is None:
         return Response(response='', status=500)
 
@@ -45,14 +45,14 @@ def onlyoffice_check_file_info(**kwargs):
     user_info = onlyoffice_util.get_user_info(cookie)
     file_node = BaseFileNode.load(file_id)
     if file_node is None:
-        logger.error('BaseFileNode None')
+        logger.warning('onlyoffice: BaseFileNode None')
         return Response(response='', status=500)
     file_version = onlyoffice_util.get_file_version(file_id)
     cookies = { websettings.COOKIE_NAME: cookie }
     file_info = onlyoffice_util.get_file_info(file_node, file_version, cookies)
     filename = '' if file_info is None else file_info['name']
 
-    logger.info('ONLYOFFICE file opened : user id = {}, fullname = {}, file_name = {}'
+    logger.info('ONLYOFFICE: file opened : user id = {}, fullname = {}, file_name = {}'
                 .format(user_info['user_id'], user_info['full_name'], filename))
 
     res = {
@@ -117,7 +117,7 @@ def onlyoffice_file_content_view(**kwargs):
         return Response(response='', status=500)
 
     jsonobj = token.decrypt(access_token)
-    # logger.info('file_content_view jsonobj = {}'.format(jsonobj))
+    # logger.info('onlyoffice: file_content_view jsonobj = {}'.format(jsonobj))
     if jsonobj is None:
         return Response(response='', status=500)
 
@@ -130,15 +130,15 @@ def onlyoffice_file_content_view(**kwargs):
     user_info = onlyoffice_util.get_user_info(cookie)
     file_node = BaseFileNode.load(file_id)
     if file_node is None:
-        logger.error('BaseFileNode None')
+        logger.warning('onlyoffice: BaseFileNode None')
         return Response(response='', status=500)
     file_version = onlyoffice_util.get_file_version(file_id)
     cookies = { websettings.COOKIE_NAME: cookie }
     file_info = onlyoffice_util.get_file_info(file_node, file_version, cookies)
     filename = '' if file_info is None else file_info['name']
 
-    # logger.info('file_content_view: method, file_id, access_token = {} {} {}'.format(request.method, file_id, access_token))
-    # logger.info('waterbutler url = {}'.format(websettings.WATERBUTLER_URL))
+    # logger.info('onlyoffice: file_content_view: method, file_id, access_token = {} {} {}'.format(request.method, file_id, access_token))
+    # logger.info('onlyoffice: waterbutler url = {}'.format(websettings.WATERBUTLER_URL))
 
     if request.method == 'GET':
         #  wopi GetFile endpoint
@@ -146,7 +146,7 @@ def onlyoffice_file_content_view(**kwargs):
         status_code = ''
         try:
             wburl = file_node.generate_waterbutler_url(version=file_version, action='download', direct=None, _internal=True)
-            # logger.info('wburl, cookies = {}  {}'.format(wburl, cookies))
+            # logger.info('onlyoffice: wburl, cookies = {}  {}'.format(wburl, cookies))
             response = requests.get(
                 wburl,
                 cookies=cookies,
@@ -156,23 +156,23 @@ def onlyoffice_file_content_view(**kwargs):
             if status_code == 200:
                 content = response.raw
             else:
-                logger.error('Waterbutler return error.')
+                logger.warning('onlyoffice: Waterbutler return error.')
         except Exception as err:
-            logger.error(err)
+            logger.warning(err)
             return
 
         return Response(response=content, status=status_code)
 
     if request.method == 'POST':
         #  wopi PutFile endpoint
-        logger.info('ONLYOFFICE file saved  : user id = {}, fullname = {}, file_name = {}'
+        logger.info('ONLYOFFICE: file saved  : user id = {}, fullname = {}, file_name = {}'
                     .format(user_info['user_id'], user_info['full_name'], filename))
         if not request.data:
             return Response(response='Not possible to get the file content.', status=401)
 
         data = request.data
         wburl = file_node.generate_waterbutler_url(direct=None, _internal=True) + '?kind=file'
-        logger.debug('wburl = {}'.format(wburl))
+        logger.debug('onlyoffice: wburl = {}'.format(wburl))
         try:
             response = requests.put(
                 wburl,
@@ -181,9 +181,9 @@ def onlyoffice_file_content_view(**kwargs):
             )
             status_code = response.status_code
             if status_code != 200:
-                logger.error('Waterbutler return error.')
+                logger.warning('onlyoffice: Waterbutler return error.')
         except Exception as err:
-            logger.error(err)
+            logger.warning(err)
 
         return Response(status=status_code)
 
@@ -191,22 +191,22 @@ def onlyoffice_file_content_view(**kwargs):
 # Do not add decorator, or else online editor will not open.
 def onlyoffice_lock_file(**kwargs):
     file_id = kwargs['file_id']
-    logger.info('lock_file: file_id = {}'.format(file_id))
+    logger.debug('onlyoffice: lock_file: file_id = {}'.format(file_id))
 
     if request.method == 'POST':
         operation = request.META.get('X-WOPI-Override', None)
         if operation == 'LOCK':
             lockId = request.META.get('X-WOPI-Lock', None)
-            logger.debug(f"Lock: file id: {file_id}, access token: {request.args.get['access_token']}, lock id: {lockId}")
+            logger.debug(f"onlyoffice: Lock: file id: {file_id}, access token: {request.args.get['access_token']}, lock id: {lockId}")
         elif operation == 'UNLOCK':
             lockId = request.META.get('X-WOPI-Lock', None)
-            logger.debug(f"UnLock: file id: {file_id}, access token: {request.args.get['access_token']}, lock id: {lockId}")
+            logger.debug(f"onlyoffice: UnLock: file id: {file_id}, access token: {request.args.get['access_token']}, lock id: {lockId}")
         elif operation == 'REFRESH_LOCK':
             lockId = request.META.get('X-WOPI-Lock', None)
-            logger.debug(f"RefreshLock: file id: {file_id}, access token: {request.args.get['access_token']}, lock id: {lockId}")
+            logger.debug(f"onlyoffice: RefreshLock: file id: {file_id}, access token: {request.args.get['access_token']}, lock id: {lockId}")
         elif operation == 'RENAME':
             toName = request.META.get('X-WOPI-RequestedName', None)
-            logger.debug(f"Rename: file id: {file_id}, access token: {request.args.get['access_token']}, toName: {toName}")
+            logger.debug(f"onlyoffice: Rename: file id: {file_id}, access token: {request.args.get['access_token']}, toName: {toName}")
 
     return Response(status=200)   # Status 200
 
@@ -215,13 +215,12 @@ def onlyoffice_lock_file(**kwargs):
 def onlyoffice_edit_by_onlyoffice(**kwargs):
     file_id = kwargs['file_id']
     cookie = request.cookies.get(websettings.COOKIE_NAME)
-    #logger.debug('cookie = {}'.format(cookie))
-    #logger.info('cookie = {}'.format(cookie))
+    # logger.info('onlyoffice: cookie = {}'.format(cookie))
 
     # file_id -> fileinfo
     file_node = BaseFileNode.load(file_id)
     if file_node is None:
-        logger.error('BaseFileNode None')
+        logger.warning('onlyoffice: BaseFileNode None')
         return Response(response='', status=500)
 
     ext = os.path.splitext(file_node.name)[1][1:]
@@ -230,28 +229,28 @@ def onlyoffice_edit_by_onlyoffice(**kwargs):
     token_ttl = (time.time() + settings.WOPI_TOKEN_TTL) * 1000
 
     wopi_client_host = settings.WOPI_CLIENT_ONLYOFFICE
-    logger.debug('edit_online.index_view wopi_client_host = {}'.format(wopi_client_host))
+    logger.debug('onlyoffice: edit_online.index_view wopi_client_host = {}'.format(wopi_client_host))
 
     wopi_url = ''
     wopi_client_url = onlyoffice_util.get_onlyoffice_url(wopi_client_host, 'edit', ext)
     if wopi_client_url:
         wopi_src_host = settings.WOPI_SRC_HOST
         wopi_src = f'{wopi_src_host}/wopi/files/{file_id}'
-        # logger.info('edit_by_onlyoffice.index_view wopi_src = {}'.format(wopi_src))
+        # logger.info('onlyoffice: edit_by_onlyoffice.index_view wopi_src = {}'.format(wopi_src))
         wopi_url = wopi_client_url \
             + 'rs=ja-jp&ui=ja-jp'  \
             + '&WOPISrc=' + wopi_src
 
-    # logger.info('edit_by_online.index_view wopi_url = {}'.format(wopi_url))
+    # logger.info('onlyoffice: edit_by_online.index_view wopi_url = {}'.format(wopi_url))
 
     # Get public key for proof-key check from onlyoffice server, if did not have yet.
     if pkhelper.hasKey() is False:
         proof_key = onlyoffice_util.get_proof_key(wopi_client_host)
         if proof_key is not None:
             pkhelper.setKey(proof_key)
-            logger.info('edit_by_onlyoffice pkhelper key initialized.')
+            # logger.info('onlyoffice: edit_by_onlyoffice pkhelper key initialized.')
 
-    logger.info('edit_by_online.index_view wopi_url = {}'.format(wopi_url))
+    logger.debug('onlyoffice: edit_by_online.index_view wopi_url = {}'.format(wopi_url))
     context = {
         'wopi_url': wopi_url,
         'access_token': access_token,

--- a/addons/onlyoffice/views.py
+++ b/addons/onlyoffice/views.py
@@ -43,8 +43,9 @@ def onlyoffice_check_file_info(**kwargs):
 
     cookie = token.get_cookie(jsonobj)    
     user_info = onlyoffice_util.get_user_info(cookie)
-    file_node = BaseFileNode.load(file_id)
-    if file_node is None:
+    try:
+        file_node = BaseFileNode.objects.get(_id=file_id)
+    except Exception:
         logger.warning('onlyoffice: BaseFileNode None')
         return Response(response='', status=500)
     file_version = onlyoffice_util.get_file_version(file_id)
@@ -128,8 +129,9 @@ def onlyoffice_file_content_view(**kwargs):
 
     cookie = token.get_cookie(jsonobj)
     user_info = onlyoffice_util.get_user_info(cookie)
-    file_node = BaseFileNode.load(file_id)
-    if file_node is None:
+    try:
+        file_node = BaseFileNode.objects.get(_id=file_id)
+    except Exception:
         logger.warning('onlyoffice: BaseFileNode None')
         return Response(response='', status=500)
     file_version = onlyoffice_util.get_file_version(file_id)
@@ -216,13 +218,11 @@ def onlyoffice_edit_by_onlyoffice(**kwargs):
     file_id = kwargs['file_id']
     cookie = request.cookies.get(websettings.COOKIE_NAME)
     # logger.info('onlyoffice: cookie = {}'.format(cookie))
-
-    # file_id -> fileinfo
-    file_node = BaseFileNode.load(file_id)
-    if file_node is None:
+    try:
+        file_node = BaseFileNode.objects.get(_id=file_id)
+    except Exception:
         logger.warning('onlyoffice: BaseFileNode None')
         return Response(response='', status=500)
-
     ext = os.path.splitext(file_node.name)[1][1:]
     access_token = token.encrypt(cookie, file_id)
     # access_token ttl (ms)

--- a/addons/onlyoffice/views.py
+++ b/addons/onlyoffice/views.py
@@ -41,7 +41,7 @@ def onlyoffice_check_file_info(**kwargs):
     if token.check_token(jsonobj, file_id) is False:
         return Response(response='', status=500)
 
-    cookie = token.get_cookie(jsonobj)    
+    cookie = token.get_cookie(jsonobj)
     user_info = onlyoffice_util.get_user_info(cookie)
     try:
         file_node = BaseFileNode.objects.get(_id=file_id)

--- a/addons/onlyoffice/views.py
+++ b/addons/onlyoffice/views.py
@@ -49,7 +49,7 @@ def onlyoffice_check_file_info(**kwargs):
         logger.warning('onlyoffice: BaseFileNode None')
         return Response(response='', status=500)
     file_version = onlyoffice_util.get_file_version(file_id)
-    cookies = { websettings.COOKIE_NAME: cookie }
+    cookies = {websettings.COOKIE_NAME: cookie}
     file_info = onlyoffice_util.get_file_info(file_node, file_version, cookies)
     filename = '' if file_info is None else file_info['name']
 
@@ -135,7 +135,7 @@ def onlyoffice_file_content_view(**kwargs):
         logger.warning('onlyoffice: BaseFileNode None')
         return Response(response='', status=500)
     file_version = onlyoffice_util.get_file_version(file_id)
-    cookies = { websettings.COOKIE_NAME: cookie }
+    cookies = {websettings.COOKIE_NAME: cookie}
     file_info = onlyoffice_util.get_file_info(file_node, file_version, cookies)
     filename = '' if file_info is None else file_info['name']
 


### PR DESCRIPTION
## Purpose

 GRDMとONLYOFFICEとの接続に対し、以下の機能を追加する。

  - WaterButlerにアクセスするためのトークンを、暗号化したものをONLYOFFICE用のaccess_tokenとしてONLYOFFICEに渡す。
  - ONLYOFFICEからファイル読み書き要求時にaccess_tokenを復号し、Waterbutlerにアクセスするトークンとして使用する。
  - access_tokenに対して、有効期限、内容等のチェックを行う。

## Changes

  - トークン関連処理追加 (token.py. util.py)
  - 暗号処理に使うパラメータを設定ファイルに追加 (settings以下の__init__.py, defaults.py)
  - ログメッセージのレベル見直し
  - テストコード追加 (tests/test_token.py)
  - 一部バグフィックス (views.py)

## QA Notes

  - none.

## Documentation

  - none

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
