### PR TITLE
[GRDM-62705] ENABLE_TIMESTAMP = False でタイムスタンプ局へのリクエストを完全に停止できるように修正

### DIFF
--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -646,3 +646,18 @@ class TestOSFAbortableResult(OsfTestCase):
         nt.assert_true(task.ready())
         mock_logger.error.assert_any_call('Failed to get task status! Exception message:')
         mock_logger.error.assert_any_call(msg)
+
+
+class TestEnableTimestampGuard(OsfTestCase):
+    """When ENABLE_TIMESTAMP is False, add_token and check_file_timestamp must
+    return immediately, so that no request is sent to the timestamp authority.
+    """
+
+    @mock.patch('website.util.timestamp.settings.ENABLE_TIMESTAMP', False)
+    def test_add_token_disabled(self):
+        # Args are never touched when the guard is effective.
+        nt.assert_is_none(timestamp.add_token(None, None, None))
+
+    @mock.patch('website.util.timestamp.settings.ENABLE_TIMESTAMP', False)
+    def test_check_file_timestamp_disabled(self):
+        nt.assert_is_none(timestamp.check_file_timestamp(None, None, None))

--- a/website/util/timestamp.py
+++ b/website/util/timestamp.py
@@ -317,6 +317,8 @@ def get_full_list(uid, pid, node):
     return provider_list
 
 def check_file_timestamp(uid, node, data, verify_external_only=False):
+    if not settings.ENABLE_TIMESTAMP:
+        return None
     user = OSFUser.objects.get(id=uid)
     file_node = BaseFileNode.objects.get(_id=data['file_id'])
     if not userkey_generation_check(user._id):
@@ -525,6 +527,8 @@ def cancel_celery_task(node):
     return result
 
 def add_token(uid, node, data):
+    if not settings.ENABLE_TIMESTAMP:
+        return None
     try:
         user = OSFUser.objects.get(id=uid)
         file_node = BaseFileNode.objects.get(_id=data['file_id'])


### PR DESCRIPTION
## Purpose

`ENABLE_TIMESTAMP = False` を設定してもタイムスタンプ局(TSA)へのリクエストが止まらない問題を修正します。

現状の `ENABLE_TIMESTAMP` はファイルアップロード時のフック等5関数でのみ参照されており、`False` にしても以下の経路からはTSAへのリクエストが送信され続けます:

- ファイル画面の「Request Trusted Timestamp」アクション
- 証跡管理タブ・管理画面からの一括付与 (`celery_add_timestamp_token`)
- wiki インポート時のファイルコピー
- Nextcloud Institutions / Dropbox Business の Webhook 起点の自動付与

トークン発行(=TSAへの通信)を行う `AddTimestamp` / `AddTimestampHash` は `add_token()` の内部からのみ呼ばれるため、`add_token()` の入口で遮断すれば全経路を網羅できます。また、uPKI構成では検証も外部コマンド(ネットワークアクセスの可能性あり)経由で行われるため、検証の共通入口である `check_file_timestamp()` も停止対象に含めます。

## Changes

- `add_token()` / `check_file_timestamp()` の冒頭に `ENABLE_TIMESTAMP` による早期 return を追加(同ファイル内の既存ガードと同じ形式)
- フラグ無効時に両関数が即座に `None` を返すことを確認するテストを追加

## QA Notes

- 権限判定のコードには触れていません
- `ENABLE_TIMESTAMP = True`(デフォルト、変更なし)の環境では挙動は一切変わりません
- `ENABLE_TIMESTAMP = False` の環境でのE2Eテストとして、自動E2Eテストを実行しました。 https://github.com/RCOSDP/RDM-e2e-test-nb/actions/runs/33574939526 ... Migrationの失敗は #780 , Metadataの失敗に関しては、arXiv APIによる補完処理の失敗(サービスの状況によりまれに失敗) で, Flowable Formsの失敗は https://github.com/RCOSDP/RDM-ember-osf-web/pull/198 , Wikiの問題についてはmainでも発生中であるため、問題ないものと判断しました。

## Documentation

None (`ENABLE_TIMESTAMP` は既存の設定項目です)

## Side Effects

`ENABLE_TIMESTAMP = False` の環境でのみ、以下の既知の影響があります(UI側の整理は別途対応予定):

- ファイル詳細ページの検証APIが500となり、タイムスタンプ検証欄に「Fail: not responded」と表示されます
- Nextcloud Institutions / Dropbox Business のWebhook処理で `AttributeError` がログに記録されます(ファイル単位の `except` で捕捉されタスクは継続します。TSAへの通信は発生しません。Nextcloud は更新検出カーソルが進まないため、同じファイルが次回以降も再検出されます)
- 証跡管理タブの一括検証/付与タスクは全件スキップで正常終了し、`TIMESTAMP_ALL_VERIFIED` / `TIMESTAMP_ALL_ADDED` の NodeLog が記録されます

## Ticket

GRDM-62705
