### PR TITLE
[GRDM-53044] S3/S3互換ストレージの認証情報識別にAccess Keyを追加

### DIFF
--- a/addons/s3/views.py
+++ b/addons/s3/views.py
@@ -90,21 +90,25 @@ def s3_add_user_account(auth, **kwargs):
         }, http_status.HTTP_400_BAD_REQUEST
 
     account = None
+    # GRDM-53044 Identify S3 authentication information using both the AWS Account and Access Key
+    provider_id = f'{user_info.id}\t{access_key}'
+    masked_access_key = f'****{access_key[-4:]}' if len(access_key) > 4 else '****'
+    display_name = f'{user_info.display_name} ({masked_access_key})'
     try:
         account = ExternalAccount(
             provider=SHORT_NAME,
             provider_name=FULL_NAME,
             oauth_key=access_key,
             oauth_secret=secret_key,
-            provider_id=user_info.id,
-            display_name=user_info.display_name,
+            provider_id=provider_id,
+            display_name=display_name,
         )
         account.save()
     except ValidationError:
         # ... or get the old one
         account = ExternalAccount.objects.get(
             provider=SHORT_NAME,
-            provider_id=user_info.id
+            provider_id=provider_id,
         )
         if account.oauth_key != access_key or account.oauth_secret != secret_key:
             account.oauth_key = access_key


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

S3/S3互換ストレージの認証情報識別にAccess Keyを追加

## Changes

- 従来AWSアカウント番号(S3互換ストレージの場合、ストレージホスト名とバケットオーナーID)で識別管理していた認証情報に関して、識別子としてAccess Keyを追加しました。これにより同一AWSアカウントの複数のAccess Keyを使い分け可能になります
- アカウント表示名には、 `(****Access Keyの末尾4文字)` が追加されます。これは複数のAccess Keyのうちどれを使うのかを識別可能にするためです。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-53044