### PR TITLE
未病データベース メタデータ登録チェックリストの説明文修正

### DIFF
--- a/website/project/metadata/ms2-mibyodb-metadata.json
+++ b/website/project/metadata/ms2-mibyodb-metadata.json
@@ -1203,7 +1203,7 @@
               "properties": [
                 {
                   "id": "Position-of-column",
-                  "title": "行の位置（日本語）|Position of column (Japanese)",
+                  "title": "列の位置（日本語）|Position of column (Japanese)",
                   "type": "string",
                   "format": "textarea"
                 },
@@ -1954,7 +1954,7 @@
           "type": "choose",
           "format": "multiselect",
           "required": true,
-          "help": "未病DBでは、メタデータカタログを通して研究コラボレーションが創発・活発化することが期待されています。実験・数理・応用など様々な分野の研究者が互いの持つ研究資産を理解しコラボレーションにつながるためには、各提供者が自身の研究について分野外から見ても十分に理解可能な形で説明を付与する必要があります。未病DBのコンセプトやメタデータ入力についての解説は以下のリンクを参照ください。（未病DBガイドライン、未病DBデータ格納手順書）\nhttps://rdm.nii.ac.jp/3sw6v/\nhttps://rdm.nii.ac.jp/ve4fp/|The Mebyo Database (Mebyo DB) is expected to promote and facilitate interdisciplinary research collaboration through its metadata catalog. \nTo enable researchers from diverse fields—such as experimental, mathematical, and applied sciences—to understand one another’s research assets and work together effectively, each data provider must describe their research in a manner that is accessible to those outside their specific field.\nFor more details, please refer to the Mebyo DB Guidelines.\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
+          "help": "未病DBでは、メタデータカタログを通して研究コラボレーションが創発・活発化することが期待されています。実験・数理・応用など様々な分野の研究者が互いの持つ研究資産を理解しコラボレーションにつながるためには、各提供者が自身の研究について分野外から見ても十分に理解可能な形で説明を付与する必要があります。未病DBのコンセプトやメタデータ入力についての解説は以下のリンクを参照ください。\n\n未病DBガイドライン：https://rdm.nii.ac.jp/3sw6v/\n未病DBデータ格納手順書：https://rdm.nii.ac.jp/6hs2b/|The Mebyo Database (Mebyo DB) is expected to promote and facilitate interdisciplinary research collaboration through its metadata catalog. \nTo enable researchers from diverse fields—such as experimental, mathematical, and applied sciences—to understand one another’s research assets and work together effectively, each data provider must describe their research in a manner that is accessible to those outside their specific field.\nFor more details, please refer to the Mebyo DB Guidelines.\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/\nMebyo DB Deposition Guide (Under Development): https://rdm.nii.ac.jp/6hs2b/",
           "options": [
             {
               "text": "メタデータは、他の研究者が見ても分かりやすい形で記入しましたか？|Is the metadata written in a way that other researchers can easily understand?"
@@ -1983,7 +1983,7 @@
           "type": "choose",
           "format": "multiselect",
           "required": true,
-          "help": "未病DBでは、公開・制限公開・共有・制限共有の各共有レベルが設定されています。各研究データは倫理審査などの状況に応じて、正しい共有レベルに設定する必要があります。各共有レベルについての解説は以下のリンクを参照ください。（未病DBガイドライン）\nhttps://rdm.nii.ac.jp/3sw6v/|Mebyo DB has public, restricted public, shared, and restricted shared levels.\nEach dataset must be set to the appropriate sharing level according to the situation, such as ethics review. For details on each sharing level, please refer to the following link.\n\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
+          "help": "未病DBでは、公開・制限公開・共有・制限共有の各共有レベルが設定されています。各研究データは倫理審査などの状況に応じて、正しい共有レベルに設定する必要があります。各共有レベルについての解説は以下のリンクを参照ください。\n\n未病DBガイドライン：https://rdm.nii.ac.jp/3sw6v/|Mebyo DB has public, restricted public, shared, and restricted shared levels.\nEach dataset must be set to the appropriate sharing level according to the situation, such as ethics review. For details on each sharing level, please refer to the following link.\n\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
           "options": [
             {
               "text": "共有レベルは適切ですか？制限共有とすべき研究データが含まれていませんか？|Is the sharing level appropriate? Are there any datasets that should be set as restricted sharing?"
@@ -2026,7 +2026,7 @@
           "type": "choose",
           "format": "multiselect",
           "required": true,
-          "help": "各提供者は自身の研究データに対して責任をもって管理する必要があります。未病DBでは、各データセットに関して提供者にコンタクトを取る必要がある場合に、メタデータに記載された連絡先の情報を元に連絡をとります。そのため、メタデータの連絡先は常にコンタクト可能なものに更新してある必要があります。研究データの取扱や提供者の責務については以下のリンクを参照ください。（未病DBガイドライン）\nhttps://rdm.nii.ac.jp/3sw6v/|Each provider is responsible for managing their research data. \nIn the Mebyo Database (Mebyo DB), if it becomes necessary to contact a provider regarding a dataset, contact information listed in the metadata can used to start communication. \nTherefore, it is necessary to always keep the contact information up to date. \nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
+          "help": "各提供者は自身の研究データに対して責任をもって管理する必要があります。未病DBでは、各データセットに関して提供者にコンタクトを取る必要がある場合に、メタデータに記載された連絡先の情報を元に連絡をとります。そのため、メタデータの連絡先は常にコンタクト可能なものに更新してある必要があります。研究データの取扱や提供者の責務については以下のリンクを参照ください。\n\n未病DBガイドライン：https://rdm.nii.ac.jp/3sw6v/|Each provider is responsible for managing their research data. \nIn the Mebyo Database (Mebyo DB), if it becomes necessary to contact a provider regarding a dataset, contact information listed in the metadata can used to start communication. \nTherefore, it is necessary to always keep the contact information up to date. \nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
           "options": [
             {
               "text": "有効なメールアドレスがメタデータに正しく記載されていますか？|Is a valid email address correctly listed in the metadata?"
@@ -2056,7 +2056,7 @@
           "type": "choose",
           "format": "multiselect",
           "required": true,
-          "help": "未病DBでは各提供者のオーサーシップや著作権について協定書に規定しています。各データセットにおいて、協定書を参考にデータ利用者との間で事前に取り決めを交わしておくことを推奨しています。提供者の権利については以下のリンクを参照ください。（協定書、未病DBガイドライン）|In the Mebyo Database (Mebyo DB), authorship and copyright are stipulated in the agreement. \nIt is recommended that providers make prior arrangements with data users based on the Agreement for each dataset. For details on provider rights, please refer to the following links.\n\nMS2 Agreement: https://rdm.nii.ac.jp/ve4fp/\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
+          "help": "未病DBでは各提供者のオーサーシップや著作権について協定書に規定しています。各データセットにおいて、協定書を参考にデータ利用者との間で事前に取り決めを交わしておくことを推奨しています。提供者の権利については以下のリンクを参照ください。\n\n協定書：https://rdm.nii.ac.jp/ve4fp/\n未病DBガイドライン：https://rdm.nii.ac.jp/3sw6v/|In the Mebyo Database (Mebyo DB), authorship and copyright are stipulated in the agreement. \nIt is recommended that providers make prior arrangements with data users based on the Agreement for each dataset. For details on provider rights, please refer to the following links.\n\nMS2 Agreement: https://rdm.nii.ac.jp/ve4fp/\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
           "options": [
             {
               "text": "未病DBが定めるオーサーシップや著作権に関する指針について理解しましたか？|Do you understand the Mebyo DB's authorship and copyright policies?",

--- a/website/project/metadata/ms2-mibyodb-metadata.json
+++ b/website/project/metadata/ms2-mibyodb-metadata.json
@@ -1895,7 +1895,7 @@
           "type": "choose",
           "format": "multiselect",
           "required": true,
-          "help": "「ムーンショット目標2研究データデポジットの基本方針に係る協定書」（付帯事項含む。以降協定書）および「ムーンショット目標２データベースガイドライン」（以降ガイドライン）はムーンショット目標2（以降MS2）に参画する全ての研究参加者がその内容を理解し、遵守する必要があります。内容について改めて確認したい方は以下のリンクを参照ください。\n\n協定書：https://rdm.nii.ac.jp/ve4fp/\n未病DBガイドライン：https://rdm.nii.ac.jp/3sw6v/|All participants in Moonshot Goal 2 (MS2) are required to understand and comply with the \"Agreement on the Policy of Research Project for the Moonshot Goal 22\" (including supplementary provisions, hereinafter \"Agreement\") and the \"Moonshot Goal 2 Database Guidelines\" (hereinafter \"Guidelines\"). If you would like to review the content, please refer to the following links.\nMS2 Agreement: https://rdm.nii.ac.jp/ve4fp/\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
+          "help": "「ムーンショット目標2研究データデポジットの基本方針に係る協定書」（付帯事項含む。以降協定書）および「ムーンショット目標２データベースガイドライン」（以降ガイドライン）はムーンショット目標2（以降MS2）に参画する全ての研究参加者がその内容を理解し、遵守する必要があります。内容について改めて確認したい方は以下のリンクを参照ください。\n\n協定書：https://rdm.nii.ac.jp/d3y6e/\n協定書付帯事項：https://rdm.nii.ac.jp/ve4fp/\n未病DBガイドライン：https://rdm.nii.ac.jp/3sw6v/|All participants in Moonshot Goal 2 (MS2) are required to understand and comply with the \"Agreement on the Policy of Research Project for the Moonshot Goal 22\" (including supplementary provisions, hereinafter \"Agreement\") and the \"Moonshot Goal 2 Database Guidelines\" (hereinafter \"Guidelines\"). If you would like to review the content, please refer to the following links.\nMS2 Agreement: https://rdm.nii.ac.jp/d3y6e/\nMS2 Agreement - Supplementary Provisions: https://rdm.nii.ac.jp/ve4fp/\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
           "options": [
             {
               "text": "「ムーンショット目標2研究データデポジットの基本方針に係る協定書」（付帯事項含む。以降協定書）および「ムーンショット目標２データベースガイドライン」を全て読み、内容を理解しましたか？|Have you read and understood the Agreement and Guidelines?"
@@ -2056,7 +2056,7 @@
           "type": "choose",
           "format": "multiselect",
           "required": true,
-          "help": "未病DBでは各提供者のオーサーシップや著作権について協定書に規定しています。各データセットにおいて、協定書を参考にデータ利用者との間で事前に取り決めを交わしておくことを推奨しています。提供者の権利については以下のリンクを参照ください。\n\n協定書：https://rdm.nii.ac.jp/ve4fp/\n未病DBガイドライン：https://rdm.nii.ac.jp/3sw6v/|In the Mebyo Database (Mebyo DB), authorship and copyright are stipulated in the agreement. \nIt is recommended that providers make prior arrangements with data users based on the Agreement for each dataset. For details on provider rights, please refer to the following links.\n\nMS2 Agreement: https://rdm.nii.ac.jp/ve4fp/\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
+          "help": "未病DBでは各提供者のオーサーシップや著作権について協定書に規定しています。各データセットにおいて、協定書を参考にデータ利用者との間で事前に取り決めを交わしておくことを推奨しています。提供者の権利については以下のリンクを参照ください。\n\n協定書：https://rdm.nii.ac.jp/d3y6e/\n協定書付帯事項：https://rdm.nii.ac.jp/ve4fp/\n未病DBガイドライン：https://rdm.nii.ac.jp/3sw6v/|In the Mebyo Database (Mebyo DB), authorship and copyright are stipulated in the agreement. \nIt is recommended that providers make prior arrangements with data users based on the Agreement for each dataset. For details on provider rights, please refer to the following links.\n\nMS2 Agreement: https://rdm.nii.ac.jp/d3y6e/\nMS2 Agreement - Supplementary Provisions: https://rdm.nii.ac.jp/ve4fp/\nMebyo DB Guidelines: https://rdm.nii.ac.jp/3sw6v/",
           "options": [
             {
               "text": "未病DBが定めるオーサーシップや著作権に関する指針について理解しましたか？|Do you understand the Mebyo DB's authorship and copyright policies?",


### PR DESCRIPTION
## Purpose

未病データベースのメタデータ登録フローのチェックリスト画面における説明文中のURLを修正。

## Changes

- 参照ドキュメントURLの記述形式の統一
- 「未病DBデータ格納手順書」のURL追加

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

None
