### PR TITLE
[GRDM-48578] オフィスソフトウエア連携機能実装　エラー処理追加、不具合修正 (to rcos-release branch)

### DIFF
--- a/addons/onlyoffice/requirements.txt
+++ b/addons/onlyoffice/requirements.txt
@@ -1,2 +1,1 @@
 #
-pycryptodome==3.20.0

--- a/addons/onlyoffice/routes.py
+++ b/addons/onlyoffice/routes.py
@@ -7,7 +7,7 @@ TEMPLATE_DIR = './addons/onlyoffice/templates'
 edit_routes = {
     # Edit by ONLYOFFICE
     'rules': [
-        Rule(['/<guid>/editonlyoffice/<file_id>'], 'get',
+        Rule(['/<guid>/editonlyoffice/<provider>/<path:path>/'], 'get',
         views.onlyoffice_edit_by_onlyoffice,
         OsfWebRenderer('edit_online.mako', trust=True, template_dir=TEMPLATE_DIR),)
     ]

--- a/addons/onlyoffice/templates/error.mako
+++ b/addons/onlyoffice/templates/error.mako
@@ -1,0 +1,12 @@
+<%inherit file="base.mako"/>
+<%def name="title()">${message_short}</%def>
+<%def name="content()">
+<div class="container">
+    <div class='row'>
+        <div class='col-md-12'>
+            <h2 id='error' data-http-status-code="${code}">${message_short}</h2>
+            <p>${ message_long | unicode, n }</p>
+        </div>
+    </div>
+</div>
+</%def>

--- a/addons/onlyoffice/tests/test_view.py
+++ b/addons/onlyoffice/tests/test_view.py
@@ -90,6 +90,7 @@ class TestOnlyofficeAddon(OsfTestCase):
         mock_filenode.name = 'filename.docx'
         mock_user_info = {'user_id': 'userid', 'full_name': 'fullname', 'display_name': 'dispname'}
         mock_file_info = {'name': 'filename.docx', 'mtime': '202501010000'}
+        mock_file_version = ''
         mock_access_token = {websettings.COOKIE_NAME: 'cookie'}
 
         with mock.patch.object(BaseFileNode.objects, 'get', return_value=mock_filenode):
@@ -98,6 +99,7 @@ class TestOnlyofficeAddon(OsfTestCase):
                     with mock.patch.object(onlyoffice_token, 'decrypt', return_value=mock_jsonobj):
                         with mock.patch.object(onlyoffice_token, 'check_token', return_value=mock_check_token):
                             with mock.patch.object(onlyoffice_util, 'get_file_info', return_value=mock_file_info):
-                                with mock.patch.object(onlyoffice_util, 'check_proof_key', return_value=mock_proof_key):
-                                    res = onlyoffice_check_file_info(file_id='ABCDEFG')
+                                with mock.patch.object(onlyoffice_util, 'get_file_version', return_value=mock_file_version):
+                                    with mock.patch.object(onlyoffice_util, 'check_proof_key', return_value=mock_proof_key):
+                                        res = onlyoffice_check_file_info(file_id='ABCDEFG')
         assert res['BaseFileName'] == 'filename.docx'

--- a/addons/onlyoffice/tests/test_view.py
+++ b/addons/onlyoffice/tests/test_view.py
@@ -89,7 +89,7 @@ class TestOnlyofficeAddon(OsfTestCase):
         mock_filenode = Filenode()
         mock_filenode.name = 'filename.docx'
         mock_user_info = {'user_id': 'userid', 'full_name': 'fullname', 'display_name': 'dispname'}
-        mock_file_info = {'name': 'filename.docx'}
+        mock_file_info = {'name': 'filename.docx', 'mtime': '202501010000'}
         mock_access_token = {websettings.COOKIE_NAME: 'cookie'}
 
         with mock.patch.object(BaseFileNode.objects, 'get', return_value=mock_filenode):

--- a/addons/onlyoffice/util.py
+++ b/addons/onlyoffice/util.py
@@ -2,7 +2,7 @@
 import logging
 import requests
 from lxml import etree
-from osf.models import BaseFileNode, OSFUser
+from osf.models import OSFUser
 from osf.utils.permissions import WRITE
 from requests.exceptions import RequestException
 
@@ -58,12 +58,10 @@ def get_file_info(file_node, file_version, cookies):
     return file_info
 
 
-def get_file_version(file_id):
+def get_file_version(file_node):
     file_version = ''
-    base_file_data = BaseFileNode.objects.filter(_id=file_id)
-    if base_file_data.exists():
-        base_file_data = base_file_data.get()
-        file_versions = base_file_data.versions.all()
+    if file_node.provider == 'osfstorage':
+        file_versions = file_node.versions.all()
         if file_versions is not None and file_versions.exists():
             file_version = file_versions.latest('id').identifier
     return file_version

--- a/addons/onlyoffice/views.py
+++ b/addons/onlyoffice/views.py
@@ -54,7 +54,7 @@ def onlyoffice_check_file_info(**kwargs):
 
     logger.debug('onlyoffice: check_file_info file_id = {}, file_node.name = {}'.format(file_id, file_node.name))
 
-    file_version = onlyoffice_util.get_file_version(file_id)
+    file_version = onlyoffice_util.get_file_version(file_node)
     cookies = {websettings.COOKIE_NAME: cookie}
     file_info = onlyoffice_util.get_file_info(file_node, file_version, cookies)
     if file_info is None:
@@ -150,9 +150,9 @@ def onlyoffice_file_content_view(**kwargs):
         logger.warning('onlyoffice: user: {} BaseFileNode None.'.format(user_info['user_id']))
         return Response(response='onlyoffice file_content_view exception in BaseFileNode.objects.get.', status=500)
 
-    # logger.info('onlyoffice: file_content_view file_id = {}, file_node.name = {}'.format(file_id, file_node.name))
+    logger.debug('onlyoffice: file_content_view file_id = {}, file_node.name = {}'.format(file_id, file_node.name))
 
-    file_version = onlyoffice_util.get_file_version(file_id)
+    file_version = onlyoffice_util.get_file_version(file_node)
     cookies = {websettings.COOKIE_NAME: cookie}
     file_info = onlyoffice_util.get_file_info(file_node, file_version, cookies)
     if file_info is None:

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1472,7 +1472,7 @@ function _createFile(event, dismissCallback, helpText, extension) {
         orderFolder.call(tb, parent);
         item.notify.update(gettext('New file created!'), 'success', undefined, 1000);
         if (extension.match('(txt|docx|xlsx|pptx)')) {
-            var edit_url = window.contextVars.osfURL + window.contextVars.currentUser.id + '/editonlyoffice' +item.data.path;
+            var edit_url = window.contextVars.osfURL + window.contextVars.node.id + '/editonlyoffice/' +item.data.id;
             window.open(edit_url, 'ONLYOFFICE Editor');
         }
         if(dismissCallback) {

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -569,7 +569,7 @@ var FileViewPage = {
             (
                 window.contextVars.wopi.onlyoffice_url && ctrl.file.name.match(editExtensions) && ctrl.isLatestVersion && ctrl.canEdit()
             ) ? m('.btn-group.m-t-xs', [
-                    m('a.btn.btn-sm.btn-default.file-edit', {href: 'editonlyoffice/' + ctrl.file.id, target: '_blank'}, _('Edit(ONLYOFFICE)'))
+                    m('a.btn.btn-sm.btn-default.file-edit', {href: '/' + window.contextVars.node.id + '/editonlyoffice/' + ctrl.file.provider + ctrl.file.path, target: '_blank'}, _('Edit(ONLYOFFICE)'))
             ]) : ''
         ]));
 


### PR DESCRIPTION
## Purpose

 rcos-release に対する修正
 - エラー処理の追加
　　read only プロジェクト下のファイルについて、URLを直接指定しての編集を禁止
　　check out ファイルへの他ユーザによる編集を禁止
 - ファイルread/writeのストリーム化
 - アドオンストレージに対する不具合対応

## Changes

 - routes.py
 - views.py
 - util.py
 - website/static/jsfangorn.js
 - website/static/js/filepage/index.js

## QA Notes

 - None

## Documentation

 - None

## Side Effects

 - None

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
