### PR TITLE
Wikiページ並び替えAPIに書き込み権限チェックを追加

### DIFF
--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -3340,6 +3340,31 @@ class TestWikiPageSort(OsfTestCase):
         self.assertEqual(result_wiki_child_page2, {'parent_id': wiki_page2_id, 'sort_order': 1})
         self.assertEqual(result_wiki_child_page3, {'parent_id': wiki_child_page2_id, 'sort_order': 1})
 
+    def _wiki_sort_payload(self):
+        return {
+            'sortedData': [
+                {'name': 'wiki page1', 'id': self.guid1, 'sortOrder': 1, 'children': [], 'fold': False},
+                {'name': 'wiki page2', 'id': self.guid2, 'sortOrder': 2, 'children': [
+                    {'name': 'wiki child page1', 'id': self.child_guid1, 'sortOrder': 1, 'children': [], 'fold': False},
+                    {'name': 'wiki child page2', 'id': self.child_guid2, 'sortOrder': 2, 'children': [
+                        {'name': 'wiki child page3', 'id': self.child_guid3, 'sortOrder': 1, 'children': [], 'fold': False}
+                    ], 'fold': False}
+                ], 'fold': False}
+            ]
+        }
+
+    def test_project_update_wiki_page_sort_requires_login(self):
+        url = self.project.api_url_for('project_update_wiki_page_sort')
+        res = self.app.post_json(url, self._wiki_sort_payload(), expect_errors=True)
+        assert_equal(res.status_code, http_status.HTTP_401_UNAUTHORIZED)
+
+    def test_project_update_wiki_page_sort_requires_write_permission(self):
+        read_user = AuthUserFactory()
+        self.project.add_contributor(read_user, permissions=READ, auth=Auth(self.user))
+        url = self.project.api_url_for('project_update_wiki_page_sort')
+        res = self.app.post_json(url, self._wiki_sort_payload(), auth=read_user.auth, expect_errors=True)
+        assert_equal(res.status_code, http_status.HTTP_403_FORBIDDEN)
+
     def test_project_update_wiki_page_sort(self):
         url = self.project.api_url_for('project_update_wiki_page_sort')
         res = self.app.post_json(url, { 'sortedData': [{'name': 'wiki page1', 'id': self.guid1, 'sortOrder': 1, 'children': [], 'fold': False}, {'name': 'wiki page2', 'id': self.guid2, 'sortOrder': 2, 'children': [{'name': 'wiki child page1', 'id': self.child_guid1, 'sortOrder': 1, 'children': [], 'fold': False}, {'name': 'wiki child page2', 'id': self.child_guid2, 'sortOrder': 2, 'children': [{'name': 'wiki child page3', 'id': self.child_guid3, 'sortOrder': 1, 'children': [], 'fold': False}], 'fold': False}], 'fold': False}]}, auth=self.user.auth)

--- a/addons/wiki/tests/test_wiki_import.py
+++ b/addons/wiki/tests/test_wiki_import.py
@@ -2746,7 +2746,7 @@ class TestWikiViews(OsfTestCase, unittest.TestCase):
                     }
                 ]
             },
-            auth=self.auth
+            auth=self.user.auth
         )
         page_names = ['importpagea1', 'importpageb2', 'wiki child page1', 'wiki child page2', 'wiki child page3']
         result_list = list(WikiPage.objects.filter(page_name__in=page_names).order_by('page_name').values_list('page_name', 'parent_id', 'sort_order'))

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -1368,6 +1368,8 @@ def set_wiki_import_task_proces_end(node):
     qs_alive_task.update(process_end=process_end)
 
 @must_be_valid_project  # returns project
+@must_have_permission(WRITE)  # returns user, project
+@must_not_be_registration
 @must_have_addon('wiki', 'node')
 def project_update_wiki_page_sort(node, **kwargs):
     data = request.get_json()


### PR DESCRIPTION
## Purpose

Add write permission check to the wiki page sort API (project_update_wiki_page_sort), which was missing authorization controls.

## Changes

- Added @must_have_permission(WRITE) and @must_not_be_registration decorators to project_update_wiki_page_sort in addons/wiki/views.py
- Added tests for unauthorized (401) and forbidden (403) responses in addons/wiki/tests/test_wiki.py

## QA Notes

  - Does this change require a data migration? No
  - What is the level of risk?
    - Any permissions code touched? Yes. Added permission decorators to an endpoint that previously had none.    - Is this an additive or subtractive change, other?
    - Is this an additive or subtractive change, other? Additive (adding checks that were missing)
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - Through API. No version change. Endpoint: POST /api/v1/project/<pid>/wiki/sort/update/
    - Verify that a logged-in user with WRITE permission can sort wiki pages (200)
    - Verify that an unauthenticated request is rejected (401)
    - Verify that a READ-only contributor is rejected (403)
    - Verify that the request is rejected for registrations (400)
  - What features or workflows might this change impact? Wiki page reordering only
  - How will this impact performance? No impact

## Documentation

No documentation changes required.

## Side Effects

None. The UI already restricts the sort button to users with write permission. This change aligns the API behavior with the existing UI behavior.

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/60809
