### PR TITLE
[GRDM-54829] ROR API v2対応

### DIFF
--- a/addons/metadata/suggestion.py
+++ b/addons/metadata/suggestion.py
@@ -37,7 +37,7 @@ ERAD_COLUMNS = [
     'JAPAN_GRANT_NUMBER', 'PROGRAM_NAME_JA', 'PROGRAM_NAME_EN', 'FUNDING_STREAM_CODE',
 ]
 
-ROR_URL = 'https://api.ror.org/organizations'
+ROR_URL = 'https://api.ror.org/v2/organizations'
 
 
 def valid_suggestion_key(key):
@@ -446,8 +446,12 @@ def suggestion_ror(key, keyword):
     response.raise_for_status()
     res = []
     for item in response.json()['items']:
-        labels = item.get('labels', [])
-        name_ja = next((l['label'] for l in labels if l['iso639'] == 'ja'), item['name'])
+        names = item.get('names', [])
+        display_name = next((n['value'] for n in names if 'ror_display' in n.get('types', [])),
+                           next((n['value'] for n in names if n.get('lang') == 'en'), ''))
+        name_ja = next((n['value'] for n in names if n.get('lang') == 'ja' and 'label' in n.get('types', [])),
+                      next((n['value'] for n in names if n.get('lang') == 'ja'), display_name))
+        item['name'] = display_name
         res.append({
             'key': key,
             'value': {


### PR DESCRIPTION
## Purpose

ROR API がデフォルトで v2 を返すようになったため、メタデータアドオンの ROR 補完機能を修正

## Changes

- [GRDM-54829] RORによる機関情報補完ができなくなった の修正
  - ROR API エンドポイントを v2 に更新
  - v2 スキーマ変更に対応（names配列への移行）
  - 日本語名取得時にlabelタイプを優先するよう修正

## QA Notes

TBD

## Documentation

None

## Side Effects

None

## Ticket

GRDM-54829