### PR TITLE
S3 Compat SigV4 addon reauth  リンクを削除

### DIFF
--- a/admin/rdm_addons/utils.py
+++ b/admin/rdm_addons/utils.py
@@ -23,7 +23,7 @@ def get_institusion_settings_template(config):
     short_name = config.short_name
     base_path = os.path.join('rdm_addons', 'addons')
 
-    if short_name in ['dataverse', 'owncloud', 's3', 'iqbrims',
+    if short_name in ['dataverse', 'owncloud', 's3', 's3compatsigv4', 'iqbrims',
                       'dropboxbusiness', 'weko']:
         return os.path.join(base_path, '{}_institution_settings.html'.format(short_name))
     return os.path.join(base_path, 'institution_settings_default.html')

--- a/admin/templates/rdm_addons/addons/s3compatsigv4_institution_settings.html
+++ b/admin/templates/rdm_addons/addons/s3compatsigv4_institution_settings.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<!-- Authorization -->
+<div class="addon-settings addon-generic scripted"
+     data-addon-short-name="{{ addon.addon_short_name }}"
+     data-addon-name="{{ addon.addon_full_name }}"
+     data-institution-id="{{ institution.id }}">
+    <h4 class="addon-title">
+      <img class="addon-icon" src="{{ addon.addon_icon_url }}">
+      <span>{{ addon.addon_full_name }}</span>
+    </h4>
+</div>

--- a/admin_tests/rdm_addons/test_utils.py
+++ b/admin_tests/rdm_addons/test_utils.py
@@ -10,6 +10,12 @@ from admin.rdm_addons import utils
 import logging
 logging.getLogger('website.project.model').setLevel(logging.DEBUG)
 
+
+class AddonConfig(object):
+    def __init__(self, short_name):
+        self.short_name = short_name
+
+
 class TestRdmAddonOption(AdminTestCase):
     def setUp(self):
         super(TestRdmAddonOption, self).setUp()
@@ -37,3 +43,8 @@ class TestRdmAddonOption(AdminTestCase):
 
         option = utils.get_rdm_addon_option(self.institution.id, 'dropboxbusiness', create=False)
         nt.assert_false(option.is_allowed)
+
+    def test_get_s3compatsigv4_institution_settings_template(self):
+        template = utils.get_institusion_settings_template(AddonConfig('s3compatsigv4'))
+
+        nt.assert_equal(template, 'rdm_addons/addons/s3compatsigv4_institution_settings.html')


### PR DESCRIPTION
## 概要
- S3 Compatible Storage (SigV4) 用の admin 機関設定テンプレートを追加しました
- `s3compatsigv4` が汎用 OAuth 設定テンプレートではなく、専用テンプレートを使用するように変更しました
- テンプレート選択の挙動を確認する単体テストを追加しました

## 背景
`/addons/<institution_id>/` にアクセスした際、S3 Compatible Storage (SigV4) に `Connect or Reauthorize Account` が表示されていました。

しかし、このリンクは汎用 OAuth 接続用テンプレートに由来しており、S3 Compatible Storage (SigV4) では有効に動作しません。S3 Compatible Storage (SigV4) は access key / secret key を使う方式であり、admin Addons 画面側には対応する OAuth 接続フローがないため、無効なリンクを表示しないようにしました。
