### PR TITLE
[GRDM-50994] Display Node ID item in node list screen

### DIFF
--- a/admin/templates/rdm_timestampadd/node_list.html
+++ b/admin/templates/rdm_timestampadd/node_list.html
@@ -37,6 +37,7 @@
                     </script>
                 </th>
                 {% endif %}
+                <th>{% trans "Node id" %}</th>
                 <th>{% trans "GUID" %}</th>
                 <th>
                     {% trans "Title" %}
@@ -63,6 +64,9 @@
                        class="btn btn-primary">
                         {{ node.id }}
                     </a>
+                </td>
+                <td>
+                    {{ node.guid }}
                 </td>
                 <td>
                     <a href="{% url 'timestampadd:timestamp_add' institution_id=institution.id guid=node.root.id %}">

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2497,6 +2497,12 @@ class Node(AbstractNode):
         """For v1 compat"""
         return False
 
+    @property
+    def guid(self):
+        """Return node's GUID if it exists, otherwise return None."""
+        guid = self.guids.first()
+        return guid._id if guid else guid
+
 def remove_addons(auth, resource_object_list):
     for config in AbstractNode.ADDONS_AVAILABLE:
         try:

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -614,6 +614,15 @@ class TestNodeMODMCompat:
         assert node in Node.objects.filter(guids___id=node._id, guids___id__isnull=False)
 
 
+class TestNode:
+    def test_node_guid(self, node):
+        assert node.guid == node.guids.first()._id
+
+    def test_node_guid_none(self, node):
+        node.guids.all().delete()
+        assert node.guid is None
+
+
 # copied from tests/test_models.py
 class TestProject:
 


### PR DESCRIPTION
## Ticket

GRDM-50994

## Purpose

Display Node ID (GUID) item in node list screen

## Changes

  - admin/templates/rdm_timestampadd/node_list.html
    - Change Guid -> "Node id" column in node list table
  - osf/models/node.py
    - Add new guid property for Node model

## QA Notes


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->
