### PR TITLE
Prevent errors caused by duplicate wiki pages

### DIFF
--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -260,11 +260,12 @@ class WikiPageNodeManager(models.Manager):
 
     def get_for_node(self, node, name=None, id=None):
         if name:
-            try:
-                name = (name or '').strip()
-                return WikiPage.objects.get(page_name__iexact=name, deleted__isnull=True, node=node)
-            except WikiPage.DoesNotExist:
-                return None
+            name = (name or '').strip()
+            return WikiPage.objects.filter(
+                page_name__iexact=name,
+                deleted__isnull=True,
+                node=node,
+            ).order_by('created', 'id').first()
         return WikiPage.load(id)
 
     def get_for_child_nodes(self, node, parent=None):

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -26,7 +26,6 @@ from celery.result import AsyncResult
 from celery.contrib.abortable import AbortableAsyncResult
 from flask import request
 from flask_babel import lazy_gettext as _
-from django.db.models.expressions import F
 from django_bulk_update.helper import bulk_update
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -120,7 +120,26 @@ def _get_wiki_versions(node, name, anonymous=False):
         for version in versions
     ]
 
+def _iter_wiki_latest_deduped_by_canonical_name(node, wiki_version_qs):
+    """Yield WikiVersion rows whose wiki_page matches get_for_node for that name.
+
+    Duplicate active WikiPage rows with the same page_name (case-insensitive) are
+    hidden from menus; the canonical row matches WikiPage.objects.get_for_node.
+    """
+    canonical_cache = {}
+    for page in wiki_version_qs:
+        wp = page.wiki_page
+        key = wp.page_name.lower()
+        if key not in canonical_cache:
+            canonical_cache[key] = WikiPage.objects.get_for_node(node, wp.page_name)
+        canonical = canonical_cache[key]
+        if canonical is None or canonical.id != wp.id:
+            continue
+        yield page
+
 def _get_wiki_pages_latest(node):
+    qs = WikiPage.objects.get_wiki_pages_latest(node).order_by(
+        F('wiki_page__sort_order'), F('name'))
     return [
         {
             'name': page.wiki_page.page_name,
@@ -130,10 +149,12 @@ def _get_wiki_pages_latest(node):
             'wiki_content': _wiki_page_content(page.wiki_page.page_name, node=node),
             'sort_order': page.wiki_page.sort_order
         }
-        for page in WikiPage.objects.get_wiki_pages_latest(node).order_by(F('wiki_page__sort_order'), F('name'))
+        for page in _iter_wiki_latest_deduped_by_canonical_name(node, qs)
     ]
 
 def _get_wiki_child_pages_latest(node, parent):
+    qs = WikiPage.objects.get_wiki_child_pages_latest(node, parent).order_by(
+        F('wiki_page__sort_order'), F('name'))
     return [
         {
             'name': page.wiki_page.page_name,
@@ -143,7 +164,7 @@ def _get_wiki_child_pages_latest(node, parent):
             'wiki_content': _wiki_page_content(page.wiki_page.page_name, node=node),
             'sort_order': page.wiki_page.sort_order
         }
-        for page in WikiPage.objects.get_wiki_child_pages_latest(node, parent).order_by(F('wiki_page__sort_order'), F('name'))
+        for page in _iter_wiki_latest_deduped_by_canonical_name(node, qs)
     ]
 
 def _get_wiki_api_urls(node, name, additional_urls=None):
@@ -1357,9 +1378,13 @@ def _get_sorted_list(sorted_data, parent_wiki_id):
     return id_list, sort_list, parent_wiki_id_list
 
 def _bulk_update_wiki_sort(node, sort_id_list, sort_num_list, parent_wiki_id_list):
+    # Tree payload omits duplicate-name rows (see _iter_wiki_latest_deduped_by_canonical_name); skip those.
+    sort_ids = set(sort_id_list)
     wiki_pages = node.wikis.filter(deleted__isnull=True).exclude(page_name='home')
 
     for page in wiki_pages:
+        if page._primary_key not in sort_ids:
+            continue
         idx = sort_id_list.index(page._primary_key)
         sort_order_number = sort_num_list[idx]
         parent_wiki_id = parent_wiki_id_list[idx]

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -26,6 +26,7 @@ from celery.result import AsyncResult
 from celery.contrib.abortable import AbortableAsyncResult
 from flask import request
 from flask_babel import lazy_gettext as _
+from django.db.models import Func
 from django.db.models.expressions import F
 from django_bulk_update.helper import bulk_update
 from django.core.exceptions import ObjectDoesNotExist
@@ -120,26 +121,29 @@ def _get_wiki_versions(node, name, anonymous=False):
         for version in versions
     ]
 
-def _iter_wiki_latest_deduped_by_canonical_name(node, wiki_version_qs):
-    """Yield WikiVersion rows whose wiki_page matches get_for_node for that name.
+def _sort_wiki_versions_for_menu(wiki_versions):
+    """sort_order, then page name (null sort_order last). After DISTINCT ON dedupe."""
+    wiki_versions.sort(
+        key=lambda wv: (wv.wiki_page.sort_order is None, wv.wiki_page.sort_order, wv.wiki_page.page_name or ''))
 
-    Duplicate active WikiPage rows with the same page_name (case-insensitive) are
-    hidden from menus; the canonical row matches WikiPage.objects.get_for_node.
+
+def _wiki_versions_latest_deduped_by_canonical_name(wiki_version_qs):
+    """One WikiVersion per LOWER(name), same as get_for_node (min wiki_page__created, then id).
+
+    get_wiki_pages_latest annotates `name=F('wiki_page__page_name')`. PostgreSQL DISTINCT ON.
     """
-    canonical_cache = {}
-    for page in wiki_version_qs:
-        wp = page.wiki_page
-        key = wp.page_name.lower()
-        if key not in canonical_cache:
-            canonical_cache[key] = WikiPage.objects.get_for_node(node, wp.page_name)
-        canonical = canonical_cache[key]
-        if canonical is None or canonical.id != wp.id:
-            continue
-        yield page
+    q = (
+        wiki_version_qs
+        .annotate(name_lower=Func(F('name'), function='LOWER'))
+        .order_by('name_lower', 'wiki_page__created', 'wiki_page__id')
+        .distinct('name_lower')
+    )
+    return list(q)
 
 def _get_wiki_pages_latest(node):
-    qs = WikiPage.objects.get_wiki_pages_latest(node).order_by(
-        F('wiki_page__sort_order'), F('name'))
+    base = WikiPage.objects.get_wiki_pages_latest(node)
+    pages = _wiki_versions_latest_deduped_by_canonical_name(base)
+    _sort_wiki_versions_for_menu(pages)
     return [
         {
             'name': page.wiki_page.page_name,
@@ -149,12 +153,13 @@ def _get_wiki_pages_latest(node):
             'wiki_content': _wiki_page_content(page.wiki_page.page_name, node=node),
             'sort_order': page.wiki_page.sort_order
         }
-        for page in _iter_wiki_latest_deduped_by_canonical_name(node, qs)
+        for page in pages
     ]
 
 def _get_wiki_child_pages_latest(node, parent):
-    qs = WikiPage.objects.get_wiki_child_pages_latest(node, parent).order_by(
-        F('wiki_page__sort_order'), F('name'))
+    base = WikiPage.objects.get_wiki_child_pages_latest(node, parent)
+    pages = _wiki_versions_latest_deduped_by_canonical_name(base)
+    _sort_wiki_versions_for_menu(pages)
     return [
         {
             'name': page.wiki_page.page_name,
@@ -164,7 +169,7 @@ def _get_wiki_child_pages_latest(node, parent):
             'wiki_content': _wiki_page_content(page.wiki_page.page_name, node=node),
             'sort_order': page.wiki_page.sort_order
         }
-        for page in _iter_wiki_latest_deduped_by_canonical_name(node, qs)
+        for page in pages
     ]
 
 def _get_wiki_api_urls(node, name, additional_urls=None):
@@ -1378,7 +1383,7 @@ def _get_sorted_list(sorted_data, parent_wiki_id):
     return id_list, sort_list, parent_wiki_id_list
 
 def _bulk_update_wiki_sort(node, sort_id_list, sort_num_list, parent_wiki_id_list):
-    # Tree payload omits duplicate-name rows (see _iter_wiki_latest_deduped_by_canonical_name); skip those.
+    # Tree payload omits duplicate-name rows (see _wiki_versions_latest_deduped_by_canonical_name); skip those.
     sort_ids = set(sort_id_list)
     wiki_pages = node.wikis.filter(deleted__isnull=True).exclude(page_name='home')
 

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -26,7 +26,6 @@ from celery.result import AsyncResult
 from celery.contrib.abortable import AbortableAsyncResult
 from flask import request
 from flask_babel import lazy_gettext as _
-from django.db.models import Func
 from django.db.models.expressions import F
 from django_bulk_update.helper import bulk_update
 from django.core.exceptions import ObjectDoesNotExist
@@ -130,15 +129,22 @@ def _sort_wiki_versions_for_menu(wiki_versions):
 def _wiki_versions_latest_deduped_by_canonical_name(wiki_version_qs):
     """One WikiVersion per LOWER(name), same as get_for_node (min wiki_page__created, then id).
 
-    get_wiki_pages_latest annotates `name=F('wiki_page__page_name')`. PostgreSQL DISTINCT ON.
+    get_wiki_pages_latest annotates `name=F('wiki_page__page_name')`.
+    Keep DB access to a single query and dedupe in Python for older Django versions
+    where annotate() + distinct(fields) is not supported.
     """
-    q = (
-        wiki_version_qs
-        .annotate(name_lower=Func(F('name'), function='LOWER'))
-        .order_by('name_lower', 'wiki_page__created', 'wiki_page__id')
-        .distinct('name_lower')
-    )
-    return list(q)
+    q = wiki_version_qs.order_by('wiki_page__created', 'wiki_page__id')
+
+    seen_names = set()
+    deduped = []
+    for wiki_version in q:
+        canonical_name = (wiki_version.name or '').lower()
+        if canonical_name in seen_names:
+            continue
+        seen_names.add(canonical_name)
+        deduped.append(wiki_version)
+
+    return deduped
 
 def _get_wiki_pages_latest(node):
     base = WikiPage.objects.get_wiki_pages_latest(node)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
This PR fixes issues related to Wiki page retrieval when duplicate records exist. The purpose is to prevent errors caused by duplicated Wiki pages and ensure stable page loading and listing behavior.

## Changes

・Updated retrieval logic to prevent failures when duplicate Wiki page records exist
・Modified the page display logic to show only the latest Wiki page and avoid errors during access
・Updated the Wiki list logic to display only the oldest created record when duplicates are present

## QA Notes

・Does this change require a data migration?
　No data migration required.
・What is the level of risk?
　Low to medium.
・Any permissions code touched?
　No.
・Is this an additive or subtractive change, other?
　Logic adjustment for existing retrieval behavior.
・How can QA verify?
　Through UI and backend behavior validation.
　・Confirm Wiki pages open without errors even when duplicate records exist
　・Confirm only the latest Wiki page is displayed when accessing the page
　・Confirm only the oldest created record appears in the Wiki list when duplicates exist
・What features or workflows might this change impact?
　・Wiki page retrieval
　・Wiki page listing
　・Duplicate data handling
・How will this impact performance?
　Minimal impact expected.

## Documentation

No documentation updates required.

## Side Effects

Behavior for duplicate Wiki data is now standardized, which may change how previously duplicated records were displayed.

## Ticket

#58754
