### PR TITLE
chaqge admin menu visibility

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -133,6 +133,8 @@
                         <i class='fa fa-link'></i><span> {% trans "Login Availability Control" %}</span>
                     </a>
                 </li>
+            {% endif %}
+            {% if user.is_superuser %}
                 <li>
                     <a href="{% url 'loa:list' %}">
                         <i class='fa fa-link'></i><span> {% trans "Level of Assurance" %}</span>


### PR DESCRIPTION
admin画面のLoAメニューの表示条件を
機関管理者または統合管理者 から 統合管理者のみ に変更する