### PR TITLE
[GRDM-57041] JAIRO Cloudアドオン OAuth2スコープにitem:updateを追加

### DIFF
--- a/addons/weko/settings/defaults.py
+++ b/addons/weko/settings/defaults.py
@@ -10,7 +10,7 @@ DEFAULT_TIMEOUT = 30  # seconds
 
 # Default OAuth2 scopes for WEKO repositories
 # Can be a list of scopes or a callable that takes repo_settings and returns a list
-DEFAULT_APPLICATION_SCOPES = ['item:create deposit:actions deposit:write index:create user:activity user:email']
+DEFAULT_APPLICATION_SCOPES = ['item:create item:update deposit:actions deposit:write index:create user:activity user:email']
 
 ENABLE_CSV_GENERATION = True
 ENABLE_RO_CRATE_GENERATION = True


### PR DESCRIPTION
## Purpose

JAIRO CloudアドオンのデフォルトOAuth2スコープに `item:update` を追加する。

## Changes

- JAIRO Cloudアドオン: `DEFAULT_APPLICATION_SCOPES` に `item:update` スコープを追加

## QA Notes

None

## Documentation

None

## Side Effects

None

## Ticket

GRDM-57041