### PR TITLE
[GRDM-51005] Institution List Selection Screen in User Identification Information

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -168,8 +168,8 @@
               </li>
           {% endif %}
           {% if user.is_superuser %}
-             <li class="{% if request.resolver_match.url_name == 'user_identification_list' or request.resolver_match.url_name == 'user_identification_detail' %}active{% endif %}">
-                 <a href="{% url 'user_identification_information:user_identification_list' %}">
+             <li class="{% if request.resolver_match.url_name == 'user_identification_institutions' or request.resolver_match.url_name == 'user_identification_list' or request.resolver_match.url_name == 'user_identification_detail' %}active{% endif %}">
+                 <a href="{% url 'user_identification_information:user_identification_institutions' %}">
                      <i class='fa fa-link'></i><span>{% trans "User Identification Information" %}</span>
                  </a>
              </li>

--- a/admin/templates/user_identification_information/user_identification_details.html
+++ b/admin/templates/user_identification_information/user_identification_details.html
@@ -14,7 +14,7 @@
         <div class="col-md-12" style="display:flex; align-items: baseline; justify-content: space-between;">
             <h3>{% trans "User details" %}</h3>
             {% if user.is_superuser %}
-                <a href="{% url 'user_identification_information:user_identification_list' %}" class="btn btn-primary">
+                <a href="{% url 'user_identification_information:user_identification_list' institution_id=user_details.affiliation.id %}" class="btn btn-primary">
                     {% trans "Return" %}
                 </a>
             {% else %}

--- a/admin/templates/user_identification_information/user_identification_institution_list.html
+++ b/admin/templates/user_identification_information/user_identification_institution_list.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% load render_bundle from webpack_loader %}
+
+{% block top_includes %}
+    <link rel="stylesheet" type="text/css" href="/static/css/institutions.css"/>
+{% endblock %}
+
+{% block title %}
+    <title>{% trans "List of Institutions" %}</title>
+{% endblock title %}
+
+{% block content %}
+    <h2>{% trans "List of Institutions" %}</h2>
+
+    {% include "util/pagination.html" with items=page status=status %}
+    <table class="table table-striped table-hover table-responsive">
+        <thead>
+        <tr>
+            <th>{% trans "Logo" %}</th>
+            <th width="30%">{% trans "Name" %}</th>
+            <th>{% trans "Description" %}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for institution in institutions %}
+            <tr>
+                <td>
+                    <a href="{% url 'user_identification_information:user_identification_list' institution_id=institution.id %}">
+                        <img class="institution-logo"
+                             src="{{ logohost }}/static/img/institutions/shields/{{ institution.logo_name }}"
+                             alt="{{ institution.name }}">
+                    </a>
+                </td>
+                <td>
+                    <a href="{% url 'user_identification_information:user_identification_list' institution_id=institution.id %}">{{ institution.name }}</a>
+                </td>
+                <td>{{ institution.description | safe }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% if not institutions|length %}
+        <h3>{% trans "No results found" %}</h3>
+    {% endif %}
+{% endblock content %}

--- a/admin/templates/user_identification_information/user_identification_list.html
+++ b/admin/templates/user_identification_information/user_identification_list.html
@@ -123,11 +123,9 @@
     }
 </style>
 <h2 id="title">{% trans "User Identification Information" %}</h2>
-{% if user.is_superuser == False %}
-    <h3 id="sub-title">
-        {% blocktrans %}{{ institution_name }}{% endblocktrans %}
-    </h3>
-{% endif %}
+<h3 id="sub-title">
+    {% blocktrans %}{{ institution_name }}{% endblocktrans %}
+</h3>
 <form
         class="form-inline flex-container search-form"
         action="#"
@@ -189,7 +187,7 @@
         <a
                 class="btn btn-primary"
                 style="padding-left: 6px; padding-right: 6px"
-                href="{% url 'user_identification_information:user_identification_export_csv' %}"
+                href="{% url 'user_identification_information:user_identification_export_csv' institution_id=institution_id %}"
         >{% trans "Export All Users Statistics (CSV)" %}</a
         >
     {% else %}

--- a/admin/user_identification_information/urls.py
+++ b/admin/user_identification_information/urls.py
@@ -7,9 +7,9 @@ app_name = 'admin'
 urlpatterns = [
     url(r'^institutions/$', views.UserIdentificationInstitutionListView.as_view(),
         name='user_identification_institutions'),
-    url(r'^institutions/(?P<institution_id>[a-z0-9]+)/$', views.UserIdentificationListView.as_view(),
+    url(r'^institutions/(?P<institution_id>[0-9]+)/$', views.UserIdentificationListView.as_view(),
         name='user_identification_list'),
-    url(r'^institutions/(?P<institution_id>[a-z0-9]+)/csvexport/$', views.ExportFileCSVView.as_view(),
+    url(r'^institutions/(?P<institution_id>[0-9]+)/csvexport/$', views.ExportFileCSVView.as_view(),
         name='user_identification_export_csv'),
     url(r'^(?P<guid>[a-z0-9]+)/$', views.UserIdentificationDetailView.as_view(),
         name='user_identification_detail'),

--- a/admin/user_identification_information/urls.py
+++ b/admin/user_identification_information/urls.py
@@ -5,9 +5,11 @@ from . import views
 app_name = 'admin'
 
 urlpatterns = [
-    url(r'^$', views.UserIdentificationListView.as_view(),
+    url(r'^institutions/$', views.UserIdentificationInstitutionListView.as_view(),
+        name='user_identification_institutions'),
+    url(r'^institutions/(?P<institution_id>[a-z0-9]+)/$', views.UserIdentificationListView.as_view(),
         name='user_identification_list'),
-    url(r'^csvexport/$', views.ExportFileCSVView.as_view(),
+    url(r'^institutions/(?P<institution_id>[a-z0-9]+)/csvexport/$', views.ExportFileCSVView.as_view(),
         name='user_identification_export_csv'),
     url(r'^(?P<guid>[a-z0-9]+)/$', views.UserIdentificationDetailView.as_view(),
         name='user_identification_detail'),

--- a/admin/user_identification_information/views.py
+++ b/admin/user_identification_information/views.py
@@ -137,6 +137,7 @@ class UserIdentificationListView(RdmPermissionMixin, UserPassesTestMixin, UserId
         """check user permissions"""
         # login check
         if not self.is_authenticated:
+            self.raise_exception = False
             return False
 
         # permitted if superuser
@@ -263,6 +264,7 @@ class ExportFileCSVView(RdmPermissionMixin, UserPassesTestMixin, UserIdentificat
         """check user permissions"""
         # login check
         if not self.is_authenticated:
+            self.raise_exception = False
             return False
 
         # permitted if superuser

--- a/admin_tests/user_identification_information/test_views.py
+++ b/admin_tests/user_identification_information/test_views.py
@@ -378,8 +378,9 @@ class TestUserIdentificationListView(AdminTestCase):
 
     def test__permission_anonymous(self):
         self.request.user = self.anon
-        with nt.assert_raises(PermissionDenied):
-            views.UserIdentificationListView.as_view()(self.request)
+        response = views.UserIdentificationListView.as_view()(self.request)
+        nt.assert_equal(response.status_code, 302)
+        nt.assert_in('login', str(response))
 
     def test__permission_normal_user(self):
         self.request.user = self.user
@@ -526,8 +527,9 @@ class TestExportFileCSVView(AdminTestCase):
 
     def test__permission_anonymous(self):
         self.request.user = self.anon
-        with nt.assert_raises(PermissionDenied):
-            views.ExportFileCSVView.as_view()(self.request)
+        response = views.ExportFileCSVView.as_view()(self.request)
+        nt.assert_equal(response.status_code, 302)
+        nt.assert_in('login', str(response))
 
     def test__permission_normal_user(self):
         self.request.user = self.user


### PR DESCRIPTION
## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
GRDM-51005

## Purpose

<!-- Describe the purpose of your changes -->
Add an institution list screen for User Identification Information.

## Changes

<!-- Briefly describe or list your changes  -->
- Change the URL link for the User Identification Information menu.
- Add URL, logic, and screen for the institution list.
- Add institution_id path param to current URLs.
- Add institution_id filter to current user queries in the User Identification Information screen and export CSV function.

## QA Notes


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->
