### PR TITLE
[GRDM-44441] アイテムクリックとリンクコピーでリンクが異なる不具合の修正

### DIFF
--- a/addons/metadata/suggestion.py
+++ b/addons/metadata/suggestion.py
@@ -1,5 +1,6 @@
 import logging
 
+from future.moves.urllib.parse import unquote
 import requests
 from rest_framework import status as http_status
 
@@ -416,8 +417,10 @@ def download_file(url, cookies):
     return response
 
 def suggestion_file_data_number(key, filepath, node):
-    parts = filepath.split('/')
+    decoded_filepath = unquote(filepath)
+    parts = decoded_filepath.split('/')
     is_dir = parts[0] == 'dir'
+
     if is_dir:
         value = 'files/{}'.format(filepath)
     else:

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1802,7 +1802,7 @@ function gotoFileEvent (item, toUrl) {
     var tb = this;
     var redir = new URI(item.data.nodeUrl);
     redir.segment('files').segment(item.data.provider).segmentCoded(item.data.path.substring(1));
-    var fileurl  = redir.toString() + toUrl;
+    var fileurl  = encodeURI(redir.toString() + toUrl);
 
     // construct view only link into file url as it gets removed from url params in IE
     if ($osf.isIE()) {
@@ -1836,7 +1836,7 @@ function getPersistentLinkFor(item) {
         if (item.data.materialized !== undefined && item.data.materialized.length > 0) {
             path = item.data.materialized;
         }
-        redir.segment('files/dir').segment(item.data.provider).segment(path.substring(1));
+        redir.segment('files/dir').segment(item.data.provider).segmentCoded(path.substring(1));
     } else {
         redir.segment('files').segment(item.data.provider).segmentCoded(item.data.path.substring(1));
     }


### PR DESCRIPTION
## Purpose

表題のとおりです。
以前のCAS対応がデグレしないように、二重エンコードで統一する方向で修正しました。

## Changes

* アイテムクリックとリンクコピーのどちらでも segmentCoded と encodeURI による二重エンコードをするよう修正しました。
* Metadata の Data Number サジェスト時に生成するGUIDも二重エンコードのURLをベースに作成するよう修正しました。

## QA Notes
None

## Documentation
None

## Side Effects

<!-- Any possible side effects? -->

## Ticket
GRDM-44441
