### PR TITLE
Feature/wiki live editing mode button

### DIFF
--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -242,7 +242,7 @@ class WikiVersion(ObjectIDMixin, BaseModel):
 
 class WikiPageNodeManager(models.Manager):
 
-    def create_for_node(self, node, name, content, auth, parent=None, is_wiki_import=False):
+    def create_for_node(self, node, name, content, auth, parent=None, is_wiki_import=False,  add_activity_log=True):
         existing_wiki_page = WikiPage.objects.get_for_node(node, name)
         if existing_wiki_page:
             raise NodeStateError('Wiki Page already exists.')
@@ -255,7 +255,7 @@ class WikiPageNodeManager(models.Manager):
             is_wiki_import=is_wiki_import
         )
         # Creates a WikiVersion object
-        wiki_page.update(auth.user, content, is_wiki_import=is_wiki_import)
+        wiki_page.update(auth.user, content, is_wiki_import=is_wiki_import, add_log=add_activity_log)
         return wiki_page
 
     def get_for_node(self, node, name=None, id=None):
@@ -312,29 +312,31 @@ class WikiPage(GuidMixin, BaseModel):
                 self.node.update_search(wiki_page=self)
         return rv
 
-    def update(self, user, content, is_wiki_import=False):
+    def update(self, user, content, is_wiki_import=False, add_log=True):
         """
         Updates the wiki with the provided content by creating a new version
 
         :param user: The user that is updating the wiki
         :param content: Latest content for wiki
+        :param add_log: Whether to add WIKI_UPDATED to the activity log (default True)
         """
         version = WikiVersion(user=user, wiki_page=self, content=content, identifier=self.current_version_number + 1)
         version.save(is_wiki_import=is_wiki_import)
 
-        self.node.add_log(
-            action=NodeLog.WIKI_UPDATED,
-            params={
-                'project': self.node.parent_id,
-                'node': self.node._primary_key,
-                'page': self.page_name,
-                'page_id': self._primary_key,
-                'version': version.identifier,
-            },
-            auth=Auth(user),
-            log_date=version.created,
-            save=True
-        )
+        if add_log:
+            self.node.add_log(
+                action=NodeLog.WIKI_UPDATED,
+                params={
+                    'project': self.node.parent_id,
+                    'node': self.node._primary_key,
+                    'page': self.page_name,
+                    'page_id': self._primary_key,
+                    'version': version.identifier,
+                },
+                auth=Auth(user),
+                log_date=version.created,
+                save=True
+            )
         return version
 
     def update_active_sharejs(self, node):

--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -242,7 +242,7 @@ class WikiVersion(ObjectIDMixin, BaseModel):
 
 class WikiPageNodeManager(models.Manager):
 
-    def create_for_node(self, node, name, content, auth, parent=None, is_wiki_import=False,  add_activity_log=True):
+    def create_for_node(self, node, name, content, auth, parent=None, is_wiki_import=False, add_activity_log=True):
         existing_wiki_page = WikiPage.objects.get_for_node(node, name)
         if existing_wiki_page:
             raise NodeStateError('Wiki Page already exists.')

--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -59,7 +59,7 @@ def validate_page_name(value):
         raise NameEmptyError('Page name cannot be blank.')
     if value.find('/') != -1:
         raise NameInvalidError('Page name cannot contain forward slashes.')
-    if len(value) > 100:
+    if len(value) > 200:
         raise NameMaximumLengthError('Page name cannot be greater than 100 characters.')
     return True
 

--- a/addons/wiki/templates/import_wiki_page.mako
+++ b/addons/wiki/templates/import_wiki_page.mako
@@ -1,3 +1,4 @@
+## -*- coding: utf-8 -*-
 <%def name="stylesheets()">
     ${parent.stylesheets()}
     <link rel="stylesheet" href="/static/css/pages/wiki-page.css">
@@ -115,6 +116,15 @@
         const WIKI_IMPORT_TIMEOUT = WIKI_IMPORT_INTERVAL * IMPORT_N;
         const WIKI_IMPORT_OPERATION = 'import';
         const VALIDATE_WIKI_IMPORT_OPERATION = 'validate';
+        const MAX_DISPLAY_NAME_LENGTH = 60; // Maximum number of characters to display
+
+        // Function to truncate file name for display
+        function truncateFileName(fileName, maxLength) {
+            if (!fileName || fileName.length <= maxLength) {
+                return fileName;
+            }
+            return fileName.substring(0, maxLength) + '...';
+        }
 
         $wikiImportForm.on('submit', async function (e) {
             e.preventDefault();
@@ -295,11 +305,15 @@
                     if (item.status === 'valid_exists') {
                         valid_exists_ctn++;
                         $alertInfoForm.find('.partOperationAll').css('display', '');
-                        $('#validateInfo ul').append('<li>' + (item.path).slice(1) + '</li>')
-                        $('#perFileDifinitionForm ul').append('<li id="' + (item.path).slice(1) + '" name="WikiImportOperationPerItem">' + '<div name="WikiImportOperationPerName">' +  (item.path).slice(1) + '</div>' + selectOperation + '</li>');
+                        var displayPath = (item.path).slice(1);
+                        var truncatedPath = truncateFileName(displayPath, MAX_DISPLAY_NAME_LENGTH);
+                        $('#validateInfo ul').append('<li title="' + displayPath + '">' + truncatedPath + '</li>')
+                        $('#perFileDifinitionForm ul').append('<li id="' + (item.path).slice(1) + '" name="WikiImportOperationPerItem">' + '<div name="WikiImportOperationPerName" title="' + displayPath + '">' + truncatedPath + '</div>' + selectOperation + '</li>');
                     } else if (item.status === 'valid_duplicated'){
                         $('#attentionDuplicatedInfo').css('display', '');
-                        $('#duplicatedInfo ul').append('<li>' + (item.path).slice(1) + '</li>')
+                        var displayPath = (item.path).slice(1);
+                        var truncatedPath = truncateFileName(displayPath, MAX_DISPLAY_NAME_LENGTH);
+                        $('#duplicatedInfo ul').append('<li title="' + displayPath + '">' + truncatedPath + '</li>')
                     }
                 });
                 if (valid_exists_ctn === 0) {

--- a/addons/wiki/templates/sort_wiki_page.mako
+++ b/addons/wiki/templates/sort_wiki_page.mako
@@ -14,7 +14,7 @@
                 <div class="modal-body sort-modal-body">
                     <h3 class="sort-title">${_("Wiki Tree")}</h3>
                     <div id="manageWikitree" class="scripted">
-                        <ul class="sort-tree" data-bind="sortable: {template: 'wikitreeRow', data: $root.data, afterMove: $root.afterMove, beforeMove: $root.beforeMove}"></ul>
+                        <ul class="sort-tree" data-bind="sortable: {template: 'wikitreeRow', data: $root.data, afterMove: $root.afterMove, beforeMove: $root.beforeMove, options: { dropOnEmpty: true } }"></ul>
                     </div>
                 </div><!-- end modal-body -->
                 <div class="modal-footer sort-modal-footer">
@@ -41,7 +41,7 @@
     </div>
     <!-- /ko -->
     <!-- ko if: $data.children() -->
-    <ul class="sort-children" data-bind="sortable: { template: 'wikitreeRow', data: $data.children, afterMove: $root.afterMove, beforeMove: $root.beforeMove}"></ul>
+    <ul class="sort-children" data-bind="sortable: { template: 'wikitreeRow', data: $data.children, afterMove: $root.afterMove, beforeMove: $root.beforeMove, options: { dropOnEmpty: true }}"></ul>
     <!-- /ko -->
   </li>
 </script>

--- a/addons/wiki/tests/test_models.py
+++ b/addons/wiki/tests/test_models.py
@@ -15,7 +15,7 @@ class TestWikiPageModel:
 
     @pytest.mark.enable_implicit_clean
     def test_page_name_cannot_be_greater_than_100_characters(self):
-        bad_name = 'a' * 101
+        bad_name = 'a' * 201
         page = WikiPage(page_name=bad_name)
         with pytest.raises(NameMaximumLengthError):
             page.save()

--- a/addons/wiki/tests/test_views.py
+++ b/addons/wiki/tests/test_views.py
@@ -222,7 +222,7 @@ class TestRenameNodeWiki(OsfTestCase):
             self.second_wiki.rename(invalid_name, self.auth)
 
     def test_rename_name_maximum_length(self):
-        new_name = 'a' * 101
+        new_name = 'a' * 201
         with pytest.raises(NameMaximumLengthError):
             self.second_wiki.rename(new_name, self.auth)
 

--- a/addons/wiki/tests/test_wiki_import.py
+++ b/addons/wiki/tests/test_wiki_import.py
@@ -124,7 +124,7 @@ class TestWikiPageNodeManager(OsfTestCase, unittest.TestCase):
 
         # True?
         mock_create.assert_called_with(is_wiki_import=True, node=self.project, page_name='home child', parent=None, user=self.user)
-        wiki_page.update.assert_called_with(self.user, 'home child content', is_wiki_import=True)
+        wiki_page.update.assert_called_with(self.user, 'home child content', add_log=True, is_wiki_import=True)
 
     @mock.patch('addons.wiki.models.WikiPage.objects.create')
     def test_create_for_node_false(self, mock_create):
@@ -142,7 +142,7 @@ class TestWikiPageNodeManager(OsfTestCase, unittest.TestCase):
 
         # False
         mock_create.assert_called_with(is_wiki_import=False, node=self.project, page_name='home child', parent=None, user=self.user)
-        wiki_page.update.assert_called_with(self.user, 'home child content', is_wiki_import=False)
+        wiki_page.update.assert_called_with(self.user, 'home child content', add_log=True, is_wiki_import=False)
 
     def test_create(self):
         new_node = WikiPage.objects.create(

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -31,6 +31,7 @@ from django_bulk_update.helper import bulk_update
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from framework.exceptions import HTTPError
+from framework.auth import Auth
 from framework.auth.utils import privacy_info_handle
 from framework.auth.decorators import must_be_logged_in
 from framework.auth.core import get_current_user_id
@@ -618,6 +619,11 @@ def format_project_wiki_pages(node, auth):
     pages = []
     can_edit = node.has_permission(auth.user, WRITE) and not node.is_registration
     project_wiki_pages = _get_wiki_pages_latest(node)
+    # ホームが存在せず、編集可能な場合は自動作成（Reorder Wiki Tree で表示するため）
+    # add_activity_log=False: Wikiタブを開いただけの自動作成ではアクティビティログに残さない
+    if (can_edit and auth.user and
+            not WikiPage.objects.get_for_node(node, 'home')):
+        WikiPage.objects.create_for_node(node, 'home', '', Auth(auth.user), add_activity_log=False)
     home_wiki_page = format_home_wiki_page(node)
     pages.append(home_wiki_page)
     for wiki_page in project_wiki_pages:

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -556,3 +556,137 @@ li[name="WikiImportOperationPerItem"] {
   border: 1px solid #ccc;
   padding: 8px;
 }
+
+/* Hide collaborativeStatus and cp-sidebar-content by default */
+#collaborativeStatus,
+.cp-sidebar-content {
+    display: none !important;
+    visibility: hidden !important;
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+/* Ensure icons are visible in wiki tree */
+.tb-expand-icon-holder,
+.tb-expand-icon-holder > i,
+.tb-expand-icon-holder > span {
+    display: inline-block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+}
+
+/* Fix long file names in wiki tree - truncate with ellipsis */
+.tb-row .tb-td {
+    overflow: visible !important;
+}
+
+.tb-row .tb-td .fg-file-links {
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
+    display: inline-block !important;
+    max-width: calc(100% - 30px) !important;
+}
+
+/* Fix long file names in wiki import modal - truncate with ellipsis */
+#alertInfo #validateInfo ul,
+#alertInfo #duplicatedInfo ul,
+#alertInfo #duplicatedFolder ul {
+    padding-left: 20px !important;
+    margin: 0 !important;
+    list-style: none !important;
+}
+
+#alertInfo #validateInfo ul li,
+#alertInfo #duplicatedInfo ul li,
+#alertInfo #duplicatedFolder ul li {
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    display: -webkit-box !important;
+    -webkit-line-clamp: 2 !important;
+    -webkit-box-orient: vertical !important;
+    max-width: 100% !important;
+    position: relative !important;
+    padding-left: 15px !important;
+    margin-left: 0 !important;
+    cursor: help !important;
+    word-wrap: break-word !important;
+    word-break: break-word !important;
+    line-height: 1.5 !important;
+    height: auto !important;
+    max-height: none !important;
+}
+
+#alertInfo #validateInfo ul li::before,
+#alertInfo #duplicatedInfo ul li::before,
+#alertInfo #duplicatedFolder ul li::before {
+    content: "・" !important;
+    position: absolute !important;
+    left: 0 !important;
+    display: inline-block !important;
+    width: 15px !important;
+}
+
+#alertInfo #perFileDifinitionForm ul {
+    padding-left: 0 !important;
+    margin: 0 !important;
+}
+
+#alertInfo #perFileDifinitionForm ul li {
+    display: flex !important;
+    align-items: flex-start !important;
+    justify-content: space-between !important;
+    overflow: visible !important;
+    width: 100% !important;
+    box-sizing: border-box !important;
+    padding: 8px 0 !important;
+    margin: 0 !important;
+    list-style: none !important;
+    position: relative !important;
+    padding-left: 0 !important;
+}
+
+#alertInfo #perFileDifinitionForm ul li::before {
+    content: "・" !important;
+    position: absolute !important;
+    left: 5px !important;
+    top: 8px !important;
+    display: inline-block !important;
+    width: auto !important;
+    line-height: 1.5 !important;
+    margin-right: 0 !important;
+}
+
+#alertInfo #perFileDifinitionForm ul li div[name="WikiImportOperationPerName"] {
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    display: -webkit-box !important;
+    -webkit-line-clamp: 2 !important;
+    -webkit-box-orient: vertical !important;
+    flex: 1 1 auto !important;
+    min-width: 0 !important;
+    max-width: calc(100% - 160px) !important;
+    margin-right: 30px !important;
+    margin-left: -30px !important;
+    cursor: help !important;
+    word-wrap: break-word !important;
+    word-break: break-word !important;
+    line-height: 1.5 !important;
+    align-self: flex-start !important;
+}
+
+#alertInfo #perFileDifinitionForm ul li div[name="WikiImportOperationPer"] {
+    flex: 0 0 auto !important;
+    min-width: 120px !important;
+    max-width: 130px !important;
+    width: 130px !important;
+    margin-left: auto !important;
+    align-self: center !important;
+    margin-top: 0 !important;
+}
+
+#alertInfo #perFileDifinitionForm ul li div[name="WikiImportOperationPer"] .form-control {
+    width: 100% !important;
+    min-width: 120px !important;
+    max-width: 130px !important;
+}

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -558,7 +558,6 @@ li[name="WikiImportOperationPerItem"] {
 }
 
 /* Hide collaborativeStatus and cp-sidebar-content by default */
-#collaborativeStatus,
 .cp-sidebar-content {
     display: none !important;
     visibility: hidden !important;

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -575,6 +575,21 @@ li[name="WikiImportOperationPerItem"] {
     opacity: 1 !important;
 }
 
+/* Fix icon and file name alignment in wiki tree */
+#grid .tb-expand-icon-holder,
+#grid .tb-expand-icon-holder > i,
+#grid .tb-expand-icon-holder > span,
+#grid .tb-row .tb-td .fg-file-links {
+    vertical-align: middle !important;
+}
+
+/* Fix icon vertical position (method 3: nudge icon up to align with text) */
+#grid .tb-expand-icon-holder > i,
+#grid .tb-expand-icon-holder > span {
+    position: relative !important;
+    top: -2px !important;
+}
+
 /* Fix long file names in wiki tree - truncate with ellipsis */
 .tb-row .tb-td {
     overflow: visible !important;


### PR DESCRIPTION
## Purpose
This PR is a re-request of a previous pull request with additional fixes and UI improvements for the Wiki page functionality. The goal is to enhance usability and consistency when managing and editing Wiki pages.

## Changes
・Re-request of a previously submitted PR with updates
・Enabled drag-and-drop functionality to allow reordering Wiki pages under other Wiki pages (nested structure support)
・Ensured the Home page is included and visible during Wiki page reordering
・Aligned the position of file icons and file names in the file list displayed on the left side of the Wiki page
・Fixed an issue where the "Live editing mode" button was not displayed in the top-right corner of the Wiki page

## QA Notes
・Data Migration:
　No data migration required
・Risk Level:
　Low to medium
　・No permissions-related code changes
　・Primarily UI and front-end interaction updates (additive changes)
・QA Verification:
　Verify via UI
　・Confirm Wiki pages can be reordered via drag-and-drop, including nesting under other pages
　・Confirm the Home page appears in the reorder list
　・Check that file icons and file names are properly aligned in the left sidebar
　・Confirm the "Live editing mode" button is visible in the top-right of the Wiki page
・Impacted Features / Workflows:
　・Wiki page management (reordering, hierarchy)
　・Wiki page UI (sidebar and header area)
・Performance Impact:
　Minimal, as changes are primarily UI-related

## Documentation
No documentation updates required

## Side Effects
No known side effects at this time

## Ticket
　#58720
　#58721
