### PR TITLE
[GRDM-50321] Project Metadata関連リソースの権限調整

### DIFF
--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -340,7 +340,7 @@ class NodeLinksShowIfVersion(ShowIfVersion):
 
 
 # GRDM-50321 Project Metadata should be available to non-admins.
-class IsAdminContributorToRegisterDrafts(permissions.BasePermission):
+class IsWritableContributorToRegisterDrafts(permissions.BasePermission):
 
     acceptable_models = (AbstractNode, DraftRegistration,)
 
@@ -350,9 +350,6 @@ class IsAdminContributorToRegisterDrafts(permissions.BasePermission):
         """
         assert_resource_type(obj, self.acceptable_models)
         auth = get_user_auth(request)
-        if request.method != 'POST':
-            if request.method in permissions.SAFE_METHODS:
-                return obj.is_public or obj.can_view(auth)
-            else:
-                return obj.has_permission(auth.user, osf_permissions.WRITE)
-        return obj.is_admin_contributor(auth.user)
+        if request.method in permissions.SAFE_METHODS:
+            return obj.is_public or obj.can_view(auth)
+        return obj.has_permission(auth.user, osf_permissions.WRITE)

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -718,9 +718,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         return len(registrations)
 
     def get_draft_registration_count(self, obj):
-        auth = get_user_auth(self.context['request'])
-        if obj.has_permission(auth.user, osf_permissions.ADMIN):
-            return obj.draft_registrations_active.count()
+        return obj.draft_registrations_active.count()
 
     def get_pointers_count(self, obj):
         return obj.linked_nodes.count()

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -84,6 +84,7 @@ from api.nodes.permissions import (
     ExcludeWithdrawals,
     NodeLinksShowIfVersion,
     ReadOnlyIfWithdrawn,
+    IsAdminContributorToRegisterDrafts,
 )
 from api.nodes.serializers import (
     NodeSerializer,
@@ -756,6 +757,7 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
         # GRDM-50321 Project Metadata should be available to non-admins.
         # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
         # Therefore, the project metadata should be available to non-admins.
+        IsAdminContributorToRegisterDrafts,
         ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -84,7 +84,7 @@ from api.nodes.permissions import (
     ExcludeWithdrawals,
     NodeLinksShowIfVersion,
     ReadOnlyIfWithdrawn,
-    IsAdminContributorToRegisterDrafts,
+    IsWritableContributorToRegisterDrafts,
 )
 from api.nodes.serializers import (
     NodeSerializer,
@@ -757,7 +757,7 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
         # GRDM-50321 Project Metadata should be available to non-admins.
         # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
         # Therefore, the project metadata should be available to non-admins.
-        IsAdminContributorToRegisterDrafts,
+        IsWritableContributorToRegisterDrafts,
         ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -71,11 +71,9 @@ from api.logs.serializers import NodeLogSerializer, NodeLogDownloadSerializer
 from api.nodes.filters import NodesFilterMixin
 from api.nodes.permissions import (
     IsAdmin,
-    IsAdminContributor,
     IsPublic,
     AdminOrPublic,
     ContributorOrPublic,
-    AdminContributorOrPublic,
     RegistrationAndPermissionCheckForPointers,
     ContributorDetailPermissions,
     ReadOnlyIfRegistration,
@@ -685,7 +683,10 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
     Use DraftRegistrationsList endpoint instead.
     """
     permission_classes = (
-        IsAdminContributor,
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
+        # Therefore, the project metadata should be available to non-admins.
+        ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )
@@ -721,7 +722,10 @@ class NodeDraftRegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestro
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        IsAdminContributor,
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
+        # Therefore, the project metadata should be available to non-admins.
+        ContributorOrPublic,
     )
     parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
 
@@ -749,7 +753,10 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_registrations_list).
     """
     permission_classes = (
-        AdminContributorOrPublic,
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
+        # Therefore, the project metadata should be available to non-admins.
+        ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ExcludeWithdrawals,

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -61,7 +61,7 @@ from api.wikis.serializers import RegistrationWikiSerializer
 
 from api.base.utils import get_object_or_error
 from framework.sentry import log_exception
-from osf.utils.permissions import ADMIN
+from osf.utils.permissions import WRITE
 
 
 class RegistrationMixin(NodeMixin):
@@ -177,7 +177,7 @@ class RegistrationList(JSONAPIBaseView, generics.ListCreateAPIView, bulk_views.B
 
         # A user must be an admin contributor on the node (not group member), and have
         # admin perms on the draft to register
-        if node.is_admin_contributor(user) and draft.has_permission(user, ADMIN):
+        if node.has_permission(user, WRITE) and draft.has_permission(user, WRITE):
             try:
                 serializer.save(draft=draft)
             except ValidationError as e:
@@ -185,7 +185,7 @@ class RegistrationList(JSONAPIBaseView, generics.ListCreateAPIView, bulk_views.B
                 raise e
         else:
             raise PermissionDenied(
-                'You must be an admin contributor on both the project and the draft registration to create a registration.',
+                'You must has a write permission on both the project and the draft registration to create a registration.',
             )
 
     def check_branched_from(self, draft):

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -470,6 +470,43 @@ class TestDraftRegistrationUpdateWithNode(TestDraftRegistrationUpdate, TestUpdat
             'comments': 'This is my first registration.'
         }
 
+    # GRDM-50321 Change permissions for drafts
+    def test_cannot_update_draft(
+            self, app, user_write_contrib,
+            user_read_contrib, user_non_contrib,
+            project_public, group,
+            payload, url_draft_registrations, group_mem):
+
+        #   test_read_only_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_read_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_write_contributor_can_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_write_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_logged_in_non_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_non_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_unauthenticated_user_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload, expect_errors=True)
+        assert res.status_code == 401
+
 
 @pytest.mark.django_db
 class TestDraftRegistrationUpdateWithDraftNode(TestDraftRegistrationUpdate):
@@ -512,6 +549,43 @@ class TestDraftRegistrationUpdateWithDraftNode(TestDraftRegistrationUpdate):
             'comments': 'This is my first registration.'
         }
 
+    # GRDM-50321 Change permissions for drafts
+    def test_cannot_update_draft(
+            self, app, user_write_contrib,
+            user_read_contrib, user_non_contrib,
+            project_public, group,
+            payload, url_draft_registrations, group_mem):
+
+        #   test_read_only_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_read_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_write_contributor_can_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_write_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_logged_in_non_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_non_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_unauthenticated_user_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload, expect_errors=True)
+        assert res.status_code == 401
+
 
 class TestDraftRegistrationPatchNew(TestDraftRegistrationPatch):
     @pytest.fixture()
@@ -547,6 +621,43 @@ class TestDraftRegistrationPatchNew(TestDraftRegistrationPatch):
         data = res.json['data']
         assert schema._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['attributes']['registration_metadata'] == payload['data']['attributes']['registration_metadata']
+
+    # GRDM-50321 Change permissions for drafts
+    def test_cannot_update_draft(
+            self, app, user_write_contrib,
+            user_read_contrib, user_non_contrib,
+            project_public, group,
+            payload, url_draft_registrations, group_mem):
+
+        #   test_read_only_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_read_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_write_contributor_can_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_write_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_logged_in_non_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_non_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_unauthenticated_user_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload, expect_errors=True)
+        assert res.status_code == 401
 
 
 class TestDraftRegistrationDelete(TestDraftRegistrationDelete):

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -64,6 +64,37 @@ class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
         res = app.get(url_draft_registrations, expect_errors=True)
         assert res.status_code == 401
 
+    # GRDM-50321 Change permissions for drafts
+    def test_can_view_draft_list_by_non_admin_user(
+            self, app, user_write_contrib, project_public,
+            user_read_contrib, user_non_contrib,
+            url_draft_registrations, group, group_mem):
+
+        # test_read_only_contributor_can_view_draft_list
+        res = app.get(
+            url_draft_registrations,
+            auth=user_read_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_read_write_contributor_can_view_draft_list
+        res = app.get(
+            url_draft_registrations,
+            auth=user_write_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_logged_in_non_contributor_can_view_draft_list(when node is public)
+        res = app.get(
+            url_draft_registrations,
+            auth=user_non_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_unauthenticated_user_can_view_draft_list(when node is public)
+        res = app.get(url_draft_registrations, expect_errors=True)
+        assert res.status_code == 401
+
 
 class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
     @pytest.fixture()

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -887,6 +887,23 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             return parent.is_admin_parent(user, include_group_admin=include_group_admin)
         return False
 
+    def is_writable_parent(self, user, include_group_writable=True):
+        """
+        :param user: OSFUser to check for admin permissions
+        :param bool include_group_writable: Check if a user is an admin on the parent project via a group.
+                                    Useful for checking parent permissions for non-group actions like registrations.
+        :return: bool Does the user have admin permissions on this object or its parents?
+        """
+        if self.has_permission(user, WRITE, check_parent=False):
+            ret = True
+            if not include_group_writable and not self.is_contributor(user):
+                ret = False
+            return ret
+        parent = self.parent_node
+        if parent:
+            return parent.is_writable_parent(user, include_group_writable=include_group_writable)
+        return False
+
     def find_readable_descendants(self, auth):
         """ Returns a generator of first descendant node(s) readable by <user>
         in each descendant branch.
@@ -1398,9 +1415,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         :param parent Node: parent registration of registration to be created
         :param provider RegistrationProvider: provider to submit the registration to
         """
-        # NOTE: Admins can register child nodes even if they don't have write access to them, but not if they are group admins
-        not_contributor_or_admin_parent = not self.is_contributor(auth.user) and not self.is_admin_parent(user=auth.user, include_group_admin=False)
-        cannot_edit_or_admin_parent = not self.can_edit(auth=auth) and not self.is_admin_parent(user=auth.user)
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        not_contributor_or_admin_parent = not self.is_contributor(auth.user) and not self.is_writable_parent(user=auth.user, include_group_writable=False)
+        cannot_edit_or_admin_parent = not self.can_edit(auth=auth) and not self.is_writable_parent(user=auth.user)
         if cannot_edit_or_admin_parent or not_contributor_or_admin_parent:
             raise PermissionsError(
                 'User {} does not have permission '
@@ -1551,8 +1568,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     def require_approval(self, user, notify_initiator_on_complete=False):
         if not self.is_registration:
             raise NodeStateError('Only registrations can require registration approval')
-        if not self.is_admin_contributor(user):
-            raise PermissionsError('Only admins can initiate a registration approval')
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        if not self.has_permission(user, WRITE):
+            raise PermissionsError('Only writers can initiate a registration approval')
 
         approval = self._initiate_approval(user, notify_initiator_on_complete)
 

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -295,8 +295,11 @@ class Registration(AbstractNode):
         :raises: PermissionsError if user is not an admin for the Node
         :raises: ValidationError if end_date is not within time constraints
         """
-        if not self.is_admin_contributor(user):
-            raise PermissionsError('Only admins may embargo a registration')
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
+        # Therefore, the project metadata should be available to non-admins.
+        if not self.is_contributor(user) or not self.can_edit(user=user):
+            raise PermissionsError('Only users with write permission can project metadata.')
         if not self._is_embargo_date_valid(end_date):
             if (end_date - timezone.now()) >= settings.EMBARGO_END_DATE_MIN:
                 raise ValidationError('Registrations can only be embargoed for up to four years.')


### PR DESCRIPTION
ember-osf-web側の修正と合わせてMergeしてください。 https://github.com/RCOSDP/RDM-ember-osf-web/pull/144

## Purpose

Project Metadata関連リソースの権限調整

## Changes

- Project Metadataを非管理者でも書き込み権限があれば操作できるよう、APIの必須パーミッションを修正
- Project Metadataを非管理者でも書き込み権限があれば操作できるよう、Draftからの登録処理を修正

Upstreamとのマージ時にそれとわかるようコメントも追加しています。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-50321