### PR TITLE
Fixed bug in creating ro-crate without additional metadata files.

### DIFF
--- a/addons/weko/schema/ro_crate.py
+++ b/addons/weko/schema/ro_crate.py
@@ -538,14 +538,13 @@ def _build_hierarchical_object(user, target_index, file_metadata, download_file_
                 if 'choose-additional-metadata' in value:
                     url = value['choose-additional-metadata']
                     value_data = json.loads(url.get('value') or '[]')
-                    if not value_data:
-                        continue
-                    file_path = value_data[0]['path']
-                    file_name = file_path.split('/')[-1]
-                    for item in value_data:
-                        item['path'] = item['path'].replace('osfstorage/', '')
-                    url['value'] = file_name
-                    value['choose-additional-metadata'] = url
+                    if value_data:
+                        file_path = value_data[0]['path']
+                        file_name = file_path.split('/')[-1]
+                        for item in value_data:
+                            item['path'] = item['path'].replace('osfstorage/', '')
+                        url['value'] = file_name
+                        value['choose-additional-metadata'] = url
                 if 'absolute_url' in value:
                     url = value['absolute_url']
                     parsed_url = urlparse(url)

--- a/addons/weko/tests/test_schema.py
+++ b/addons/weko/tests/test_schema.py
@@ -2381,6 +2381,9 @@ class TestWEKOSchema(OsfTestCase):
             'grdm-files': {
                 'value': [],  # No files
             },
+            'choose-additional-metadata': {  # No additional metadata files
+                'value': '',
+            },
         }
 
         schema.write_ro_crate_json(
@@ -2410,6 +2413,7 @@ class TestWEKOSchema(OsfTestCase):
         # Project metadata should be reflected
         assert_equal(root['name'], 'Test Dataset')
         assert_equal(root['description'], 'Description of experiment purpose')
+        assert_in('ams:purposeOfExperiment', root)
 
     def test_write_ro_crate_json_mebyo_with_additional_metadata_files(self):
         """Test MEBYO schema with choose-additional-metadata containing files.


### PR DESCRIPTION
総合テスト用 #753 のコピー
