### PR TITLE
[GRDM-53622] CC0PDかつ削除済みメタデータが存在している場合のマイグレーションエラーの修正

### DIFF
--- a/osf/migrations/0242_remove_cc0pd_from_erad_schema.py
+++ b/osf/migrations/0242_remove_cc0pd_from_erad_schema.py
@@ -45,7 +45,7 @@ def migrate_CC0PD_to_CC0_for_filemetadata(*args):
         logger.warning(f'Skipped: Failed to find schema "{TARGET_SCHEMA_NAME}"')
         return
     schema_ids = [schema._id for schema in schemas]
-    filemetadatas = FileMetadata.objects.filter(metadata__isnull=False)
+    filemetadatas = FileMetadata.objects.filter(metadata__isnull=False, deleted__isnull=True)
     logger.info('Found {} file metadatas'.format(filemetadatas.count()))
     for filemetadata in filemetadatas:
         try:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

CC0PDかつ削除済みメタデータが存在している場合に、migration 0242_remove_cc0pd_from_erad_schema.py が失敗する問題の修正

## Changes

マイグレーション対象を未削除データにのみ限定することで本エラーを回避するよう修正。

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-53622
