### PR TITLE
[GRDM-61662] サービス切り替えメニューにJAIRO Cloud公開支援機能を追加

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -160,6 +160,7 @@ def get_globals():
         'status': status.pop_status_messages(),
         'prev_status': status.pop_previous_status_messages(),
         'domain': settings.DOMAIN,
+        'oasys_url': settings.OASYS_URL,
         'api_domain': settings.API_DOMAIN,
         'disk_saving_mode': settings.DISK_SAVING_MODE,
         'language': language,

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -149,6 +149,8 @@ NII_FORMAL_NAME_EN = 'National Institute of Informatics'
 RDM_URL = 'https://rdm.nii.ac.jp/'
 #nii url
 NII_HOMEPAGE_URL = 'https://www.nii.ac.jp/'
+#oasys url
+OASYS_URL = ''
 # support email
 OSF_SUPPORT_EMAIL = 'rdm_support@nii.ac.jp'
 # contact email

--- a/website/static/css/nav.css
+++ b/website/static/css/nav.css
@@ -12,3 +12,19 @@
 .osf-nav-wrapper .dropdown-menu.auth-dropdown {
   width: unset !important;
 }
+
+.osf-nav-wrapper .dropdown-menu.service-dropdown {
+  width: unset !important;
+}
+
+@media (max-width: 767px) {
+  .osf-nav-wrapper .dropdown-menu.service-dropdown {
+    position: fixed !important;
+    top: 50px !important;
+    left: 15px !important;
+    right: auto !important;
+  }
+  .osf-nav-wrapper .dropdown-menu.service-dropdown ::after {
+    left: 60px !important;
+  }
+}

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -10,9 +10,6 @@
         <div class="service-name">
             <a href="${service_url}">
                 <span class="hidden-xs"> ${osf_page_name} </span>
-              % if nav_dropdown:
-                <span class="current-service"><strong>${service_name}</strong></span>
-              % endif
             </a>
         </div>
         % if nav_dropdown:
@@ -21,12 +18,9 @@
                 <span class="fa fa-caret-down fa-2x"></span>
             </button>
             <ul class="dropdown-menu service-dropdown" role="menu">
-                <li><a data-bind="click: trackClick.bind($data, 'Home')" href="${domain}">${osf_page_name}<b>${_("HOME")}</b></a></li>
-                <li><a data-bind="click: trackClick.bind($data, 'Preprints')" href="${domain}preprints/">${osf_page_name}<b>${_("PREPRINTS")}</b></a></li>
-                <li><a data-bind="click: trackClick.bind($data, 'Registries')" href="${domain}registries/">${osf_page_name}<b>${_("REGISTRIES")}</b></a></li>
-                <li><a data-bind="click: trackClick.bind($data, 'Meetings')" href="${domain}meetings/">${osf_page_name}<b>${_("MEETINGS")}</b></a></li>
-                % if institutional_landing_flag:
-                    <li><a data-bind="click: trackClick.bind($data, 'Institutions')" href="${domain}institutions/">${osf_page_name}<b>${_("INSTITUTIONS")}</b></a></li>
+                <li><a data-bind="click: trackClick.bind($data, 'Home')" href="${domain}">${osf_page_name}</a></li>
+                % if oasys_url:
+                    <li><a data-bind="click: trackClick.bind($data, 'JAIRO Cloud Publication Support')" href="${oasys_url}">${_("JAIRO Cloud Publication Support")}</a></li>
                 % endif
             </ul>
         </div>

--- a/website/translations/en/LC_MESSAGES/messages.po
+++ b/website/translations/en/LC_MESSAGES/messages.po
@@ -1524,6 +1524,10 @@ msgstr ""
 msgid "INSTITUTIONS"
 msgstr ""
 
+#: website/templates/nav.mako:31
+msgid "JAIRO Cloud Publication Support"
+msgstr ""
+
 #: website/templates/nav.mako:34
 msgid "Toggle navigation"
 msgstr ""

--- a/website/translations/ja/LC_MESSAGES/messages.po
+++ b/website/translations/ja/LC_MESSAGES/messages.po
@@ -1910,6 +1910,10 @@ msgstr "ミーティング"
 msgid "INSTITUTIONS"
 msgstr "インスティチューション"
 
+#: website/templates/nav.mako:31
+msgid "JAIRO Cloud Publication Support"
+msgstr "JAIRO Cloud公開支援機能"
+
 #: website/templates/nav.mako:34
 msgid "Toggle navigation"
 msgstr "ナビゲーションを切り替える"


### PR DESCRIPTION
※ https://github.com/RCOSDP/RDM-ember-osf-web/pull/194 も合わせてMergeしてください。

## Purpose

GakuNin RDMのサービス切り替えメニュー（ロゴ横のドロップダウン）から、JAIRO Cloud公開支援機能（OASys）へ遷移できるようにする。

<img width="513" height="183" alt="image" src="https://github.com/user-attachments/assets/cbb6ed91-0b7f-4fc1-a992-a129db36e8a7" />


## Changes

- nav.mako
  - サービス名表示を `OSF_PAGE_NAME` に変更し、現在サービスラベル（HOME等）を削除
  - ドロップダウン項目を「GakuNin RDM」「JAIRO Cloud公開支援機能」の2項目に変更（HOME / PREPRINTS / REGISTRIES / MEETINGS を削除）
- settings
  - `OASYS_URL` を追加（未設定時はJAIRO Cloud公開支援機能の項目を表示しない）
- nav.css
  - ドロップダウン幅を内容に合わせて自動化
  - モバイル（767px以下）でドロップダウンを画面左に固定表示
- translations
  - `JAIRO Cloud Publication Support`（ja: JAIRO Cloud公開支援機能）を追加

## QA Notes

- OASys（JAIRO Cloud公開支援機能）側のE2Eテストにサービス切り替えのシナリオを追加し、本ブランチを develop にマージした構成で全シナリオが成功することを確認済みです

## Documentation

None

## Side Effects

- `NAV_DROPDOWN` 有効時のドロップダウン項目が変わります（`OASYS_URL` 未設定の環境では「GakuNin RDM」のみ表示）

## Ticket

GRDM-61662
