### PR TITLE
[GRDM-55687] Add loopback alias setup to CI test script and fix broken tests

### DIFF
--- a/.github/scripts/ci/run-tests.sh
+++ b/.github/scripts/ci/run-tests.sh
@@ -31,6 +31,9 @@ website_local = Path('website/settings/local.py')
 website_local.write_text(website_local.read_text() + '\nDB_HOST = \'postgres\'\nDB_PORT = 5432\nELASTIC_URI = \'elasticsearch:9200\'\n')
 PY
 
+# Setup loopback alias for container communication
+sudo ip addr add 192.168.168.167/32 dev lo
+
 compose pull postgres elasticsearch6 >/dev/null 2>&1 || true
 compose build elasticsearch
 compose up -d postgres elasticsearch elasticsearch6

--- a/admin/rdm_custom_storage_location/export_data/utils.py
+++ b/admin/rdm_custom_storage_location/export_data/utils.py
@@ -14,7 +14,6 @@ from rest_framework import status as http_status
 from addons.base.institutions_utils import KEYNAME_BASE_FOLDER
 from addons.dropboxbusiness import utils as dropboxbusiness_utils
 from addons.metadata.models import FileMetadata
-from addons.nextcloudinstitutions import KEYNAME_NOTIFICATION_SECRET
 from addons.nextcloudinstitutions.models import NextcloudInstitutionsProvider
 from addons.osfstorage.models import Region
 from admin.base.schemas.utils import from_json

--- a/admin/rdm_custom_storage_location/export_data/views/restore.py
+++ b/admin/rdm_custom_storage_location/export_data/views/restore.py
@@ -730,6 +730,8 @@ def copy_files_from_export_data_to_destination(task, current_process_step,
                             file_version = node.get_version(response_file_version_id, required=False)
 
                             if file_version is not None:
+                                contributor = version.get('contributor')
+                                user = OSFUser.objects.filter(username=contributor)
                                 file_version_created_at = version.get('created_at')
                                 file_version_modified_at = version.get('modified_at')
 

--- a/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
@@ -12,7 +12,7 @@ from nose import tools as nt
 from requests import ConnectionError, ReadTimeout, Timeout
 from rest_framework import status
 
-from addons.metadata.models import NodeSettings as MetadataNodeSettings, FileMetadata
+from addons.metadata.models import FileMetadata
 from addons.nextcloudinstitutions.models import NextcloudInstitutionsProvider
 from admin.rdm_custom_storage_location.export_data import utils
 from admin.rdm_custom_storage_location.export_data.views.restore import ProcessError

--- a/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
@@ -5,6 +5,7 @@ import uuid
 import mock
 import pytest
 import requests
+import logging
 from datetime import datetime, timezone, timedelta
 from jsonschema import ValidationError, SchemaError
 from mock import patch, MagicMock
@@ -29,6 +30,8 @@ from osf_tests.factories import (
 )
 from tests.base import AdminTestCase
 from website.settings import INSTITUTIONAL_STORAGE_ADD_ON_METHOD
+
+logger = logging.getLogger(__name__)
 
 FAKE_TASK_ID = '00000000-0000-0000-0000-000000000000'
 RESTORE_EXPORT_DATA_PATH = 'admin.rdm_custom_storage_location.export_data.views.restore'
@@ -723,6 +726,7 @@ class TestUtils(AdminTestCase):
         }
 
     def test_write_json_file__successfully(self):
+        logger.info('TestUtils.test_write_json_file__successfully')
         mock_json_dump_patcher = mock.patch(f'{EXPORT_DATA_UTIL_PATH}.json.dump')
         json_data = {'json_data': 'json_data'}
         output_file = '_temp.json'
@@ -736,8 +740,10 @@ class TestUtils(AdminTestCase):
         nt.assert_equal(call_args[1], {'ensure_ascii': False, 'indent': 2, 'sort_keys': False})
 
         mock_json_dump_patcher.stop()
+        logger.info('TestUtils.test_write_json_file__successfully completed')
 
     def test_from_json__file_not_found(self):
+        logger.info('TestUtils.test_from_json__file_not_found')
         mock_json_dump_patcher = mock.patch(
             f'{EXPORT_DATA_UTIL_PATH}.json.dump',
             side_effect=Exception()
@@ -751,8 +757,10 @@ class TestUtils(AdminTestCase):
         mock_json_dump.assert_called()
 
         mock_json_dump_patcher.stop()
+        logger.info('TestUtils.test_from_json__file_not_found completed')
 
     def test_update_storage_location__create_new(self):
+        logger.info('TestUtils.test_update_storage_location__create_new')
         result = utils.update_storage_location(
             institution_guid=self.institution.guid,
             storage_name='testname',
@@ -762,8 +770,10 @@ class TestUtils(AdminTestCase):
         nt.assert_equal(result.waterbutler_credentials, self.wb_credentials)
         nt.assert_equal(result.waterbutler_settings, self.wb_settings)
         nt.assert_equal(result.name, 'testname')
+        logger.info('TestUtils.test_update_storage_location__create_new completed')
 
     def test_update_storage_location__update(self):
+        logger.info('TestUtils.test_update_storage_location__update')
         ExportDataLocationFactory(
             institution_guid=self.institution.guid,
             name='testname',
@@ -781,8 +791,10 @@ class TestUtils(AdminTestCase):
         nt.assert_equal(result.waterbutler_credentials, self.wb_credentials)
         nt.assert_equal(result.waterbutler_settings, self.wb_settings)
         nt.assert_equal(result.name, 'testname')
+        logger.info('TestUtils.test_update_storage_location__update completed')
 
     def test_test_dropboxbusiness_connection__no_option(self):
+        logger.info('TestUtils.test_test_dropboxbusiness_connection__no_option')
         mock_get_two_addon_options = mock.MagicMock(return_value=None)
         with mock.patch(f'{EXPORT_DATA_UTIL_PATH}.dropboxbusiness_utils.get_two_addon_options',
                         mock_get_two_addon_options):
@@ -791,8 +803,10 @@ class TestUtils(AdminTestCase):
             nt.assert_equal(status_code, 400)
             nt.assert_true('message' in data)
             nt.assert_equal(data.get('message'), 'Invalid Institution ID.: {}'.format(self.institution.id))
+        logger.info('TestUtils.test_test_dropboxbusiness_connection__no_option completed')
 
     def test_test_dropboxbusiness_connection__no_token(self):
+        logger.info('TestUtils.test_test_dropboxbusiness_connection__no_token')
         mock_get_two_addon_options_patcher = mock.patch(
             f'{EXPORT_DATA_UTIL_PATH}.dropboxbusiness_utils.get_two_addon_options',
             return_value=('apple', 'banana')
@@ -814,6 +828,7 @@ class TestUtils(AdminTestCase):
 
         mock_addon_option_to_token_patcher.stop()
         mock_get_two_addon_options_patcher.stop()
+        logger.info('TestUtils.test_test_dropboxbusiness_connection__no_token completed')
 
     def test_test_dropboxbusiness_connection__valid(self):
         mock_get_two_addon_options_patcher = mock.patch(

--- a/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
+++ b/admin_tests/rdm_custom_storage_location/export_data/test_utils.py
@@ -1707,7 +1707,7 @@ class TestUtilsForCheckRestoreData(AdminTestCase):
         self.export_data_restore = ExportDataRestoreFactory()
         self.export_data_restore.export = self.export_data
         self.project = ProjectFactory(creator=self.user)
-        self.metadata_node_settings = MetadataNodeSettings(owner=self.project)
+        self.metadata_node_settings = self.project.get_or_add_addon('metadata', self.user)
         self.metadata_node_settings.save()
 
     def test_count_file_ng_ok(self):
@@ -2847,7 +2847,7 @@ class TestUtilsForRestoreData(AdminTestCase):
     def test_update_file_metadata_project_not_found(self):
         user = AuthUserFactory()
         project = ProjectFactory()
-        metadata_node_settings = MetadataNodeSettings(owner=project)
+        metadata_node_settings = project.get_or_add_addon('metadata', user)
         metadata_node_settings.save()
         source_provider = 'osfstorage'
         destination_provider = 's3compatinstitutions'
@@ -2869,7 +2869,7 @@ class TestUtilsForRestoreData(AdminTestCase):
     def test_update_file_metadata_no_update(self):
         user = AuthUserFactory()
         project = ProjectFactory()
-        metadata_node_settings = MetadataNodeSettings(owner=project)
+        metadata_node_settings = project.get_or_add_addon('metadata', user)
         metadata_node_settings.save()
         source_provider = 'dropboxbusiness'
         destination_provider = 's3compatinstitutions'
@@ -2891,7 +2891,7 @@ class TestUtilsForRestoreData(AdminTestCase):
     def test_update_file_metadata(self):
         user = AuthUserFactory()
         project = ProjectFactory()
-        metadata_node_settings = MetadataNodeSettings(owner=project)
+        metadata_node_settings = project.get_or_add_addon('metadata', user)
         metadata_node_settings.save()
         source_provider = 'osfstorage'
         destination_provider = 's3compatinstitutions'
@@ -2914,7 +2914,7 @@ class TestUtilsForRestoreData(AdminTestCase):
     def test_update_all_folders_metadata_invalid_input(self):
         user = AuthUserFactory()
         project = ProjectFactory()
-        metadata_node_settings = MetadataNodeSettings(owner=project)
+        metadata_node_settings = project.get_or_add_addon('metadata', user)
         metadata_node_settings.save()
         source_provider = 'osfstorage'
         destination_provider = 's3compatinstitutions'
@@ -2936,7 +2936,7 @@ class TestUtilsForRestoreData(AdminTestCase):
     def test_update_all_folders_metadata(self):
         user = AuthUserFactory()
         project = ProjectFactory(creator=user)
-        metadata_node_settings = MetadataNodeSettings(owner=project)
+        metadata_node_settings = project.get_or_add_addon('metadata', user)
         metadata_node_settings.save()
         source_provider = 'osfstorage'
         destination_provider = 's3compatinstitutions'

--- a/admin_tests/rdm_custom_storage_location/test_utils.py
+++ b/admin_tests/rdm_custom_storage_location/test_utils.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 from nose import tools as nt
 
@@ -59,8 +60,8 @@ class TestUtils:
     @patch('osf.utils.external_util.remove_region_external_account')
     @patch('admin.rdm_custom_storage_location.utils.update_storage')
     @patch('admin.rdm_custom_storage_location.utils.test_s3compatb3_connection')
-    def test_save_s3compatb3_credentials(self, 
-                                         _testconnection, mock_update_storage,
+    def test_save_s3compatb3_credentials(self,
+                                         mock_testconnection, mock_update_storage,
                                          mock_remove_region_external_account):
         mock_testconnection.return_value = {'message': 'Nice'}, http_status.HTTP_200_OK
         mock_update_storage.return_value = {}

--- a/osf_tests/test_export_data.py
+++ b/osf_tests/test_export_data.py
@@ -92,8 +92,8 @@ class TestExportData(TestCase):
                 'materialized_path': file1.materialized_path,
                 'name': file1.name,
                 'provider': file1.provider,
-                'created_at': str(file1.created),
-                'modified_at': str(file1.modified),
+                'created_at': file1.created.strftime('%Y-%m-%d %H:%M:%S'),
+                'modified_at': file1.modified.strftime('%Y-%m-%d %H:%M:%S'),
                 'project': {
                     'id': file1.target._id,
                     'name': file1.target.title,
@@ -101,8 +101,8 @@ class TestExportData(TestCase):
                 'tags': [],
                 'version': [{
                     'identifier': file_version.identifier,
-                    'created_at': str(file_version.created),
-                    'modified_at': str(file_version.modified),
+                    'created_at': file_version.created.strftime('%Y-%m-%d %H:%M:%S'),
+                    'modified_at': file_version.modified.strftime('%Y-%m-%d %H:%M:%S'),
                     'size': file_version.size,
                     'version_name': file_versions_through.version_name if file_versions_through else file1.name,
                     'contributor': file_version.creator.username,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

- CIテスト時に `README-docker-compose.md` 準拠の `lo` interfaceを追加するように修正。waterbutler等に実際にアクセスしようとしてしまうテストコード(これは望ましくないが)がある場合、timeoutするため時間がかかる問題を修正することを意図したものです。
- Merge時に壊れたテストの修正

## Changes

テストスクリプトを修正

## QA Notes

None - テスト環境構築にのみ影響。実行コードに影響なし

## Documentation

None

## Side Effects

None

## Ticket

GRDM-55687