### PR TITLE
[GRDM-50105] Fix incorrect permission handling for file operations when using Personal Access Tokens

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -286,20 +286,19 @@ def get_metric_class_for_action(action, from_mfr):
 def get_auth(auth, **kwargs):
     logger.debug('----{}:{}::{} from {}:{}::{}'.format(*inspect_info(inspect.currentframe(), inspect.stack())))
     cas_resp = None
-    if not auth.user:
-        # Central Authentication Server OAuth Bearer Token
-        authorization = request.headers.get('Authorization')
-        if authorization and authorization.startswith('Bearer '):
-            client = cas.get_client()
-            try:
-                access_token = cas.parse_auth_header(authorization)
-                cas_resp = client.profile(access_token)
-            except cas.CasError as err:
-                sentry.log_exception()
-                # NOTE: We assume that the request is an AJAX request
-                return json_renderer(err)
-            if cas_resp.authenticated:
-                auth.user = OSFUser.load(cas_resp.user)
+    # Central Authentication Server OAuth Bearer Token
+    authorization = request.headers.get('Authorization')
+    if authorization and authorization.startswith('Bearer '):
+        client = cas.get_client()
+        try:
+            access_token = cas.parse_auth_header(authorization)
+            cas_resp = client.profile(access_token)
+        except cas.CasError as err:
+            sentry.log_exception()
+            # NOTE: We assume that the request is an AJAX request
+            return json_renderer(err)
+        if cas_resp.authenticated:
+            auth.user = OSFUser.load(cas_resp.user)
 
     # get data payload
     try:


### PR DESCRIPTION
## Ticket

GRDM-50105

## Purpose

Fix issue where users with read-only permission Personal Access Tokens could write files via the Waterbutler API

## Changes

- addons/base/views.py
  - Always verify permissions when the API uses a Personal Access Token. 

## QA Notes



## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

