### PR TITLE
Wikiインポート検証・タスク結果APIにADMIN権限チェックを追加

### DIFF
--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -1861,7 +1861,7 @@ class TestWikiImport(OsfTestCase):
         mock_check_file_object_in_node.return_value = True
         dir_id = self.root_import_folder1._id
         url = self.project.api_url_for('project_wiki_validate_for_import', dir_id=dir_id)
-        res = self.app.get(url)
+        res = self.app.get(url, auth=self.user.auth)
         response_json = res.json
         task_id = response_json['taskId']
         uuid_obj = uuid.UUID(task_id)
@@ -1875,7 +1875,7 @@ class TestWikiImport(OsfTestCase):
         ))
         dir_id = self.root_import_folder1._id
         url = self.project.api_url_for('project_wiki_validate_for_import', dir_id=dir_id)
-        res = self.app.get(url, expect_errors=True)
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json['message_short'], 'directory id does not exist')
         self.assertEqual(res.json['message_long'], 'directory id does not exist')

--- a/addons/wiki/tests/test_wiki_import.py
+++ b/addons/wiki/tests/test_wiki_import.py
@@ -1245,7 +1245,7 @@ class TestWikiViews(OsfTestCase, unittest.TestCase):
         mock_check_file_object_in_node.return_value = True
         dir_id = self.root_import_folder1._id
         url = self.project.api_url_for('project_wiki_validate_for_import', dir_id=dir_id)
-        res = self.app.get(url)
+        res = self.app.get(url, auth=self.user.auth)
         response_json = res.json
         task_id = response_json['taskId']
         uuid_obj = uuid.UUID(task_id)

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -772,6 +772,9 @@ def serialize_component_wiki(node, auth):
     return None
 
 @must_be_valid_project
+@must_have_permission(ADMIN)
+@must_not_be_registration
+@must_have_addon('wiki', 'node')
 def project_wiki_validate_for_import(dir_id, node, **kwargs):
     wiki_utils.check_file_object_in_node(dir_id, node)
     node_id = node.guids.first()._id
@@ -1306,6 +1309,8 @@ def _create_import_error_list(wiki_infos, imported_list):
     return import_errors
 
 @must_be_valid_project
+@must_have_permission(ADMIN)
+@must_not_be_registration
 @must_have_addon('wiki', 'node')
 def project_get_task_result(task_id, node, **kwargs):
     res = AsyncResult(task_id, app=celery_app)


### PR DESCRIPTION
## Purpose

Harden authorization on Wiki import-related APIs so that unauthenticated users and non-admin contributors cannot start import validation or retrieve async task results.

Previously, `project_wiki_validate_for_import` and `project_get_task_result` did not require ADMIN permission (and the validate endpoint lacked registration/addon checks aligned with the production import API). This could allow unauthorized callers to obtain a task ID or read Celery task results.

This PR requires ADMIN for both endpoints and aligns decorator checks with the existing import API.

## Changes

- Add `@must_have_permission(ADMIN)`, `@must_not_be_registration`, and `@must_have_addon('wiki', 'node')` to `project_wiki_validate_for_import`
- Add `@must_have_permission(ADMIN)` and `@must_not_be_registration` to `project_get_task_result`
- Update existing wiki import tests to pass authenticated admin `auth` where needed

## QA Notes

- Does this change require a data migration? No
- Risk level: Medium (permissions code touched; additive authorization checks)
- How to verify (API, unauthenticated):
  - `GET /api/v1/project/<pid>/wiki/import/<dir_id>/validate/` → expect **401**
  - `GET /api/v1/project/<pid>/wiki/get_task_result/<task_id>/` → expect **401**
  - `POST /api/v1/project/<pid>/wiki/import/<dir_id>/` → expect **401** (unchanged baseline)
  - With project ADMIN auth, validate/import flows should still work as before
- Impacted features: Wiki import (validate / task result / import)
- Performance impact: None expected

## Documentation

No documentation updates required.

## Side Effects

Unauthenticated or non-ADMIN callers can no longer start validation or poll task results. ADMIN users are unaffected aside from the intended permission enforcement.

## Ticket
https://redmine.devops.rcos.nii.ac.jp/issues/62776
https://redmine.devops.rcos.nii.ac.jp/issues/62777