### PR TITLE
[GRDM-60941] Fix: auto-input range for Read IdP Profile

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -875,6 +875,8 @@ var ListViewModel = function(ContentModel, urls, modes, preventUnsaved) {
 
     self.idp_attr_institution = ko.observable('').extend({trimmed: true});
     self.idp_attr_department = ko.observable('').extend({trimmed: true});
+    self.idp_attr_institution_ja = ko.observable('').extend({trimmed: true});
+    self.idp_attr_department_ja = ko.observable('').extend({trimmed: true});
 
     self.tracked = self.contents;
 
@@ -1026,6 +1028,14 @@ ListViewModel.prototype.setContentFromIdP = function(content) {
     if (!isEmptyStr(dep)) {
         content.department(dep);
     }
+    var inst_ja = self.idp_attr_institution_ja();
+    if (!isEmptyStr(inst_ja) && ko.isObservable(content.institution_ja)) {
+        content.institution_ja(inst_ja);
+    }
+    var dep_ja = self.idp_attr_department_ja();
+    if (!isEmptyStr(dep_ja) && ko.isObservable(content.department_ja)) {
+        content.department_ja(dep_ja);
+    }
 };
 
 ListViewModel.prototype.unserialize = function(data) {
@@ -1056,6 +1066,18 @@ ListViewModel.prototype.unserialize = function(data) {
             val = idp_attr.department;
             if (!isEmptyStr(val)) {
                 self.idp_attr_department($osf.decodeText(val).trim());
+            }
+        }
+        if ('institution_ja' in idp_attr) {
+            val = idp_attr.institution_ja;
+            if (!isEmptyStr(val)) {
+                self.idp_attr_institution_ja($osf.decodeText(val).trim());
+            }
+        }
+        if ('department_ja' in idp_attr) {
+            val = idp_attr.department_ja;
+            if (!isEmptyStr(val)) {
+                self.idp_attr_department_ja($osf.decodeText(val).trim());
             }
         }
     }
@@ -1385,5 +1407,7 @@ module.exports = {
     // Expose private viewmodels
     _NameViewModel: NameViewModel,
     SocialViewModel: SocialViewModel,
-    BaseViewModel: BaseViewModel
+    BaseViewModel: BaseViewModel,
+    _JobsViewModel: JobsViewModel,
+    _JobViewModel: JobViewModel
 };

--- a/website/static/js/tests/profile.test.js
+++ b/website/static/js/tests/profile.test.js
@@ -130,6 +130,76 @@ describe.skip('profile', () => {
             // TODO: Test citation computes
         });
 
+        describe('JobsViewModel - Japanese fields', () => {
+            var jobsURLs = {
+                crud: '/api/v1/settings/jobs/'
+            };
+            var jobServer;
+            var vm;
+
+            before(() => {
+                jobServer = utils.createServer(sinon, [
+                    {url: jobsURLs.crud, response: {editable: true, contents: [], idp_attr: {}}}
+                ]);
+            });
+
+            after(() => {
+                jobServer.restore();
+            });
+
+            beforeEach(() => {
+                vm = new profile._JobsViewModel(jobsURLs, ['view', 'edit'], false);
+            });
+
+            describe('unserialize', () => {
+                it('should store institution_ja and department_ja from idp_attr', () => {
+                    vm.unserialize({
+                        contents: [],
+                        idp_attr: {
+                            institution: 'Test University',
+                            department: 'CS Department',
+                            institution_ja: 'テスト大学',
+                            department_ja: '情報工学科'
+                        }
+                    });
+                    assert.equal(vm.idp_attr_institution_ja(), 'テスト大学');
+                    assert.equal(vm.idp_attr_department_ja(), '情報工学科');
+                });
+            });
+
+            describe('setContentFromIdP', () => {
+                var content;
+
+                beforeEach(() => {
+                    content = new profile._JobViewModel();
+                    vm.contents([content]);
+                });
+
+                it('should assign institution_ja and department_ja to content', () => {
+                    vm.idp_attr_institution_ja('テスト大学');
+                    vm.idp_attr_department_ja('情報工学科');
+                    vm.setContentFromIdP(content);
+                    assert.equal(content.institution_ja(), 'テスト大学');
+                    assert.equal(content.department_ja(), '情報工学科');
+                });
+
+                it('should not throw when content does not have institution_ja observable', () => {
+                    vm.idp_attr_institution_ja('テスト大学');
+                    vm.idp_attr_department_ja('情報工学科');
+                    var contentWithoutJa = {
+                        institution: function() {},
+                        department: function() {},
+                        isValid: function() { return true; },
+                        institutionObjectEmpty: function() { return false; }
+                    };
+                    vm.contents([contentWithoutJa]);
+                    assert.doesNotThrow(function() {
+                        vm.setContentFromIdP(contentWithoutJa);
+                    });
+                });
+            });
+        });
+
     // TODO: Test other profile ViewModels
     });
 });


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The purpose of these changes is to allow the "Read IdP Profile" button on the Employment tab to automatically populate Japanese-language fields (`institution_ja`, `department_ja`) from the IdP (Shibboleth) attributes stored at login.

## Changes

- **Store Japanese IdP attributes in frontend ViewModel** — Update `ListViewModel.unserialize()` to store `idp_attr_institution_ja` and `idp_attr_department_ja` from the API response, in addition to the already-stored `idp_attr_institution` and `idp_attr_department`.
- **Apply Japanese IdP attributes on "Read IdP Profile"** — Update `ListViewModel.setContentFromIdP()` to write `institution_ja` and `department_ja` into the content model when the corresponding IdP attribute is non-empty.

## QA Notes
<!--
  - Does this change require a data migration? If so, what data will we migrate?
  - What is the level of risk?
    - Any permissions code touched?
    - Is this an additive or subtractive change, other?
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
  - How will this impact performance?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

60941