### PR TITLE
[GRDM-55687] Replace Travis CI with GitHub Actions docker-compose workflow

### DIFF
--- a/.github/ci/docker-compose.env
+++ b/.github/ci/docker-compose.env
@@ -1,0 +1,10 @@
+DOMAIN=http://localhost:5000/
+INTERNAL_DOMAIN=http://localhost:5000/
+API_DOMAIN=http://localhost:8000/
+OSF_DB_HOST=postgres
+OSF_DB_PORT=5432
+DB_HOST=postgres
+DB_PORT=5432
+ELASTIC_URI=elasticsearch:9200
+ELASTIC6_URI=elasticsearch6:9200
+BOTO_CONFIG=/dev/null

--- a/.github/docker-compose.ci.override.yml
+++ b/.github/docker-compose.ci.override.yml
@@ -1,0 +1,38 @@
+version: '3.4'
+
+services:
+  elasticsearch:
+    build:
+      context: .github/docker/elasticsearch
+      dockerfile: Dockerfile.ci
+
+  web:
+    image: ${OSF_TEST_IMAGE}
+    env_file:
+      - .github/ci/docker-compose.env
+      - .docker-compose.sharejs.env
+    environment:
+      OSF_DB_HOST: postgres
+      DB_HOST: postgres
+      OSF_DB_PORT: 5432
+      DB_PORT: 5432
+      ELASTIC_URI: elasticsearch:9200
+      ELASTIC6_URI: elasticsearch6:9200
+      BOTO_CONFIG: /dev/null
+  requirements:
+    image: ${OSF_TEST_IMAGE}
+    command:
+      - /bin/bash
+      - -c
+      - apk add --no-cache --virtual .build-deps build-base linux-headers python3-dev musl-dev libxml2-dev libxslt-dev postgresql-dev libffi-dev libpng-dev freetype-dev jpeg-dev &&
+        invoke requirements --all &&
+        (python3 -m compileall /usr/lib/python3.6 || true) &&
+        rm -Rf /python3.6/* &&
+        cp -Rf -p /usr/lib/python3.6 /
+    environment:
+      OSF_DB_HOST: postgres
+      DB_HOST: postgres
+      OSF_DB_PORT: 5432
+      DB_PORT: 5432
+      ELASTIC_URI: elasticsearch:9200
+      ELASTIC6_URI: elasticsearch6:9200

--- a/.github/docker/elasticsearch/Dockerfile.ci
+++ b/.github/docker/elasticsearch/Dockerfile.ci
@@ -1,0 +1,5 @@
+# syntax=docker/dockerfile:1
+FROM --platform=linux/amd64 elasticsearch:2
+
+RUN /usr/share/elasticsearch/bin/plugin install --batch analysis-kuromoji \
+    && /usr/share/elasticsearch/bin/plugin install --batch analysis-icu

--- a/.github/scripts/ci/run-tests.sh
+++ b/.github/scripts/ci/run-tests.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <TEST_BUILD>" >&2
+    exit 1
+fi
+
+TEST_BUILD="$1"
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+compose_files=(-f docker-compose.yml -f .github/docker-compose.ci.override.yml)
+compose() {
+    docker compose "${compose_files[@]}" "$@"
+}
+
+cleanup() {
+    compose down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cp website/settings/local-travis.py website/settings/local.py
+cp api/base/settings/local-travis.py api/base/settings/local.py
+cp tasks/local-dist.py tasks/local.py
+
+python3 <<'PY'
+from pathlib import Path
+website_local = Path('website/settings/local.py')
+website_local.write_text(website_local.read_text() + '\nDB_HOST = \'postgres\'\nDB_PORT = 5432\nELASTIC_URI = \'elasticsearch:9200\'\n')
+PY
+
+compose pull postgres elasticsearch6 web >/dev/null 2>&1 || true
+compose build elasticsearch
+compose up -d postgres elasticsearch elasticsearch6
+
+for _ in $(seq 1 60); do
+    if compose exec -T postgres pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; then
+        break
+    fi
+    sleep 5
+done
+
+if ! compose exec -T postgres pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; then
+    echo "postgres did not become ready" >&2
+    exit 1
+fi
+
+for url in "http://localhost:9200/_cluster/health?wait_for_status=yellow" "http://localhost:9201/_cluster/health?wait_for_status=yellow"; do
+    for _ in $(seq 1 60); do
+        if curl -fs "$url" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 5
+    done
+    if ! curl -fs "$url" >/dev/null 2>&1; then
+        echo "elasticsearch endpoint $url did not respond" >&2
+        exit 1
+    fi
+done
+
+compose run --rm requirements
+
+read -r -d '' container_script <<'BASH' || true
+set -euo pipefail
+set -x
+export PATH="/usr/local/bin:/usr/bin:$PATH"
+invoke travis_addon_settings
+# Minimal Ember app shells so send_from_directory returns 200 during tests
+mkdir -p "$HOME/preprints" "$HOME/website/ember_osf_web"
+for ember_stub in "$HOME/preprints/index.html" "$HOME/website/ember_osf_web/index.html"; do
+    if [ ! -f "$ember_stub" ]; then
+        printf '<!doctype html><title>stub</title>' > "$ember_stub"
+    fi
+done
+if [ "$TEST_BUILD" = "addons" ]; then
+    cat <<'EOF' > ~/.nodeenvrc
+[nodeenv]
+node = system
+EOF
+    pip3 install --force-reinstall --no-deps pre-commit==1.10.5
+    hash -r
+fi
+mkdir -p user_key_info
+cp root_cert_verifycate.pem user_key_info/
+netstat -an | grep 'tcp.*LISTEN' || true
+pip3 uninstall uritemplate.py --yes || true
+pip3 install uritemplate.py==0.3.0
+if [ "$TEST_BUILD" = "api1_and_js" ]; then
+    invoke assets --dev
+fi
+invoke "test_travis_${TEST_BUILD}" -n 1
+BASH
+
+compose run --rm \
+    -e TEST_BUILD="$TEST_BUILD" \
+    -e BOWER_ALLOW_ROOT=1 \
+    -e NPM_CONFIG_FORCE=true \
+    -e npm_config_force=true \
+    web bash -lc "$container_script"

--- a/.github/scripts/ci/run-tests.sh
+++ b/.github/scripts/ci/run-tests.sh
@@ -31,7 +31,7 @@ website_local = Path('website/settings/local.py')
 website_local.write_text(website_local.read_text() + '\nDB_HOST = \'postgres\'\nDB_PORT = 5432\nELASTIC_URI = \'elasticsearch:9200\'\n')
 PY
 
-compose pull postgres elasticsearch6 web >/dev/null 2>&1 || true
+compose pull postgres elasticsearch6 >/dev/null 2>&1 || true
 compose build elasticsearch
 compose up -d postgres elasticsearch elasticsearch6
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set image owner
+        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
@@ -29,11 +32,11 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/rdm-osf.io:${{ github.sha }}
+          tags: ghcr.io/${{ env.OWNER_LC }}/rdm-osf.io:${{ github.sha }}
 
       - name: Export image reference
         id: meta
-        run: echo "image=ghcr.io/${{ github.repository_owner }}/rdm-osf.io:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        run: echo "image=ghcr.io/${OWNER_LC}/rdm-osf.io:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,38 +12,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     outputs:
       image: ${{ steps.meta.outputs.image }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image owner
-        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Build and push base image
-        uses: docker/build-push-action@v6
+      - name: Build Docker image
         id: build
+        run: |
+          docker build -t rdm-osf-test:${{ github.sha }} -f ./Dockerfile .
+
+      - name: Save Docker image
+        run: |
+          docker save rdm-osf-test:${{ github.sha }} -o /tmp/rdm-osf-image.tar
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
         with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ghcr.io/${{ env.OWNER_LC }}/rdm-osf.io:${{ github.sha }}
+          name: rdm-osf-image
+          path: /tmp/rdm-osf-image.tar
+          retention-days: 1
 
       - name: Export image reference
         id: meta
-        run: echo "image=ghcr.io/${OWNER_LC}/rdm-osf.io:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        run: echo "image=rdm-osf-test:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
   tests:
     runs-on: ubuntu-latest
     needs: build-image
     permissions:
       contents: read
-      packages: read
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -53,8 +52,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: rdm-osf-image
+          path: /tmp
+
+      - name: Load Docker image
+        run: |
+          docker load -i /tmp/rdm-osf-image.tar
 
       - name: Run matrix job
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,61 @@
+name: Unit Tests
+
+on:
+  push:
+    branches-ignore:
+      - '[0-9]*'
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/rdm-osf.io:${{ github.sha }}
+
+      - name: Export image reference
+        id: meta
+        run: echo "image=ghcr.io/${{ github.repository_owner }}/rdm-osf.io:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+  tests:
+    runs-on: ubuntu-latest
+    needs: build-image
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        test_build: [addons, website, api1_and_js, api2, api3_and_osf]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Run matrix job
+        env:
+          TEST_BUILD: ${{ matrix.test_build }}
+          OSF_TEST_IMAGE: ${{ needs.build-image.outputs.image }}
+        run: |
+          bash .github/scripts/ci/run-tests.sh "$TEST_BUILD"


### PR DESCRIPTION
## Purpose

Travis CI が Ubuntu 22.04 / Python 3.6 組み合わせで恒常的に失敗する状況を受け、既存の Docker／docker-compose 基盤を活用したまま同等のMatrixテストを GitHub Actions  で実現する。

## Changes

- Dockerfile を用いた CI 用ベースイメージをワークフロー冒頭でビルド → GHCR に push → 後続マトリクスが同一イメージを pull して再利用する構成を追加
- Travis `invoke test_travis_*` パイプラインを docker-compose 経由で再現し、`addons / website / api1_and_js / api2 / api3_and_osf` の 5 並列ジョブを GitHub Actions で実行
- compose override を GHCR イメージ参照に切り替え、Travis 専用イメージ依存を排除

## QA Notes

- `feature/alternative-workflow-for-travis-ci` ブランチで GitHub Actions（Unit Tests）を手動実行し、マトリクス 5 ジョブが通ることを確認済み  
  - https://github.com/yacchin1205/RDM2-osf.io/actions/runs/18346607957

## Documentation

- 特になし（必要なら README CI 章へ追記を検討）

## Side Effects

- GHCR への push/pull がワークフローに必須となるため、Runner の権限・レジストリのストレージ管理が必要

## Ticket

GRDM-55687
