### PR TITLE
Feature/wiki prevent ancestor reversion

### DIFF
--- a/addons/wiki/templates/edit.mako
+++ b/addons/wiki/templates/edit.mako
@@ -269,6 +269,25 @@
       </div><!-- end row -->
     </div>
 
+    <div class="modal fade" id="closeConfirmModal" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h3 class="modal-title">${_("Unsaved Changes")}</h3>
+          </div>
+          <div class="modal-body">
+            <p>${_("Your changes have not been saved. Do you want to save before closing?")}</p>
+          </div>
+          <div class="modal-footer">
+              <button type="button" class="btn btn-default" data-dismiss="modal">${_("Cancel")}</button>
+              <button type="button" class="btn btn-danger" data-bind="click: discardAndClose">${_("Discard")}</button>
+              <button type="button" class="btn btn-success" data-bind="click: saveAndClose">${_("Save and Close")}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div><!-- end wiki -->
 

--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -3340,6 +3340,31 @@ class TestWikiPageSort(OsfTestCase):
         self.assertEqual(result_wiki_child_page2, {'parent_id': wiki_page2_id, 'sort_order': 1})
         self.assertEqual(result_wiki_child_page3, {'parent_id': wiki_child_page2_id, 'sort_order': 1})
 
+    def _wiki_sort_payload(self):
+        return {
+            'sortedData': [
+                {'name': 'wiki page1', 'id': self.guid1, 'sortOrder': 1, 'children': [], 'fold': False},
+                {'name': 'wiki page2', 'id': self.guid2, 'sortOrder': 2, 'children': [
+                    {'name': 'wiki child page1', 'id': self.child_guid1, 'sortOrder': 1, 'children': [], 'fold': False},
+                    {'name': 'wiki child page2', 'id': self.child_guid2, 'sortOrder': 2, 'children': [
+                        {'name': 'wiki child page3', 'id': self.child_guid3, 'sortOrder': 1, 'children': [], 'fold': False}
+                    ], 'fold': False}
+                ], 'fold': False}
+            ]
+        }
+
+    def test_project_update_wiki_page_sort_requires_login(self):
+        url = self.project.api_url_for('project_update_wiki_page_sort')
+        res = self.app.post_json(url, self._wiki_sort_payload(), expect_errors=True)
+        assert_equal(res.status_code, http_status.HTTP_401_UNAUTHORIZED)
+
+    def test_project_update_wiki_page_sort_requires_write_permission(self):
+        read_user = AuthUserFactory()
+        self.project.add_contributor(read_user, permissions=READ, auth=Auth(self.user))
+        url = self.project.api_url_for('project_update_wiki_page_sort')
+        res = self.app.post_json(url, self._wiki_sort_payload(), auth=read_user.auth, expect_errors=True)
+        assert_equal(res.status_code, http_status.HTTP_403_FORBIDDEN)
+
     def test_project_update_wiki_page_sort(self):
         url = self.project.api_url_for('project_update_wiki_page_sort')
         res = self.app.post_json(url, { 'sortedData': [{'name': 'wiki page1', 'id': self.guid1, 'sortOrder': 1, 'children': [], 'fold': False}, {'name': 'wiki page2', 'id': self.guid2, 'sortOrder': 2, 'children': [{'name': 'wiki child page1', 'id': self.child_guid1, 'sortOrder': 1, 'children': [], 'fold': False}, {'name': 'wiki child page2', 'id': self.child_guid2, 'sortOrder': 2, 'children': [{'name': 'wiki child page3', 'id': self.child_guid3, 'sortOrder': 1, 'children': [], 'fold': False}], 'fold': False}], 'fold': False}]}, auth=self.user.auth)

--- a/addons/wiki/tests/test_wiki_import.py
+++ b/addons/wiki/tests/test_wiki_import.py
@@ -2746,7 +2746,7 @@ class TestWikiViews(OsfTestCase, unittest.TestCase):
                     }
                 ]
             },
-            auth=self.auth
+            auth=self.user.auth
         )
         page_names = ['importpagea1', 'importpageb2', 'wiki child page1', 'wiki child page2', 'wiki child page3']
         result_list = list(WikiPage.objects.filter(page_name__in=page_names).order_by('page_name').values_list('page_name', 'parent_id', 'sort_order'))

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -1368,6 +1368,8 @@ def set_wiki_import_task_proces_end(node):
     qs_alive_task.update(process_end=process_end)
 
 @must_be_valid_project  # returns project
+@must_have_permission(WRITE)  # returns user, project
+@must_not_be_registration
 @must_have_addon('wiki', 'node')
 def project_update_wiki_page_sort(node, **kwargs):
     data = request.get_json()

--- a/website/translations/ja/LC_MESSAGES/messages.po
+++ b/website/translations/ja/LC_MESSAGES/messages.po
@@ -1224,6 +1224,22 @@ msgstr "重要な情報、リンク、または画像をここに追加して、
 msgid "Close"
 msgstr "閉じる"
 
+#: addons/wiki/templates/edit.mako:277
+msgid "Unsaved Changes"
+msgstr "未保存の変更"
+
+#: addons/wiki/templates/edit.mako:280
+msgid "Your changes have not been saved. Do you want to save before closing?"
+msgstr "編集内容は保存されていません。閉じる前に保存しますか？"
+
+#: addons/wiki/templates/edit.mako:284
+msgid "Discard"
+msgstr "破棄"
+
+#: addons/wiki/templates/edit.mako:285
+msgid "Save and Close"
+msgstr "保存して閉じる"
+
 #: addons/wiki/templates/edit.mako:218 addons/wiki/templates/edit.mako:225
 msgid "Compare"
 msgstr "比較"


### PR DESCRIPTION
## Purpose
Prevent wiki "ancestor reversion" caused by stale local drafts after closing the editor without saving. This PR adds the close-confirmation UI and Japanese translations. Editor behavior is in the companion PR on `RDM-wiki-develop`.

## Changes
- Add a close confirmation modal (`closeConfirmModal`) with Cancel / Discard / Save and Close
- Add Japanese translations for the new modal strings

## QA Notes
- Does this change require a data migration? If so, what data will we migrate?
  - No
- What is the level of risk?
  - Low–medium (UI/i18n only in this repo; behavior depends on the wiki editor PR)
- Any permissions code touched?
  - No
- Is this an additive or subtractive change, other?
  - Additive (new modal and translations)
- How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
  - Through UI, together with the `RDM-wiki-develop` PR:
    1. Edit a wiki page, make unsaved changes, click Close → modal appears
    2. Cancel keeps the editor open
    3. Discard / Save and Close closes as expected
    4. Japanese locale shows the translated strings
- If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - N/A
- What features or workflows might this change impact?
  - Wiki edit page close flow
- How will this impact performance?
  - Negligible

## Documentation
- No documentation updates required

## Side Effects
- None expected from this PR alone. Full behavior requires the companion `RDM-wiki-develop` change.

## Ticket
https://redmine.devops.rcos.nii.ac.jp/issues/61563