### PR TITLE
Extend maximum Wiki page title length from 100 to 200 characters

### DIFF
--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -59,7 +59,7 @@ def validate_page_name(value):
         raise NameEmptyError('Page name cannot be blank.')
     if value.find('/') != -1:
         raise NameInvalidError('Page name cannot contain forward slashes.')
-    if len(value) > 100:
+    if len(value) > 200:
         raise NameMaximumLengthError('Page name cannot be greater than 100 characters.')
     return True
 


### PR DESCRIPTION
## Purpose

Wikiページ名が100文字を超える場合にインポートできない制限があったため、
ページ名の最大長を200文字まで拡張し、長いタイトルのWikiページも
正常にインポートできるように対応しました。

## Changes

- Wikiページ名の最大文字数制限を100文字から200文字に変更
- インポート処理におけるタイトル長チェックロジックを修正

## QA Notes

- Does this change require a data migration? If so, what data will we migrate?
  - データ移行は不要です。既存データへの影響はありません。

- What is the level of risk?
  - 低
    - Any permissions code touched?
      - 権限関連のコード変更はありません。
    - Is this an additive or subtractive change, other?
      - 既存仕様の拡張（additive change）です。

- How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
  - UIを通じて確認可能です。
    - 200文字以内のWikiページ名を持つページをインポートし、
      正常に取り込めることを確認してください。

- What features or workflows might this change impact?
  - Wikiインポート機能のみが対象です。
  - 通常のWiki作成・閲覧フローへの影響はありません。

- How will this impact performance?
  - 文字列長の上限変更のみのため、性能への影響はありません。

## Ticket

#56584