### PR TITLE
[GRDM-51579] Fix 「利用統計」screen not displaying full screen

### DIFF
--- a/admin/static/css/base.css
+++ b/admin/static/css/base.css
@@ -29,7 +29,3 @@ form p label {
     padding-top: 20px;
     padding-bottom: 20px;
 }
-
-.wrapper {
-    overflow-y: hidden;
-}

--- a/admin/static/js/project_limit_number/setting.js
+++ b/admin/static/js/project_limit_number/setting.js
@@ -91,6 +91,7 @@ $(document).ready(function() {
     $('#setting_name_id').on('invalid', setInvalidMessageForSettingName);
     $('#template_id').on('invalid', setInvalidMessageForTemplateName);
     $('input[name="attribute_value_input"]').on('invalid', setInvalidMessageForAttributeValue);
+    $('.wrapper').css('overflow-y', 'hidden');
 })
 
 // Trim input data on blur


### PR DESCRIPTION
## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
GRDM-51579

## Purpose

<!-- Describe the purpose of your changes -->
Fix the 'RDM Statistics' screen does not display full screen due to missing scrollbar.

## Changes

<!-- Briefly describe or list your changes  -->
Move hidden scrollbar of class "wrapper" in common CSS file to Project Limit Number's Javascript file

## QA Notes


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->
