### PR TITLE
[GRDM-61058] 削除済み項目 metadata-access-rights の残存によるWEKOエクスポート失敗の修正

### DIFF
--- a/addons/metadata/utils.py
+++ b/addons/metadata/utils.py
@@ -151,7 +151,7 @@ def transform_name_fields_item(data):
     if creators is not None:
         rows = creators['value']
         if isinstance(rows, str):
-            rows = json.loads(rows)
+            rows = json.loads(rows) if rows.strip() else []
             creators['value'] = rows
         if isinstance(rows, list) and _transform_creators_rows(rows):
             dirty = True

--- a/osf/migrations/0270_remove_metadata_access_rights.py
+++ b/osf/migrations/0270_remove_metadata_access_rights.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+noop = migrations.RunPython.noop
+
+TARGET_SCHEMA_NAME = '公的資金による研究データのメタデータ登録'
+
+OBSOLETE_KEY = 'grdm-file:metadata-access-rights'
+
+
+def _transform_item(data):
+    if OBSOLETE_KEY in data:
+        data.pop(OBSOLETE_KEY, None)
+        return True
+    return False
+
+
+def _transform_entry(entry):
+    metadata = entry.get('metadata', {})
+    if OBSOLETE_KEY in metadata:
+        metadata.pop(OBSOLETE_KEY, None)
+        return True
+    return False
+
+
+def remove_metadata_access_rights(*args):
+    from addons.metadata.utils import FileMetadataMigrator
+    migrator = FileMetadataMigrator(
+        TARGET_SCHEMA_NAME,
+        _transform_item,
+        _transform_entry,
+    )
+    migrator.run()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0269_merge_20260525_0425'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_metadata_access_rights, noop),
+    ]


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

削除済みの質問 `grdm-file:metadata-access-rights` が古いメタデータ（`items[].data`）に残っているため、WEKO のメタデータ生成時に `KeyError('Question grdm-file:metadata-access-rights not found')` が発生する問題の修正。あわせて、`creators` が空文字 `""` のときに姓名分割 migration `0267` が `JSONDecodeError` で失敗する問題も修正。

## Changes

- migration `0270_remove_metadata_access_rights` を追加し、e-Rad スキーマの `FileMetadata` / `Registration` / `DraftRegistration` から `grdm-file:metadata-access-rights` キーを除去（既存の `FileMetadataMigrator` を利用）
- `transform_name_fields_item` で `creators` が空文字 `""` の場合をガードし、`json.loads("")` を呼ばず `[]` として扱う

## QA Notes

- 今回のような退行(変更前データに関して、WEKO送信に失敗する)を検出できるように、Migration後にWEKO送信ができることのテストを追加 https://github.com/RCOSDP/RDM-e2e-test-nb/pull/44
- 本件変更を適用しない場合に、E2E Migration Test from 20250906(WEKO) が失敗することを確認済みです https://github.com/yacchin1205/RDM2-e2e-test-nb/actions/runs/27873662038

## Documentation

None

## Side Effects

None

## Ticket

GRDM-61058
