### PR TITLE
Feature/y websocket jwt auth

### DIFF
--- a/addons/wiki/settings/defaults.py
+++ b/addons/wiki/settings/defaults.py
@@ -8,6 +8,11 @@ SHAREJS_HOST = 'localhost'
 SHAREJS_PORT = 7007
 SHAREJS_URL = '{}:{}'.format(SHAREJS_HOST, SHAREJS_PORT)
 
+Y_WEBSOCKET_SECRET = os.environ.get('Y_WEBSOCKET_SECRET', '')
+Y_WEBSOCKET_JWT_ALGORITHM = 'HS256'
+# Token validity for WebSocket connection (seconds). Not enforced after connection is established.
+Y_WEBSOCKET_TOKEN_TTL = int(os.environ.get('Y_WEBSOCKET_TOKEN_TTL', 8 * 60 * 60))
+
 Y_WEBSOCKET_HOST = 'localhost'
 Y_WEBSOCKET_PORT = 1234
 Y_WEBSOCKET_URL = '{}:{}'.format(Y_WEBSOCKET_HOST, Y_WEBSOCKET_PORT)

--- a/addons/wiki/templates/edit.mako
+++ b/addons/wiki/templates/edit.mako
@@ -522,6 +522,7 @@ ${parent.javascript_bottom()}
         metadata: {
             registration: true,
             docId: ${ sharejs_uuid | sjson, n },
+            yWebsocketToken: ${ y_websocket_token | sjson, n },
             userId: ${user_id | sjson, n },
             userName: ${ user_full_name | sjson, n },
             userUrl: ${ user_url | sjson, n },

--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -35,7 +35,7 @@ from addons.wiki.models import WikiImportTask, WikiPage, WikiVersion, render_con
 from addons.wiki.utils import (
     get_sharejs_uuid, generate_private_uuid, share_db, delete_share_doc,
     migrate_uuid, format_wiki_version, serialize_wiki_settings, serialize_wiki_widget,
-    check_file_object_in_node
+    check_file_object_in_node, generate_y_websocket_token
 )
 from addons.wiki.views import WIKI_IMPORT_TASK_ALREADY_EXISTS
 from addons.wiki import tasks
@@ -3380,3 +3380,54 @@ class TestWikiPageSort(OsfTestCase):
         self.assertEqual(result_wiki_child_page1, {'parent_id': wiki_page2_id, 'sort_order': 1})
         self.assertEqual(result_wiki_child_page2, {'parent_id': wiki_page2_id, 'sort_order': 2})
         self.assertEqual(result_wiki_child_page3, {'parent_id': wiki_child_page2_id, 'sort_order': 1})
+
+@pytest.mark.enable_bookmark_creation
+@mock.patch('addons.wiki.settings.Y_WEBSOCKET_SECRET', 'test-y-websocket-secret')
+class TestYWebsocketToken(OsfTestCase):
+
+    def setUp(self):
+        super(TestYWebsocketToken, self).setUp()
+        self.user = AuthUserFactory()
+        self.project = ProjectFactory(is_public=True, creator=self.user)
+        self.wname = 'foo.bar'
+        self.wkey = to_mongo_key(self.wname)
+
+    def test_token_generated_for_editor(self):
+        import jwt
+        from addons.wiki import settings as wiki_settings
+
+        url = self.project.web_url_for('project_wiki_view', wname=self.wname)
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+
+        body = res.body.decode()
+        sharejs_uuid = get_sharejs_uuid(self.project, self.wname)
+        assert_in(sharejs_uuid, body)
+
+        token_match = re.search(r'"yWebsocketToken":\s*"([^"]+)"', body)
+        assert_true(token_match)
+        token = token_match.group(1)
+        assert_true(token)
+
+        payload = jwt.decode(
+            token,
+            wiki_settings.Y_WEBSOCKET_SECRET,
+            algorithms=[wiki_settings.Y_WEBSOCKET_JWT_ALGORITHM],
+        )
+        assert_equal(payload['doc_id'], sharejs_uuid)
+
+    def test_token_not_visible_without_write_permission(self):
+        WikiPage.objects.create_for_node(self.project, self.wname, 'some content', Auth(self.user))
+
+        url = self.project.web_url_for('project_wiki_view', wname=self.wname)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+
+        body = res.body.decode()
+        assert_not_in(get_sharejs_uuid(self.project, self.wname), body)
+        assert_not_in('"yWebsocketToken":', body)
+
+    def test_generate_y_websocket_token_without_secret(self):
+        with mock.patch('addons.wiki.settings.Y_WEBSOCKET_SECRET', ''):
+            assert_equal(generate_y_websocket_token('doc-id'), '')
+

--- a/addons/wiki/utils.py
+++ b/addons/wiki/utils.py
@@ -4,10 +4,13 @@ import logging
 import uuid
 import unicodedata
 import ssl
+import datetime
 from future.moves.urllib.parse import quote
 
+import jwt
 from pymongo import MongoClient
 import requests
+from django.utils import timezone
 from bs4 import BeautifulSoup
 from django.apps import apps
 
@@ -64,6 +67,28 @@ def get_sharejs_uuid(node, wname):
         str(node._id)
     )) if private_uuid else None
 
+
+def generate_y_websocket_token(doc_id):
+    """
+    Generate a signed JWT for y-websocket connection authorization.
+    Returns an empty string when Y_WEBSOCKET_SECRET is not configured.
+    """
+    secret = wiki_settings.Y_WEBSOCKET_SECRET
+    if not secret or not doc_id:
+        return ''
+
+    payload = {
+        'doc_id': doc_id,
+        'exp': timezone.now() + datetime.timedelta(seconds=wiki_settings.Y_WEBSOCKET_TOKEN_TTL),
+    }
+    token = jwt.encode(
+        payload,
+        secret,
+        algorithm=wiki_settings.Y_WEBSOCKET_JWT_ALGORITHM,
+    )
+    if isinstance(token, bytes):
+        return token.decode()
+    return token
 
 def delete_share_doc(node, wname):
     """Deletes share document and removes namespace from model."""

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -325,10 +325,12 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
         rendered_before_update = False
         markdown = ''
 
+    y_websocket_token = ''
     if can_edit:
         if wiki_key not in node.wiki_private_uuids:
             wiki_utils.generate_private_uuid(node, wiki_name)
         sharejs_uuid = wiki_utils.get_sharejs_uuid(node, wiki_name)
+        y_websocket_token = wiki_utils.generate_y_websocket_token(sharejs_uuid)
     else:
         if not wiki_page and wiki_key != 'home':
             raise WIKI_PAGE_NOT_FOUND_ERROR
@@ -366,6 +368,7 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
         'sharejs_uuid': sharejs_uuid or '',
         'sharejs_url': settings.SHAREJS_URL,
         'y_websocket_url': settings.Y_WEBSOCKET_URL,
+        'y_websocket_token': y_websocket_token,
         'is_current': is_current,
         'version_settings': version_settings,
         'pages_current': _get_wiki_pages_latest(node),


### PR DESCRIPTION
## Purpose

Issue signed JWTs for y-websocket connections used by Wiki collaborative editing, so only users with write permission can authenticate to the WebSocket endpoint.
This is a security hardening change to prevent unauthenticated y-websocket access.

## Changes

- Add `Y_WEBSOCKET_SECRET`, `Y_WEBSOCKET_JWT_ALGORITHM`, and `Y_WEBSOCKET_TOKEN_TTL` settings
- Add `generate_y_websocket_token()` to issue JWTs for editable wiki pages
- Expose `yWebsocketToken` to the edit page via `edit.mako` / `contextVars`
- Add tests covering token issuance for editors and non-visibility for users without write permission

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
    - No
  - What is the level of risk?
    - Medium (authentication-related; token issuance follows existing wiki write permission checks)
    - Any permissions code touched?
      - Yes, indirectly: tokens are issued only when the user can edit the wiki. Existing permission logic is reused; permission rules themselves are unchanged
    - Is this an additive or subtractive change, other?
      - Additive. If `Y_WEBSOCKET_SECRET` is unset, the token remains an empty string (backward compatible)
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - UI: Open a wiki edit page as a user with write permission and confirm `yWebsocketToken` is present in page context
    - UI: Open the same page without write permission and confirm no usable token is exposed
    - With `Y_WEBSOCKET_SECRET` configured, verify collaborative editing still works together with the wiki-frontend client change and the authenticated y-websocket image
  - What features or workflows might this change impact?
    - Wiki Milkdown collaborative editing (y-websocket)
  - How will this impact performance?
    - Negligible: one JWT is generated per editable wiki page render

## Documentation

- Deployment docs should mention `Y_WEBSOCKET_SECRET` (and optionally `Y_WEBSOCKET_TOKEN_TTL`)
- No API versioning / developer.osf.io updates required

## Side Effects

- If y-websocket auth is enabled with a secret before OSF and the frontend are deployed, existing clients may fail to connect
- Coordinate rollout with `RDM-wiki-frontend` and the y-websocket auth image

## Related PRs

### Bitbucket
- deploy: https://bitbucket.org/osf_japan/r-deploy/pull-requests/84
- R-helm-charts: https://bitbucket.org/osf_japan/r-helm-charts/pull-requests/20

### GitHub
- RDM-wiki-frontend: https://github.com/RCOSDP/RDM-wiki-frontend/pull/15

## Ticket

https://redmine.devops.rcos.nii.ac.jp/issues/60810