### PR TITLE
[GRDM-47630] WEKOアドオンの下書きファイルをアドオン方式機関ストレージに保存可能にする

### DIFF
--- a/addons/weko/models.py
+++ b/addons/weko/models.py
@@ -206,6 +206,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             'url': provider.sword_url,
             'index_id': self.index_id,
             'index_title': self.index_title,
+            'default_storage_provider': default_provider.short_name,
             'default_storage': default_provider.serialize_waterbutler_settings(),
         }
 


### PR DESCRIPTION
RDM-waterbutlerの対応Pull Requestは https://github.com/RCOSDP/RDM-waterbutler/pull/71 です。合わせてマージいただけますと幸いです。

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

WEKOアドオンの下書きファイルをアドオン方式機関ストレージに保存可能にする

## Changes

- [GRDM-47630] WEKOアドオンのsettingsに、下書き保存先ストレージプロバイダ名 `default_storage_provider` を格納可能にする

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-47630