### PR TITLE
[GRDM-50321] Project Metadata関連リソースの権限調整 (RCOS環境)

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -83,6 +83,7 @@ from api.nodes.permissions import (
     ExcludeWithdrawals,
     NodeLinksShowIfVersion,
     ReadOnlyIfWithdrawn,
+    IsAdminContributorToRegisterDrafts,
 )
 from api.nodes.serializers import (
     NodeSerializer,
@@ -720,6 +721,7 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
         # GRDM-50321 Project Metadata should be available to non-admins.
         # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
         # Therefore, the project metadata should be available to non-admins.
+        IsAdminContributorToRegisterDrafts,
         ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -70,11 +70,9 @@ from api.logs.serializers import NodeLogSerializer
 from api.nodes.filters import NodesFilterMixin
 from api.nodes.permissions import (
     IsAdmin,
-    IsAdminContributor,
     IsPublic,
     AdminOrPublic,
     ContributorOrPublic,
-    AdminContributorOrPublic,
     RegistrationAndPermissionCheckForPointers,
     ContributorDetailPermissions,
     ReadOnlyIfRegistration,
@@ -649,7 +647,10 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
     Use DraftRegistrationsList endpoint instead.
     """
     permission_classes = (
-        IsAdminContributor,
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
+        # Therefore, the project metadata should be available to non-admins.
+        ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )
@@ -685,7 +686,10 @@ class NodeDraftRegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestro
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        IsAdminContributor,
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
+        # Therefore, the project metadata should be available to non-admins.
+        ContributorOrPublic,
     )
     parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
 
@@ -713,7 +717,10 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_registrations_list).
     """
     permission_classes = (
-        AdminContributorOrPublic,
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
+        # Therefore, the project metadata should be available to non-admins.
+        ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ExcludeWithdrawals,

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -470,6 +470,43 @@ class TestDraftRegistrationUpdateWithNode(TestDraftRegistrationUpdate, TestUpdat
             'comments': 'This is my first registration.'
         }
 
+    # GRDM-50321 Change permissions for drafts
+    def test_cannot_update_draft(
+            self, app, user_write_contrib,
+            user_read_contrib, user_non_contrib,
+            project_public, group,
+            payload, url_draft_registrations, group_mem):
+
+        #   test_read_only_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_read_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_write_contributor_can_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_write_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_logged_in_non_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_non_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_unauthenticated_user_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload, expect_errors=True)
+        assert res.status_code == 401
+
 
 @pytest.mark.django_db
 class TestDraftRegistrationUpdateWithDraftNode(TestDraftRegistrationUpdate):
@@ -512,6 +549,43 @@ class TestDraftRegistrationUpdateWithDraftNode(TestDraftRegistrationUpdate):
             'comments': 'This is my first registration.'
         }
 
+    # GRDM-50321 Change permissions for drafts
+    def test_cannot_update_draft(
+            self, app, user_write_contrib,
+            user_read_contrib, user_non_contrib,
+            project_public, group,
+            payload, url_draft_registrations, group_mem):
+
+        #   test_read_only_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_read_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_write_contributor_can_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_write_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_logged_in_non_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_non_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_unauthenticated_user_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload, expect_errors=True)
+        assert res.status_code == 401
+
 
 class TestDraftRegistrationPatchNew(TestDraftRegistrationPatch):
     @pytest.fixture()
@@ -547,6 +621,43 @@ class TestDraftRegistrationPatchNew(TestDraftRegistrationPatch):
         data = res.json['data']
         assert schema._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['attributes']['registration_metadata'] == payload['data']['attributes']['registration_metadata']
+
+    # GRDM-50321 Change permissions for drafts
+    def test_cannot_update_draft(
+            self, app, user_write_contrib,
+            user_read_contrib, user_non_contrib,
+            project_public, group,
+            payload, url_draft_registrations, group_mem):
+
+        #   test_read_only_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_read_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_write_contributor_can_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_write_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_logged_in_non_contributor_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_non_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 403
+
+        #   test_unauthenticated_user_cannot_update_draft
+        res = app.patch_json_api(
+            url_draft_registrations,
+            payload, expect_errors=True)
+        assert res.status_code == 401
 
 
 class TestDraftRegistrationDelete(TestDraftRegistrationDelete):

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -63,6 +63,37 @@ class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
         res = app.get(url_draft_registrations, expect_errors=True)
         assert res.status_code == 401
 
+    # GRDM-50321 Change permissions for drafts
+    def test_can_view_draft_list_by_non_admin_user(
+            self, app, user_write_contrib, project_public,
+            user_read_contrib, user_non_contrib,
+            url_draft_registrations, group, group_mem):
+
+        # test_read_only_contributor_can_view_draft_list
+        res = app.get(
+            url_draft_registrations,
+            auth=user_read_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_read_write_contributor_can_view_draft_list
+        res = app.get(
+            url_draft_registrations,
+            auth=user_write_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_logged_in_non_contributor_can_view_draft_list(when node is public)
+        res = app.get(
+            url_draft_registrations,
+            auth=user_non_contrib.auth,
+            expect_errors=True)
+        assert res.status_code == 200
+
+        #   test_unauthenticated_user_can_view_draft_list(when node is public)
+        res = app.get(url_draft_registrations, expect_errors=True)
+        assert res.status_code == 401
+
 
 class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
     @pytest.fixture()

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -131,41 +131,45 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
         assert len(data) == 1
         assert schema._id in data[0]['relationships']['registration_schema']['links']['related']['href']
 
-    def test_cannot_view_draft_list(
+    # GRDM-50321 Change permissions for drafts
+    #     To allow non-admins to use project metadata, allow non-admins to list draft registrations.
+    #     This is a temporary workaround, because future versions will use
+    #     a specialized metadata model for project metadata instead of Registrations.
+    def test_can_view_draft_list_by_non_admin_user(
             self, app, user_write_contrib, project_public,
             user_read_contrib, user_non_contrib,
             url_draft_registrations, group, group_mem):
 
-        # test_read_only_contributor_cannot_view_draft_list
+        # test_read_only_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
             auth=user_read_contrib.auth,
             expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 200
 
-    #   test_read_write_contributor_cannot_view_draft_list
+    #   test_read_write_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
             auth=user_write_contrib.auth,
             expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 200
 
-    #   test_logged_in_non_contributor_cannot_view_draft_list
+    #   test_logged_in_non_contributor_can_view_draft_list(when node is public)
         res = app.get(
             url_draft_registrations,
             auth=user_non_contrib.auth,
             expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 200
 
-    #   test_unauthenticated_user_cannot_view_draft_list
+    #   test_unauthenticated_user_can_view_draft_list(when node is public)
         res = app.get(url_draft_registrations, expect_errors=True)
-        assert res.status_code == 401
+        assert res.status_code == 200
 
     #   test_osf_group_with_read_permissions
         project_public.remove_osf_group(group)
         project_public.add_osf_group(group, permissions.READ)
         res = app.get(url_draft_registrations, auth=group_mem.auth, expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 200
 
     def test_deleted_draft_registration_does_not_show_up_in_draft_list(
             self, app, user, draft_registration, url_draft_registrations):
@@ -303,14 +307,18 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             project_public, payload, group,
             url_draft_registrations, group_mem):
 
-        #   test_write_only_contributor_cannot_create_draft
+        # GRDM-50321 Change permissions for drafts
+        #     Allow non-admins with the write permission to create Draft Registrations
+        #     This is a temporary workaround, because future versions will use
+        #     a specialized metadata model instead of Registrations.
+        #   test_write_only_contributor_can_create_draft
         assert user_write_contrib in project_public.contributors.all()
         res = app.post_json_api(
             url_draft_registrations,
             payload,
             auth=user_write_contrib.auth,
             expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 201
 
     #   test_read_only_contributor_cannot_create_draft
         assert user_read_contrib in project_public.contributors.all()
@@ -335,15 +343,17 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             expect_errors=True)
         assert res.status_code == 403
 
-    #   test_group_admin_cannot_create_draft
+        # GRDM-50321 Change permissions for drafts
+        #   test_group_admin_can_create_draft
         res = app.post_json_api(
             url_draft_registrations,
             payload,
             auth=group_mem.auth,
             expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 201
 
-    #   test_group_write_contrib_cannot_create_draft
+        # GRDM-50321 Change permissions for drafts
+        #   test_group_write_contrib_can_create_draft
         project_public.remove_osf_group(group)
         project_public.add_osf_group(group, permissions.WRITE)
         res = app.post_json_api(
@@ -351,7 +361,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             payload,
             auth=group_mem.auth,
             expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 201
 
     #   test_reviewer_cannot_create_draft_registration
         user = AuthUserFactory()

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -295,8 +295,11 @@ class Registration(AbstractNode):
         :raises: PermissionsError if user is not an admin for the Node
         :raises: ValidationError if end_date is not within time constraints
         """
-        if not self.is_admin_contributor(user):
-            raise PermissionsError('Only admins may embargo a registration')
+        # GRDM-50321 Project Metadata should be available to non-admins.
+        # In GakuNin RDM, registered objects are used as project metadata and are not used for public registration.
+        # Therefore, the project metadata should be available to non-admins.
+        if not self.is_contributor(user) or not self.can_edit(user=user):
+            raise PermissionsError('Only users with write permission can project metadata.')
         if not self._is_embargo_date_valid(end_date):
             if (end_date - timezone.now()) >= settings.EMBARGO_END_DATE_MIN:
                 raise ValidationError('Registrations can only be embargoed for up to four years.')


### PR DESCRIPTION
ember-osf-web側の修正と合わせてMergeしてください。 https://github.com/RCOSDP/RDM-ember-osf-web/pull/150

## Purpose

Project Metadata関連リソースの権限調整

## Changes

- Project Metadataを非管理者でも書き込み権限があれば操作できるよう、APIの必須パーミッションを修正
- Project Metadataを非管理者でも書き込み権限があれば操作できるよう、Draftからの登録処理を修正

Upstreamとのマージ時にそれとわかるようコメントも追加しています。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-50321