### PR TITLE
[GRDM-44441] アイテムクリックとリンクコピーでリンクが異なる不具合の修正

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1802,7 +1802,7 @@ function gotoFileEvent (item, toUrl) {
     var tb = this;
     var redir = new URI(item.data.nodeUrl);
     redir.segment('files').segment(item.data.provider).segmentCoded(item.data.path.substring(1));
-    var fileurl  = redir.toString() + toUrl;
+    var fileurl  = encodeURI(redir.toString() + toUrl);
 
     // construct view only link into file url as it gets removed from url params in IE
     if ($osf.isIE()) {


### PR DESCRIPTION
## Purpose

表題のとおりです。
以前のCAS対応がデグレしないように、 getPersistentLinkFor の実装は変更していません。

## Changes

* アイテムクリック時( gotoFileEvent )のURL作成でも getPersistentLinkFor と同様に encodeURI による二重エンコードをするよう修正しました。

## QA Notes
None

## Documentation
None

## Side Effects
None

## Ticket
GRDM-44441
