### PR TITLE
ref 2.4.統合管理者のテロップ表示における、複数行表示の改修: Commit code handle multi line display

### DIFF
--- a/admin/templates/maintenance/display.html
+++ b/admin/templates/maintenance/display.html
@@ -26,7 +26,7 @@
             <td>{{ current_alert.start }} - {{ current_alert.end }} UTC</td>
             <td>
                 {% if current_alert.message %}
-                    {{ current_alert.message }}
+                    {{ current_alert.message|urlize|linebreaksbr }}
                 {% else %}
                     {% trans "The site will undergo maintenance between &lt;localized start time&gt;-&lt;localized end time&gt;. Thank you for your patience." %}
                 {% endif %}

--- a/osf/utils/text_rendering.py
+++ b/osf/utils/text_rendering.py
@@ -1,0 +1,8 @@
+from django.template.defaultfilters import urlize, linebreaksbr
+
+
+def render_text(text: str) -> str:
+    if not text:
+        return ''
+    result = linebreaksbr(urlize(text))
+    return result

--- a/tests/test_text_rendering.py
+++ b/tests/test_text_rendering.py
@@ -1,0 +1,38 @@
+import unittest
+from osf.utils.text_rendering import render_text
+
+
+class TestRenderText(unittest.TestCase):
+
+    def test_empty_string(self):
+        assert render_text('') == ''
+
+    def test_none_input(self):
+        assert render_text(None) == ''
+
+    def test_linebreaks(self):
+        text = 'line1\nline2'
+        result = render_text(text)
+
+        assert '<br' in result
+        assert 'line1' in result
+        assert 'line2' in result
+
+    def test_url_conversion(self):
+        text = 'Visit https://abc-test.com'
+        result = render_text(text)
+
+        assert '<a href="https://abc-test.com"' in result
+        assert 'https://abc-test.com</a>' in result
+
+    def test_url_and_linebreak(self):
+        text = 'line1\nhttps://abc-test.com'
+        result = render_text(text)
+        assert '<br' in result
+        assert '<a href="https://abc-test.com"' in result
+
+    def test_xss_not_rendered(self):
+        text = '<script>alert("xss")</script>'
+        result = render_text(text)
+        assert '<script>' not in result
+        assert 'alert' in result

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -1,4 +1,5 @@
 <%def name="nav(service_name, service_url, service_support_url, service_support_target='_self')">
+<% from osf.utils.text_rendering import render_text %>
 <link rel="stylesheet" href='/static/css/nav.css'>
 <div class="osf-nav-wrapper">
 
@@ -139,7 +140,7 @@
                         <span aria-hidden="true">&times;</span></button>
                     <strong>${_('Notice:')}</strong>
                     % if maintenance['message']:
-                        ${maintenance['message']}
+                        ${render_text(maintenance['message']) | n}
                     % else:
                         ${_('The site will undergo maintenance between <span id="maintenanceTime"></span>.') | n}
                         ${_("Thank you for your patience.")}


### PR DESCRIPTION
総合テスト用 j#730 のコピー