### PR TITLE
Develop test 20260528

### DIFF
--- a/osf/management/commands/import_EGAP.py
+++ b/osf/management/commands/import_EGAP.py
@@ -109,7 +109,7 @@ def recursive_upload(auth, node, dir_path, parent='', metadata=None):
         metadata = []
 
     try:
-        for item in os.listdir(dir_path):
+        for item in sorted(os.listdir(dir_path)):
             item_path = os.path.join(dir_path, item)
             base_url = '{}/v1/resources/{}/providers/osfstorage/{}'.format(WATERBUTLER_INTERNAL_URL, node._id, parent)
             if os.path.isfile(item_path):

--- a/osf_tests/management_commands/test_EGAP_import.py
+++ b/osf_tests/management_commands/test_EGAP_import.py
@@ -127,8 +127,8 @@ class TestEGAPImport:
 
         metadata = recursive_upload(auth, node, egap_project_path)
 
-        assert metadata[2] == {'metadata': 'for test-2!'}
-        assert metadata[1] == {'data': {'attributes': {'path': 'parent'}}}
+        assert metadata[1] == {'metadata': 'for test-2!'}
+        assert metadata[2] == {'data': {'attributes': {'path': 'parent'}}}
         assert metadata[0] == {'metadata': 'for test-1!'}
 
     @responses.activate
@@ -188,8 +188,8 @@ class TestEGAPImport:
 
         metadata = recursive_upload(auth, node, egap_project_path)
 
-        assert metadata[2] == {'metadata': 'for test-2!'}
-        assert metadata[1] == {'data': {'attributes': {'path': 'parent'}}}
+        assert metadata[1] == {'metadata': 'for test-2!'}
+        assert metadata[2] == {'data': {'attributes': {'path': 'parent'}}}
         assert metadata[0] == {'metadata': 'for test-1!'}
 
     @responses.activate

--- a/osf_tests/management_commands/test_EGAP_import.py
+++ b/osf_tests/management_commands/test_EGAP_import.py
@@ -127,9 +127,9 @@ class TestEGAPImport:
 
         metadata = recursive_upload(auth, node, egap_project_path)
 
-        assert metadata[0] == {'metadata': 'for test-2!'}
+        assert metadata[2] == {'metadata': 'for test-2!'}
         assert metadata[1] == {'data': {'attributes': {'path': 'parent'}}}
-        assert metadata[2] == {'metadata': 'for test-1!'}
+        assert metadata[0] == {'metadata': 'for test-1!'}
 
     @responses.activate
     def test_recursive_upload_retry(self, node, greg, egap_assets_path, egap_project_name):
@@ -188,9 +188,9 @@ class TestEGAPImport:
 
         metadata = recursive_upload(auth, node, egap_project_path)
 
-        assert metadata[0] == {'metadata': 'for test-2!'}
+        assert metadata[2] == {'metadata': 'for test-2!'}
         assert metadata[1] == {'data': {'attributes': {'path': 'parent'}}}
-        assert metadata[2] == {'metadata': 'for test-1!'}
+        assert metadata[0] == {'metadata': 'for test-1!'}
 
     @responses.activate
     def test_get_egap_assets(self, node_with_file, zip_data):

--- a/osf_tests/management_commands/test_EGAP_import.py
+++ b/osf_tests/management_commands/test_EGAP_import.py
@@ -90,6 +90,7 @@ class TestEGAPImport:
                     WATERBUTLER_INTERNAL_URL,
                     node._id,
                 ),
+                match_querystring=True,
                 json={'data': {'attributes': {'path': 'parent'}}},
                 status=201,
             )
@@ -101,6 +102,7 @@ class TestEGAPImport:
                     WATERBUTLER_INTERNAL_URL,
                     node._id,
                 ),
+                match_querystring=True,
                 json={'metadata': 'for test-2!'},
                 status=201,
             )
@@ -112,6 +114,7 @@ class TestEGAPImport:
                     WATERBUTLER_INTERNAL_URL,
                     node._id,
                 ),
+                match_querystring=True,
                 json={'metadata': 'for test-1!'},
                 status=201,
             )
@@ -137,6 +140,7 @@ class TestEGAPImport:
                     WATERBUTLER_INTERNAL_URL,
                     node._id,
                 ),
+                match_querystring=True,
                 json={'data': {'attributes': {'path': 'parent'}}},
                 status=201,
             )
@@ -148,6 +152,7 @@ class TestEGAPImport:
                     WATERBUTLER_INTERNAL_URL,
                     node._id,
                 ),
+                match_querystring=True,
                 status=500,
             )
         )
@@ -158,6 +163,7 @@ class TestEGAPImport:
                     WATERBUTLER_INTERNAL_URL,
                     node._id,
                 ),
+                match_querystring=True,
                 json={'metadata': 'for test-2!'},
                 status=201,
             )
@@ -169,6 +175,7 @@ class TestEGAPImport:
                     WATERBUTLER_INTERNAL_URL,
                     node._id,
                 ),
+                match_querystring=True,
                 json={'metadata': 'for test-1!'},
                 status=201,
             )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ webtest-plus==0.3.3
 mock==2.0.0
 Faker==4.0.1
 schema==0.3.1
-responses==0.8.1
+responses==0.9.0
 freezegun==1.2.1
 
 # Syntax checking


### PR DESCRIPTION
壊れたテストの修正
・responses (v.0.7.1)がリクエストURLのクエリストリングを無視する
・OS/Pythonのファイルリスト出力の出力順が不定である
事に起因する既存バグ