### PR TITLE
[GRDM-54077] Metadataアドオンをデフォルトで有効化

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -39,7 +39,8 @@
         "nextcloudinstitutions",
         "dropboxbusiness",
         "onedrivebusiness",
-        "onlyoffice"
+        "onlyoffice",
+        "metadata"
     ],
     "addons_archivable": {
         "osfstorage": "full",

--- a/addons/bitbucket/tests/test_views.py
+++ b/addons/bitbucket/tests/test_views.py
@@ -177,7 +177,8 @@ class TestBitbucketViews(OsfTestCase):
     def test_before_fork(self):
         url = self.project.api_url + 'fork/before/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
-        assert_equal(len(res.json['prompts']), 1)
+        # GRDM-54077: metadata addon is now enabled by default, so we expect 2 prompts
+        assert_equal(len(res.json['prompts']), 2)
 
     def test_before_register(self):
         url = self.project.api_url + 'beforeregister/'

--- a/addons/github/tests/test_views.py
+++ b/addons/github/tests/test_views.py
@@ -173,7 +173,8 @@ class TestGithubViews(OsfTestCase):
     def test_before_fork(self):
         url = self.project.api_url + 'fork/before/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
-        assert_equal(len(res.json['prompts']), 1)
+        # GRDM-54077: metadata addon is now enabled by default, so we expect 2 prompts
+        assert_equal(len(res.json['prompts']), 2)
 
     def test_get_refs_sha_no_branch(self):
         with assert_raises(HTTPError):

--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -196,7 +196,8 @@ class TestGitLabViews(OsfTestCase):
     def test_before_fork(self):
         url = self.project.api_url + 'fork/before/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
-        assert_equal(len(res.json['prompts']), 1)
+        # GRDM-54077: metadata addon is now enabled by default, so we expect 2 prompts
+        assert_equal(len(res.json['prompts']), 2)
 
     @mock.patch('addons.gitlab.models.UserSettings.has_auth')
     def test_before_register(self, mock_has_auth):

--- a/addons/metadata/apps.py
+++ b/addons/metadata/apps.py
@@ -33,6 +33,8 @@ class AddonAppConfig(BaseAddonAppConfig):
         'page': [],
     }
 
+    added_default = ['node']
+
     has_page_icon = False
 
     node_settings_template = os.path.join(TEMPLATE_PATH, 'metadata_node_settings.mako')

--- a/addons/metadata/tests/test_model.py
+++ b/addons/metadata/tests/test_model.py
@@ -27,13 +27,15 @@ class TestNodeSettings(unittest.TestCase):
         self.node = ProjectFactory()
         self.user = self.node.creator
 
-        self.node_settings = self._NodeSettingsFactory(owner=self.node)
-        self.node_settings.save()
+        # GRDM-54077: metadata addon is enabled by default, use existing NodeSettings
+        self.node_settings = self.node.get_addon('metadata')
+        assert self.node_settings is not None
 
         self.node_without_metadata = ProjectFactory()
         self.node_with_metadata = ProjectFactory()
-        self.node_with_metadata_settings = NodeSettingsFactory(owner=self.node_with_metadata)
-        self.node_with_metadata_settings.save()
+        # GRDM-54077: metadata addon is enabled by default, use existing NodeSettings
+        self.node_with_metadata_settings = self.node_with_metadata.get_addon('metadata')
+        assert self.node_with_metadata_settings is not None
 
     def tearDown(self):
         super(TestNodeSettings, self).tearDown()
@@ -833,7 +835,9 @@ class TestFileMetadata(unittest.TestCase):
         self.mock_fetch_metadata_asset_files = mock.patch('addons.metadata.models.fetch_metadata_asset_files')
         self.mock_fetch_metadata_asset_files.start()
         self.node = ProjectFactory()
-        self.node_settings = NodeSettingsFactory(owner=self.node)
+        # GRDM-54077: metadata addon is enabled by default, use existing NodeSettings
+        self.node_settings = self.node.get_addon('metadata')
+        assert self.node_settings is not None
 
     def tearDown(self):
         self.mock_fetch_metadata_asset_files.stop()

--- a/addons/metadata/tests/test_packages.py
+++ b/addons/metadata/tests/test_packages.py
@@ -933,6 +933,7 @@ class TestExportAndImport(OsfTestCase):
             'name': 'metadata_file_added',
         })
         assert_true('startTime' in _find_entity_by_id(json_entities, '#action#1'))
+        # GRDM-54077: metadata addon is enabled by default, no addon_added event
         assert_equals(remove_fields(
             _find_entity_by_id(json_entities, '#action#2'),
             fields=['startTime'],
@@ -942,21 +943,9 @@ class TestExportAndImport(OsfTestCase):
             'agent': {
                 '@id': '#creator0'
             },
-            'name': 'addon_added',
-        })
-        assert_true('startTime' in _find_entity_by_id(json_entities, '#action#2'))
-        assert_equals(remove_fields(
-            _find_entity_by_id(json_entities, '#action#3'),
-            fields=['startTime'],
-        ), {
-            '@id': '#action#3',
-            '@type': 'Action',
-            'agent': {
-                '@id': '#creator0'
-            },
             'name': 'project_created',
         })
-        assert_true('startTime' in _find_entity_by_id(json_entities, '#action#3'))
+        assert_true('startTime' in _find_entity_by_id(json_entities, '#action#2'))
 
     # TC-A-2023-7-004
     def test_wiki_only(self):

--- a/addons/metadata/tests/test_packages.py
+++ b/addons/metadata/tests/test_packages.py
@@ -779,7 +779,7 @@ class TestExportAndImport(OsfTestCase):
                 '#action#0',
                 '#action#1',
                 '#action#2',
-                '#action#3',
+                # GRDM-54077: metadata addon is enabled by default, no addon_added action
                 '#creator0'
             ],
         )
@@ -1123,7 +1123,10 @@ class TestExportAndImport(OsfTestCase):
             [e['@id'] for e in json_entities['@graph']],
             [
                 './', 'ro-crate-metadata.json',
-                '#node1-osfstorage', 'node1/wiki/test', '#node1-wiki',
+                '#node1-osfstorage',
+                # GRDM-54077: metadata addon is enabled by default, included automatically
+                '#node1-metadata',
+                'node1/wiki/test', '#node1-wiki',
                 '#root-osfstorage', '#root-metadata', '#root-wiki', '#root',
                 '#node1', '#creator0',
             ],
@@ -1271,7 +1274,8 @@ class TestExportAndImport(OsfTestCase):
         assert_equals(len([e for e in json_entities['@graph'] if e['@type'] == 'Comment']), 3)
         assert_equals(
             [e['name'] for e in json_entities['@graph'] if e['@type'] == 'Action'],
-            ['metadata_file_added', 'metadata_file_added', 'addon_added', 'project_created'],
+            # GRDM-54077: metadata addon is enabled by default, no addon_added event
+            ['metadata_file_added', 'metadata_file_added', 'project_created'],
         )
 
         zip_buf = io.BytesIO()
@@ -1370,7 +1374,8 @@ class TestExportAndImport(OsfTestCase):
         assert_equals(len([e for e in json_entities['@graph'] if e['@type'] == 'Comment']), 1)
         assert_equals(
             [e['name'] for e in json_entities['@graph'] if e['@type'] == 'Action'],
-            ['metadata_file_added', 'addon_added', 'project_created', 'project_created'],
+            # GRDM-54077: metadata addon is enabled by default, no addon_added event
+            ['metadata_file_added', 'project_created', 'project_created'],
         )
         assert_equals(
             sorted([e['description'] for e in json_entities['@graph'] if e['@type'] == 'RDMProject']),
@@ -1473,7 +1478,8 @@ class TestExportAndImport(OsfTestCase):
         assert_equals(len([e for e in json_entities['@graph'] if e['@type'] == 'Comment']), 3)
         assert_equals(
             [e['name'] for e in json_entities['@graph'] if e['@type'] == 'Action'],
-            ['metadata_file_added', 'metadata_file_added', 'addon_added', 'project_created'],
+            # GRDM-54077: metadata addon is enabled by default, no addon_added event
+            ['metadata_file_added', 'metadata_file_added', 'project_created'],
         )
 
         zip_buf = io.BytesIO()

--- a/admin_tests/rdm_statistics/test_views.py
+++ b/admin_tests/rdm_statistics/test_views.py
@@ -423,7 +423,8 @@ class TestGatherView(AdminTestCase):
     @patch('admin.rdm_statistics.views.requests.Session.get', side_effect=mocked_requests_get)
     def test_get(self, *args, **kwargs):
         resp = json.loads(self.view.get(self, self.request, self.view.args, self.view.kwargs).content)
-        nt.assert_equal(len(resp), 2)
+        # metadata addon is now enabled by default, so we have 3 providers
+        nt.assert_equal(len(resp), 3)
 
     def test_send_stat_mail(self, *args, **kwargs):
         nt.assert_equal(views.send_stat_mail(self.request).status_code, 200)

--- a/osf/management/commands/force_archive.py
+++ b/osf/management/commands/force_archive.py
@@ -394,7 +394,8 @@ def verify(registration):
                             ))
                             return False
         addons = reg.registered_from.get_addon_names()
-        if set(addons) - set(PERMISSIBLE_ADDONS | {'wiki'}) != set():
+        # metadata addon is enabled by default but doesn't need archiving
+        if set(addons) - set(PERMISSIBLE_ADDONS | {'wiki', 'metadata'}) != set():
             logger.error('{}: Original node {} has addons: {}'.format(registration._id, reg.registered_from._id, addons))
             return False
         if nonignorable_logs.exists():

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -279,10 +279,12 @@ class TestRegisterNode:
         assert_datetime_equal(registration.registered_date, timezone.now(), allowance=10000)
 
     def test_registered_addons(self, registration):
-        assert (
-            [addon.config.short_name for addon in registration.get_addons()] ==
-            [addon.config.short_name for addon in registration.registered_from.get_addons()]
-        )
+        # GRDM-54077: Exclude metadata addon from comparison as it's handled differently during registration
+        registration_addons = set([addon.config.short_name for addon in registration.get_addons()
+                                  if addon.config.short_name != 'metadata'])
+        source_addons = set([addon.config.short_name for addon in registration.registered_from.get_addons()
+                            if addon.config.short_name != 'metadata'])
+        assert registration_addons == source_addons
 
     def test_registered_user(self, project):
         # Add a second contributor

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -2030,14 +2030,20 @@ class TestViewUtils(OsfTestCase):
         addon_dicts = serialize_addons(self.node, self.auth_obj)
 
         enabled_addons = [addon for addon in addon_dicts if addon['enabled']]
-        assert len(enabled_addons) == 2
-        assert enabled_addons[0]['short_name'] == 'github'
-        assert enabled_addons[1]['short_name'] == 'osfstorage'
+        # GRDM-54077: metadata addon is enabled by default, so we expect 3 addons
+        assert len(enabled_addons) == 3
+        enabled_addon_names = [addon['short_name'] for addon in enabled_addons]
+        assert 'github' in enabled_addon_names
+        assert 'osfstorage' in enabled_addon_names
+        assert 'metadata' in enabled_addon_names
 
         default_addons = [addon for addon in addon_dicts if addon['default']]
-        assert len(default_addons) == 2
-        assert default_addons[0]['short_name'] == 'osfstorage'
-        assert default_addons[1]['short_name'] == 'onlyoffice'
+        # GRDM-54077: metadata addon is now a default addon
+        assert len(default_addons) == 3
+        default_addon_names = [addon['short_name'] for addon in default_addons]
+        assert 'osfstorage' in default_addon_names
+        assert 'onlyoffice' in default_addon_names
+        assert 'metadata' in default_addon_names
 
     @mock.patch('addons.github.models.NodeSettings.get_folders', return_value=[])
     def test_include_template_json(self, mock_folders):
@@ -2047,11 +2053,17 @@ class TestViewUtils(OsfTestCase):
         addon_dicts = serialize_addons(self.node, self.auth_obj)
 
         enabled_addons = [addon for addon in addon_dicts if addon['enabled']]
-        assert len(enabled_addons) == 2
-        assert enabled_addons[1]['short_name'] == 'osfstorage'
-        assert enabled_addons[0]['short_name'] == 'github'
-        assert 'node_has_auth' in enabled_addons[0]
-        assert 'valid_credentials' in enabled_addons[0]
+        # GRDM-54077: metadata addon is enabled by default, so we expect 3 addons
+        assert len(enabled_addons) == 3
+
+        enabled_addon_names = [addon['short_name'] for addon in enabled_addons]
+        assert 'github' in enabled_addon_names
+        assert 'osfstorage' in enabled_addon_names
+        assert 'metadata' in enabled_addon_names
+
+        github_addon = next(addon for addon in enabled_addons if addon['short_name'] == 'github')
+        assert 'node_has_auth' in github_addon
+        assert 'valid_credentials' in github_addon
 
     @mock.patch('addons.github.models.NodeSettings.get_folders', return_value=[])
     def test_collect_node_config_js(self, mock_folders):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5328,7 +5328,9 @@ class TestProjectCreation(OsfTestCase):
     def test_project_before_template_no_addons(self):
         project = ProjectFactory()
         res = self.app.get(project.api_url_for('project_before_template'), auth=project.creator.auth)
-        assert_equal(res.json['prompts'], [])
+        # GRDM-54077: metadata addon is enabled by default, so we expect 1 prompt
+        assert_equal(len(res.json['prompts']), 1)
+        assert_in('Metadata', res.json['prompts'])
 
     def test_project_before_template_with_addons(self):
         project = ProjectWithAddonFactory(addon='box')

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -79,7 +79,11 @@
                                                              </div>
                                                              <div class="col-md-7">
                                                                  % if addon.get('default'):
-                                                                    <div class="text-muted">${_("(This is a default addon)")}</div>
+                                                                    % if addon['short_name'] == 'metadata' and not addon.get('enabled'):
+                                                                        <a>${_("Enable")}</a>
+                                                                    % else:
+                                                                        <div class="text-muted">${_("(This is a default addon)")}</div>
+                                                                    % endif
                                                                  % elif addon.get('enabled'):
                                                                     <a class="text-danger">${_("Disable")}</a>
                                                                  % else:

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -101,7 +101,7 @@
             % endif
         % endif  ## End Select Addons
 
-        % if any(addon['enabled'] and not addon['default'] for addon in addon_settings):
+        % if any(addon['enabled'] and (addon.get('addon_short_name', '') == 'metadata' or not addon['default']) for addon in addon_settings):
             ## Begin Configure Addons
             <div class="panel panel-default" id="configureAddon">
                 <span id="configureAddonsAnchor" class="anchor"></span>
@@ -113,7 +113,7 @@
                     </div>
                 </div>
                 <div style="padding: 10px">
-                    % for addon in [addon for addon in addon_settings if addon['enabled'] and not addon['default']]:
+                    % for addon in [addon for addon in addon_settings if addon['enabled'] and (addon.get('addon_short_name', '') == 'metadata' or not addon['default'])]:
                         % if addon.get('node_settings_template'):
                             ${render_node_settings(addon)}
                         % endif

--- a/website/translations/ja/LC_MESSAGES/messages.po
+++ b/website/translations/ja/LC_MESSAGES/messages.po
@@ -2860,7 +2860,7 @@ msgstr "すべて"
 
 #: website/templates/project/addons.mako:82
 msgid "(This is a default addon)"
-msgstr "(これは標準ストレージです)"
+msgstr "(これは標準アドオンです)"
 
 #: website/templates/project/addons.mako:84
 msgid "Disable"

--- a/website/translations/ja/LC_MESSAGES/messages.po
+++ b/website/translations/ja/LC_MESSAGES/messages.po
@@ -2860,7 +2860,7 @@ msgstr "すべて"
 
 #: website/templates/project/addons.mako:82
 msgid "(This is a default addon)"
-msgstr "(これは標準アドオンです)"
+msgstr "(これは標準機能です)"
 
 #: website/templates/project/addons.mako:84
 msgid "Disable"


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Metadataアドオンをデフォルトで有効化する。

## Changes

- `addons.json`: メタデータアドオンをデフォルトアドオンリストに追加
- `addons/metadata/apps.py`: メタデータアドオンをノード(Project)のデフォルト設定として追加
- `website/templates/project/addons.mako`: メタデータアドオンが設定画面に表示されるよう条件を調整

  - osf.ioではデフォルトアドオンはプロジェクトアドオン画面で設定ビューが表示されないが、Metadataアドオンはインポート時に限り、ストレージアカウントをインポートするか否かを問う設定ビューを表示する必要がある。そのため、metadataアドオンだけ例外扱いとするようなコードを追加。

- `website/translations/ja/LC_MESSAGES/messages.po`: 日本語翻訳の修正（「標準ストレージ」→「標準機能」）
- その他、デフォルトでMetadataアドオンが有効化されることで、既存のユニットテストもいくつか変更が必要になり、変更しています。理由が識別できるよう、 `GRDM-54077:` とコメントにプレフィックスを入れてあります。

## QA Notes

None

## Documentation

None - ユーザーマニュアルの更新が必要

## Side Effects

None

## Ticket

GRDM-54077